### PR TITLE
Keep source of external packages in *build* tree

### DIFF
--- a/external/boost.cmake
+++ b/external/boost.cmake
@@ -38,8 +38,8 @@ else()
   include(ExternalProject)
   
   # Set source and build path for Boost in the TiledArray Project
-  set(BOOST_DOWNLOAD_DIR ${PROJECT_SOURCE_DIR}/external/src)
-  set(BOOST_SOURCE_DIR   ${PROJECT_SOURCE_DIR}/external/src/boost)
+  set(BOOST_DOWNLOAD_DIR ${PROJECT_BINARY_DIR}/external/source)
+  set(BOOST_SOURCE_DIR   ${PROJECT_BINARY_DIR}/external/source/boost)
   set(BOOST_BUILD_DIR   ${PROJECT_BINARY_DIR}/external/build/boost)
 
   # Set the external source

--- a/external/eigen.cmake
+++ b/external/eigen.cmake
@@ -42,7 +42,7 @@ else()
   include(ExternalProject)
 
   # Set source and build path for Eigen in the TiledArray Project
-  set(EXTERNAL_SOURCE_DIR   ${PROJECT_SOURCE_DIR}/external/src/eigen)
+  set(EXTERNAL_SOURCE_DIR   ${PROJECT_BINARY_DIR}/external/source/eigen)
   set(EXTERNAL_BUILD_DIR  ${PROJECT_BINARY_DIR}/external/build/eigen)
   set(EIGEN_URL https://bitbucket.org/eigen/eigen)
   set(EIGEN_TAG 3.2.4)

--- a/external/elemental.cmake
+++ b/external/elemental.cmake
@@ -73,7 +73,7 @@ else()
   endif()
   
   # Set the Elemental source and build directories
-  set(ELEMENTAL_SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/src/elemental) 
+  set(ELEMENTAL_SOURCE_DIR ${PROJECT_BINARY_DIR}/external/source/elemental) 
   set(ELEMENTAL_BINARY_DIR ${PROJECT_BINARY_DIR}/external/build/elemental) 
   
   ExternalProject_Add(elemental

--- a/external/madness.cmake
+++ b/external/madness.cmake
@@ -166,7 +166,7 @@ else()
   endif()
   
   # Set paths for MADNESS project
-  set(MADNESS_SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/src/madness)
+  set(MADNESS_SOURCE_DIR ${PROJECT_BINARY_DIR}/external/source/madness)
   set(MADNESS_BINARY_DIR  ${PROJECT_BINARY_DIR}/external/build/madness)
   
   ExternalProject_Add(madness


### PR DESCRIPTION
 cleaner, easier to work with multiple build dirs