### PR TITLE
tbb vector op

### DIFF
--- a/examples/vector_tests/vector.cpp
+++ b/examples/vector_tests/vector.cpp
@@ -353,6 +353,7 @@ int main(int, char**) {
   double x = 0.0;
   for(std::size_t r = 0ul; r < repeat; ++r) {
     TiledArray::math::reduce_op([](double& x, const double a) { x = std::max(x, std::abs(a)); },
+                                [](double& x ,const double a){x=std::max(x,a);},
         n, x, a);
   }
   stop = madness::wall_time();

--- a/examples/vector_tests/vector.cpp
+++ b/examples/vector_tests/vector.cpp
@@ -31,7 +31,7 @@
 #include "TiledArray/math/vector_op.h"
 #include "TiledArray/error.h"
 #include "TiledArray/math/blas.h"
-#include <tbb/cache_aligned_allocator.h>
+//#include <tbb/cache_aligned_allocator.h>
 
 #define EIGEN_NO_MALLOC
 

--- a/examples/vector_tests/vector.cpp
+++ b/examples/vector_tests/vector.cpp
@@ -34,7 +34,10 @@
 
 #define EIGEN_NO_MALLOC
 
-int main(int, char**) {
+int main(int argc, char** argv) {
+
+  madness::World& world = madness::initialize(argc,argv);
+
   const std::size_t repeat = 100;
   // Allocate some memory for tests
   const std::size_t n = 10000000;
@@ -320,13 +323,14 @@ int main(int, char**) {
   ////==========================================================================
   std::cout << "\nMaxabs:\n";
   double temp = 0.0;
+  a[10] = 100.5;
   start = madness::wall_time();
   for(std::size_t r = 0ul; r < repeat; ++r)
     for(std::size_t i = 0ul; i < n; ++i)
       temp = std::max(temp, std::abs(a[i]));
   stop = madness::wall_time();
 
-  std::cout << "base:   " << stop - start << " s\n";
+  std::cout << "base:   " << stop - start << " s " << temp << " \n";
 
   start = madness::wall_time();
   for(std::size_t r = 0ul; r < repeat; ++r) {
@@ -347,7 +351,7 @@ int main(int, char**) {
   }
   stop = madness::wall_time();
 
-  std::cout << "unwind: " << stop - start << " s\n";
+  std::cout << "unwind: " << stop - start << " s " << temp << " \n";
 
   start = madness::wall_time();
   double x = 0.0;
@@ -357,13 +361,14 @@ int main(int, char**) {
         n, x, a);
   }
   stop = madness::wall_time();
-  x += 1.0;
-  std::cout << "vector: " << stop - start << " s\n" << x;
+  std::cout << "vector: " << stop - start << " s " << x << " \n";
 
   // Deallocate memory
   free(a);
   free(b);
   free(c);
+
+  madness::finalize();
 
   return 0;
 }

--- a/examples/vector_tests/vector.cpp
+++ b/examples/vector_tests/vector.cpp
@@ -31,7 +31,6 @@
 #include "TiledArray/math/vector_op.h"
 #include "TiledArray/error.h"
 #include "TiledArray/math/blas.h"
-//#include <tbb/cache_aligned_allocator.h>
 
 #define EIGEN_NO_MALLOC
 
@@ -51,9 +50,6 @@ int main(int argc, char** argv) {
     return 1;
   if(posix_memalign(reinterpret_cast<void**>(&c), 128, sizeof(double) * n) != 0)
     return 1;
-//  a = tbb::cache_aligned_allocator<double>().allocate(n);
-//  b = tbb::cache_aligned_allocator<double>().allocate(n);
-//  c = tbb::cache_aligned_allocator<double>().allocate(n);
 
   // Init memory
   std::fill_n(a, n, 2.0);
@@ -527,9 +523,6 @@ int main(int argc, char** argv) {
   free(a);
   free(b);
   free(c);
-//  tbb::cache_aligned_allocator<double>().deallocate(a,n);
-//  tbb::cache_aligned_allocator<double>().deallocate(b,n);
-//  tbb::cache_aligned_allocator<double>().deallocate(c,n);
 
   madness::finalize();
 

--- a/examples/vector_tests/vector.cpp
+++ b/examples/vector_tests/vector.cpp
@@ -31,6 +31,7 @@
 #include "TiledArray/math/vector_op.h"
 #include "TiledArray/error.h"
 #include "TiledArray/math/blas.h"
+#include <tbb/cache_aligned_allocator.h>
 
 #define EIGEN_NO_MALLOC
 
@@ -50,6 +51,9 @@ int main(int argc, char** argv) {
     return 1;
   if(posix_memalign(reinterpret_cast<void**>(&c), 128, sizeof(double) * n) != 0)
     return 1;
+//  a = tbb::cache_aligned_allocator<double>().allocate(n);
+//  b = tbb::cache_aligned_allocator<double>().allocate(n);
+//  c = tbb::cache_aligned_allocator<double>().allocate(n);
 
   // Init memory
   std::fill_n(a, n, 2.0);
@@ -100,12 +104,21 @@ int main(int argc, char** argv) {
 
   start = madness::wall_time();
   for(std::size_t r = 0ul; r < repeat; ++r) {
+    TiledArray::math::vector_op_serial([](const double x, const double y) { return x + y; },
+                                n, c, a, b);
+  }
+  stop = madness::wall_time();
+
+  std::cout << "vector serial: " << stop - start << " s\n";
+
+  start = madness::wall_time();
+  for(std::size_t r = 0ul; r < repeat; ++r) {
     TiledArray::math::vector_op([](const double x, const double y) { return x + y; },
         n, c, a, b);
   }
   stop = madness::wall_time();
 
-  std::cout << "vector: " << stop - start << " s\n";
+  std::cout << "vector parallel: " << stop - start << " s\n";
 
   ////==========================================================================
   std::cout << "\nScale Sum:\n";
@@ -151,12 +164,70 @@ int main(int argc, char** argv) {
 
   start = madness::wall_time();
   for(std::size_t r = 0ul; r < repeat; ++r) {
+    TiledArray::math::vector_op_serial([](const double x, const double y) { return (x + y) * 3.0; },
+                                n, c, a, b);
+  }
+  stop = madness::wall_time();
+
+  std::cout << "vector serial: " << stop - start << " s\n";
+
+  start = madness::wall_time();
+  for(std::size_t r = 0ul; r < repeat; ++r) {
     TiledArray::math::vector_op([](const double x, const double y) { return (x + y) * 3.0; },
         n, c, a, b);
   }
   stop = madness::wall_time();
 
-  std::cout << "vector: " << stop - start << " s\n";
+  std::cout << "vector parallel: " << stop - start << " s\n";
+
+////==========================================================================
+  std::cout << "\nPower Sum:\n";
+  start = madness::wall_time();
+  for(std::size_t r = 0ul; r < repeat; ++r)
+    for(std::size_t i = 0ul; i < n; ++i)
+      c[i] = (std::pow(a[i],3) + std::pow(b[i],3)) * 3.0;
+  stop = madness::wall_time();
+
+  std::cout << "base:   " << stop - start << " s\n";
+
+  start = madness::wall_time();
+  for(std::size_t r = 0ul; r < repeat; ++r) {
+    const std::size_t n4 = n - (n % 8);
+    std::size_t i = 0ul;
+    for(; i < n4; i += 8) {
+      c[i]   = (std::pow(a[i],3)  + std::pow(b[i],3)) * 3.0;
+      c[i+1]   = (std::pow(a[i+1],3)  + std::pow(b[i+1],3)) * 3.0;
+      c[i+2]   = (std::pow(a[i+2],3)  + std::pow(b[i+2],3)) * 3.0;
+      c[i+3]   = (std::pow(a[i+3],3)  + std::pow(b[i+3],3)) * 3.0;
+      c[i+4]   = (std::pow(a[i+4],3)  + std::pow(b[i+4],3)) * 3.0;
+      c[i+5]   = (std::pow(a[i+5],3)  + std::pow(b[i+5],3)) * 3.0;
+      c[i+6]   = (std::pow(a[i+6],3)  + std::pow(b[i+6],3)) * 3.0;
+      c[i+7]   = (std::pow(a[i+7],3)  + std::pow(b[i+7],3)) * 3.0;
+    }
+    for(; i < n; ++i)
+      c[i] = (std::pow(a[i],3) + std::pow(b[i],3)) * 3.0;
+  }
+  stop = madness::wall_time();
+
+  std::cout << "unwind: " << stop - start << " s\n";
+
+  start = madness::wall_time();
+  for(std::size_t r = 0ul; r < repeat; ++r) {
+    TiledArray::math::vector_op_serial([](const double x, const double y) { return (std::pow(x,3) + std::pow(y,3)) * 3.0; },
+                                n, c, a, b);
+  }
+  stop = madness::wall_time();
+
+  std::cout << "vector serial: " << stop - start << " s\n";
+
+  start = madness::wall_time();
+  for(std::size_t r = 0ul; r < repeat; ++r) {
+    TiledArray::math::vector_op([](const double x, const double y) { return (std::pow(x,3) + std::pow(y,3)) * 3.0; },
+                                n, c, a, b);
+  }
+  stop = madness::wall_time();
+
+  std::cout << "vector parallel: " << stop - start << " s\n";
 
 
   ////==========================================================================
@@ -203,12 +274,21 @@ int main(int argc, char** argv) {
 
   start = madness::wall_time();
   for(std::size_t r = 0ul; r < repeat; ++r) {
+    TiledArray::math::vector_op_serial([](const double x, const double y) { return x * y; },
+                                n, c, a, b);
+  }
+  stop = madness::wall_time();
+
+  std::cout << "vector serial: " << stop - start << " s\n";
+
+  start = madness::wall_time();
+  for(std::size_t r = 0ul; r < repeat; ++r) {
     TiledArray::math::vector_op([](const double x, const double y) { return x * y; },
         n, c, a, b);
   }
   stop = madness::wall_time();
 
-  std::cout << "vector: " << stop - start << " s\n";
+  std::cout << "vector parallel: " << stop - start << " s\n";
 
   ////==========================================================================
   std::cout << "\nScale Multiply:\n";
@@ -254,12 +334,21 @@ int main(int argc, char** argv) {
 
   start = madness::wall_time();
   for(std::size_t r = 0ul; r < repeat; ++r) {
+    TiledArray::math::vector_op_serial([](const double x, const double y) { return (x * y) * 3.0; },
+                                n, c, a, b);
+  }
+  stop = madness::wall_time();
+
+  std::cout << "vector serial: " << stop - start << " s\n";
+
+  start = madness::wall_time();
+  for(std::size_t r = 0ul; r < repeat; ++r) {
     TiledArray::math::vector_op([](const double x, const double y) { return (x * y) * 3.0; },
         n, c, a, b);
   }
   stop = madness::wall_time();
 
-  std::cout << "vector: " << stop - start << " s\n";
+  std::cout << "vector parallel: " << stop - start << " s\n";
 
   ////==========================================================================
   std::cout << "\nScale:\n";
@@ -313,11 +402,19 @@ int main(int argc, char** argv) {
 
   start = madness::wall_time();
   for(std::size_t r = 0ul; r < repeat; ++r) {
+    TiledArray::math::inplace_vector_op_serial([](double& x) { x *= 3.0; }, n, c);
+  }
+  stop = madness::wall_time();
+
+  std::cout << "vector serial: " << stop - start << " s\n";
+
+  start = madness::wall_time();
+  for(std::size_t r = 0ul; r < repeat; ++r) {
     TiledArray::math::inplace_vector_op([](double& x) { x *= 3.0; }, n, c);
   }
   stop = madness::wall_time();
 
-  std::cout << "vector: " << stop - start << " s\n";
+  std::cout << "vector parallel: " << stop - start << " s\n";
 
 
   ////==========================================================================
@@ -356,20 +453,30 @@ int main(int argc, char** argv) {
   start = madness::wall_time();
   double x = 0.0;
   for(std::size_t r = 0ul; r < repeat; ++r) {
+    TiledArray::math::reduce_op_serial([](double& x, const double a) { x = std::max(x, std::abs(a)); },
+                                n, x, a);
+  }
+  stop = madness::wall_time();
+  std::cout << "vector serial: " << stop - start << " s " << x << " \n";
+
+  start = madness::wall_time();
+  x = 0.0;
+  for(std::size_t r = 0ul; r < repeat; ++r) {
     TiledArray::math::reduce_op([](double& x, const double a) { x = std::max(x, std::abs(a)); },
                                 [](double& x ,const double a){x=std::max(x,a);},
         std::numeric_limits<double>::min(),n, x, a);
   }
   stop = madness::wall_time();
-  std::cout << "vector: " << stop - start << " s " << x << " \n";
+  std::cout << "vector parallel: " << stop - start << " s " << x << " \n";
 
   ////==========================================================================
   std::cout << "\nReduce Sum:\n";
   start = madness::wall_time();
-  for(std::size_t r = 0ul; r < repeat; ++r)
+  for(std::size_t r = 0ul; r < repeat; ++r) {
     temp = 0.0;
-    for(std::size_t i = 0ul; i < n; ++i)
+    for (std::size_t i = 0ul; i < n; ++i)
       temp += b[i];
+  }
   stop = madness::wall_time();
 
   std::cout << "base:   " << stop - start << " s " << temp << " \n";
@@ -399,18 +506,30 @@ int main(int argc, char** argv) {
   start = madness::wall_time();
   for(std::size_t r = 0ul; r < repeat; ++r) {
     x = 0.0;
+    TiledArray::math::reduce_op_serial([](double& x, const double a) { x += a; },
+                                 n, x, b);
+  }
+  stop = madness::wall_time();
+  std::cout << "vector serial: " << stop - start << " s " << x << " \n";
+
+  start = madness::wall_time();
+  for(std::size_t r = 0ul; r < repeat; ++r) {
+    x = 0.0;
     TiledArray::math::reduce_op([](double& x, const double a) { x += a; },
                                 [](double& x ,const double a){x += a;},
                                 0.0, n, x, b);
   }
   stop = madness::wall_time();
-  std::cout << "vector: " << stop - start << " s " << x << " \n";
+  std::cout << "vector parallel: " << stop - start << " s " << x << " \n";
 
 
   // Deallocate memory
   free(a);
   free(b);
   free(c);
+//  tbb::cache_aligned_allocator<double>().deallocate(a,n);
+//  tbb::cache_aligned_allocator<double>().deallocate(b,n);
+//  tbb::cache_aligned_allocator<double>().deallocate(c,n);
 
   madness::finalize();
 

--- a/examples/vector_tests/vector.cpp
+++ b/examples/vector_tests/vector.cpp
@@ -358,10 +358,54 @@ int main(int argc, char** argv) {
   for(std::size_t r = 0ul; r < repeat; ++r) {
     TiledArray::math::reduce_op([](double& x, const double a) { x = std::max(x, std::abs(a)); },
                                 [](double& x ,const double a){x=std::max(x,a);},
-        n, x, a);
+        std::numeric_limits<double>::min(),n, x, a);
   }
   stop = madness::wall_time();
   std::cout << "vector: " << stop - start << " s " << x << " \n";
+
+  ////==========================================================================
+  std::cout << "\nReduce Sum:\n";
+  start = madness::wall_time();
+  for(std::size_t r = 0ul; r < repeat; ++r)
+    temp = 0.0;
+    for(std::size_t i = 0ul; i < n; ++i)
+      temp += b[i];
+  stop = madness::wall_time();
+
+  std::cout << "base:   " << stop - start << " s " << temp << " \n";
+
+  start = madness::wall_time();
+  for(std::size_t r = 0ul; r < repeat; ++r) {
+    temp = 0.0;
+    const std::size_t n4 = n - (n % 8);
+    std::size_t i = 0ul;
+    for(; i < n4; i += 8) {
+      temp += b[i];
+      temp += b[i+1];
+      temp += b[i+2];
+      temp += b[i+3];
+      temp += b[i+4];
+      temp += b[i+5];
+      temp += b[i+6];
+      temp += b[i+7];
+    }
+    for(; i < n; ++i)
+      temp += b[i];
+  }
+  stop = madness::wall_time();
+
+  std::cout << "unwind: " << stop - start << " s " << temp << " \n";
+
+  start = madness::wall_time();
+  for(std::size_t r = 0ul; r < repeat; ++r) {
+    x = 0.0;
+    TiledArray::math::reduce_op([](double& x, const double a) { x += a; },
+                                [](double& x ,const double a){x += a;},
+                                0.0, n, x, b);
+  }
+  stop = madness::wall_time();
+  std::cout << "vector: " << stop - start << " s " << x << " \n";
+
 
   // Deallocate memory
   free(a);

--- a/src/TiledArray/math/partial_reduce.h
+++ b/src/TiledArray/math/partial_reduce.h
@@ -187,6 +187,7 @@ namespace TiledArray {
     typedef PartialReduceUnwind<TILEDARRAY_LOOP_UNWIND - 1> PartialReduceUnwindN;
 
 
+    //TODO reduce_op
     /// Reduce the rows of a matrix
 
     /// <tt>op(result[i], left[i][j], right[j])</tt>.
@@ -252,7 +253,7 @@ namespace TiledArray {
 
         // Load result block
         Result result_block = result[i];
-        reduce_op(op, n, result_block, left + (i * n), right);
+        reduce_op_serial(op, n, result_block, left + (i * n), right);
         result[i] = result_block;
       }
     }
@@ -313,7 +314,7 @@ namespace TiledArray {
 
         // Load result block
         Result result_block = result[i];
-        reduce_op(op, n, result_block, arg + (i * n));
+        reduce_op_serial(op, n, result_block, arg + (i * n));
         result[i] = result_block;
       }
     }

--- a/src/TiledArray/math/vector_op.h
+++ b/src/TiledArray/math/vector_op.h
@@ -296,6 +296,8 @@ namespace TiledArray {
 
       static constexpr std::size_t block_size = TILEDARRAY_LOOP_UNWIND;
 
+      // GRAIN_SIZE is set to 8 to trigger TiledArray Unit Test
+      // in reality, partition is controled by tbb::auto_partitioner instead of GRAIN_SIZE
       static constexpr std::size_t GRAIN_SIZE = 8ul;
 
       size_t lower;

--- a/src/TiledArray/math/vector_op.h
+++ b/src/TiledArray/math/vector_op.h
@@ -500,13 +500,13 @@ namespace TiledArray {
         SizeTRange range(0, n);
 
       // if support lambda variadic
-        auto apply_vector_op = [op, result, args...](SizeTRange &range) {
-          size_t offset = range.begin();
-          size_t n_range = range.size();
-          vector_op_serial(op, n_range, result + offset, (args + offset)...);
-        };
+//        auto apply_vector_op = [op, result, args...](SizeTRange &range) {
+//          size_t offset = range.begin();
+//          size_t n_range = range.size();
+//          vector_op_serial(op, n_range, result + offset, (args + offset)...);
+//        };
       // else
-//      auto apply_vector_op = ApplyVectorOp<Op,Result,Args...>(op, result, args...);
+      auto apply_vector_op = ApplyVectorOp<Op,Result,Args...>(op, result, args...);
 
       tbb::parallel_for(range, apply_vector_op, tbb::auto_partitioner());
       #else

--- a/src/TiledArray/math/vector_op.h
+++ b/src/TiledArray/math/vector_op.h
@@ -661,7 +661,8 @@ namespace TiledArray {
         tbb::parallel_reduce(range,apply_reduce_op, tbb::auto_partitioner());
 
         result = apply_reduce_op.result();
-//        reduce_op_serial(reduce_op,n,result,args...);
+      #else
+        reduce_op_serial(reduce_op,n,result,args...);
       #endif
     }
 

--- a/src/TiledArray/math/vector_op.h
+++ b/src/TiledArray/math/vector_op.h
@@ -30,10 +30,6 @@
 #include <TiledArray/madness.h>
 #include <TiledArray/config.h>
 
-#ifdef HAVE_INTEL_TBB
-#include <tbb/tbb.h>
-#endif
-
 #define TILEDARRAY_LOOP_UNWIND ::TiledArray::math::LoopUnwind::value
 
 

--- a/src/TiledArray/size_array.h
+++ b/src/TiledArray/size_array.h
@@ -271,14 +271,15 @@ namespace TiledArray {
       /// <tt>op(result, *this[i], arg[i])</tt>.
       /// \tparam Arg The right-hand argument type
       /// \tparam Result The reduction result type
-      /// \tparam Op The binary operation type
+      /// \tparam ReduceOp The binary reduction operation type
+      /// \tparam JoinOp The join operation type
       /// \param arg The right-hand argument
       /// \param result The initial value of the reduction
       /// \param op The binary reduction operation
       /// \return The reduced value
-      template <typename Arg, typename Result, typename Op>
-      Result reduce(const Arg* const arg, Result result, const Op& op) const {
-        math::reduce_op(op, last_ - first_, result, first_, arg);
+      template <typename Arg, typename Result, typename ReduceOp, typename JoinOp>
+      Result reduce(const Arg* const arg, Result result, const ReduceOp& reduce_op, const JoinOp& join_op) const {
+        math::reduce_op(reduce_op, join_op, last_ - first_, result, first_, arg);
         return result;
       }
 
@@ -287,13 +288,14 @@ namespace TiledArray {
       /// Unary reduction operation where this object is the argument. The
       /// reduced result is computed by <tt>op(result, *this[i])</tt>.
       /// \tparam Result The reduction result type
-      /// \tparam Op The binary reduction operation type
+      /// \tparam ReduceOp The binary reduction operation type
+      /// \tparam JoinOp The join operation type
       /// \param result The initial value of the reduction
       /// \param op The unary reduction operation
       /// \return The reduced value
-      template <typename Result, typename Op>
-      Result reduce(Result result, const Op& op) const {
-        math::reduce_op(op, last_ - first_, result, first_);
+      template <typename Result, typename ReduceOp, typename JoinOp>
+      Result reduce(Result result, const ReduceOp& reduce_op, const JoinOp& join_op) const {
+        math::reduce_op(reduce_op, join_op, last_ - first_, result, first_);
         return result;
       }
 

--- a/src/TiledArray/sparse_shape.h
+++ b/src/TiledArray/sparse_shape.h
@@ -104,7 +104,8 @@ namespace TiledArray {
       const value_type threshold = threshold_;
       const unsigned int dim = tile_norms_.range().rank();
       const vector_type* restrict const size_vectors = size_vectors_.get();
-      size_type zero_tile_count = 0ul;
+      madness::AtomicInt zero_tile_count;
+      zero_tile_count = 0;
 
       if(dim == 1u) {
         auto normalize_op = [threshold, &zero_tile_count] (value_type& norm, const value_type size) {
@@ -343,7 +344,8 @@ namespace TiledArray {
 
       auto result_tile_norms_blk = result_tile_norms.block(lower_bound, upper_bound);
       const value_type threshold = threshold_;
-      size_type zero_tile_count = zero_tile_count_;
+      madness::AtomicInt zero_tile_count;
+      zero_tile_count = zero_tile_count_;
       result_tile_norms_blk.inplace_binary(other.tile_norms_,
           [threshold,&zero_tile_count] (value_type& l, const value_type r) {
             // Update the zero tile count for the result
@@ -412,7 +414,8 @@ namespace TiledArray {
 
       // Copy the data from arg to result
       const value_type threshold = threshold_;
-      size_type zero_tile_count = 0ul;
+      madness::AtomicInt zero_tile_count;
+      zero_tile_count = 0;
       auto copy_op = [threshold,&zero_tile_count] (value_type& restrict result,
           const value_type arg)
       {
@@ -446,7 +449,8 @@ namespace TiledArray {
 
       // Copy the data from arg to result
       const value_type threshold = threshold_;
-      size_type zero_tile_count = 0ul;
+      madness::AtomicInt zero_tile_count;
+      zero_tile_count = 0;
       auto copy_op = [factor,threshold,&zero_tile_count] (value_type& restrict result,
               const value_type arg)
       {
@@ -510,7 +514,8 @@ namespace TiledArray {
       TA_ASSERT(! tile_norms_.empty());
       const value_type threshold = threshold_;
       const value_type abs_factor = std::abs(factor);
-      size_type zero_tile_count = 0ul;
+      madness::AtomicInt zero_tile_count;
+      zero_tile_count = 0;
       auto op = [threshold, &zero_tile_count, abs_factor] (value_type value) {
         value *= abs_factor;
         if(value < threshold) {
@@ -538,7 +543,8 @@ namespace TiledArray {
       TA_ASSERT(! tile_norms_.empty());
       const value_type threshold = threshold_;
       const value_type abs_factor = std::abs(factor);
-      size_type zero_tile_count = 0ul;
+      madness::AtomicInt zero_tile_count;
+      zero_tile_count = 0;
       auto op = [threshold, &zero_tile_count, abs_factor] (value_type value) {
         value *= abs_factor;
         if(value < threshold) {
@@ -565,7 +571,8 @@ namespace TiledArray {
     SparseShape_ add(const SparseShape_& other) const {
       TA_ASSERT(! tile_norms_.empty());
       const value_type threshold = threshold_;
-      size_type zero_tile_count = 0ul;
+      madness::AtomicInt zero_tile_count;
+      zero_tile_count = 0;
       auto op = [threshold, &zero_tile_count] (value_type left,
           const value_type right)
       {
@@ -595,7 +602,8 @@ namespace TiledArray {
     SparseShape_ add(const SparseShape_& other, const Permutation& perm) const {
       TA_ASSERT(! tile_norms_.empty());
       const value_type threshold = threshold_;
-      size_type zero_tile_count = 0ul;
+      madness::AtomicInt zero_tile_count;
+      zero_tile_count = 0;
       auto op = [threshold, &zero_tile_count] (value_type left,
           const value_type right)
       {
@@ -627,7 +635,8 @@ namespace TiledArray {
       TA_ASSERT(! tile_norms_.empty());
       const value_type threshold = threshold_;
       const value_type abs_factor = std::abs(factor);
-      size_type zero_tile_count = 0ul;
+      madness::AtomicInt zero_tile_count;
+      zero_tile_count = 0;
       auto op = [threshold, &zero_tile_count, abs_factor] (value_type left,
           const value_type right)
       {
@@ -662,7 +671,8 @@ namespace TiledArray {
       TA_ASSERT(! tile_norms_.empty());
       const value_type threshold = threshold_;
       const value_type abs_factor = std::abs(factor);
-      size_type zero_tile_count = 0ul;
+      madness::AtomicInt zero_tile_count;
+      zero_tile_count = 0;
       auto op = [threshold, &zero_tile_count, abs_factor]
                  (value_type left, const value_type right)
       {
@@ -685,7 +695,8 @@ namespace TiledArray {
     SparseShape_ add(value_type value) const {
       TA_ASSERT(! tile_norms_.empty());
       const value_type threshold = threshold_;
-      size_type zero_tile_count = 0ul;
+      madness::AtomicInt zero_tile_count;
+      zero_tile_count = 0;
 
       Tensor<T> result_tile_norms(tile_norms_.range());
 
@@ -780,7 +791,8 @@ namespace TiledArray {
     {
       const unsigned int dim = tile_norms.range().rank();
       const value_type threshold = threshold_;
-      size_type zero_tile_count = 0ul;
+      madness::AtomicInt zero_tile_count;
+      zero_tile_count = 0;
 
       if(dim == 1u) {
         // This is the easy case where the data is a vector and can be
@@ -884,7 +896,8 @@ namespace TiledArray {
 
       factor = std::abs(factor);
       const value_type threshold = threshold_;
-      size_type zero_tile_count = 0ul;
+      madness::AtomicInt zero_tile_count;
+      zero_tile_count = 0;
       integer M = 0, N = 0, K = 0;
       gemm_helper.compute_matrix_sizes(M, N, K, tile_norms_.range(), other.tile_norms_.range());
 

--- a/src/TiledArray/tensor/kernels.h
+++ b/src/TiledArray/tensor/kernels.h
@@ -508,7 +508,7 @@ namespace TiledArray {
     template <typename ReduceOp, typename JoinOp, typename Scalar, typename T1, typename... Ts,
     typename std::enable_if<is_numeric<Scalar>::value && is_tensor<T1, Ts...>::value
              && is_contiguous_tensor<T1, Ts...>::value>::type* = nullptr>
-    Scalar tensor_reduce(ReduceOp&& reduce_op, JoinOp&&,
+    Scalar tensor_reduce(ReduceOp&& reduce_op, JoinOp&& join_op,
         Scalar identity, const T1& tensor1, const Ts&... tensors)
     {
       TA_ASSERT(! empty(tensor1, tensors...));
@@ -516,7 +516,7 @@ namespace TiledArray {
 
       const auto volume = tensor1.range().volume();
 
-      math::reduce_op(reduce_op, volume, identity,
+      math::reduce_op(reduce_op, join_op,volume, identity,
           tensor1.data(), tensors.data()...);
 
       return identity;
@@ -587,7 +587,7 @@ namespace TiledArray {
       Scalar result = identity;
       for(decltype(tensor1.range().volume()) i = 0ul; i < volume; i += stride) {
         Scalar temp = identity;
-        math::reduce_op(reduce_op, stride, temp,
+        math::reduce_op(reduce_op,join_op, stride, temp,
             tensor1.data() + tensor1.range().ordinal(i),
             (tensors.data() + tensors.range().ordinal(i))...);
         join_op(result, temp);

--- a/src/TiledArray/tensor/kernels.h
+++ b/src/TiledArray/tensor/kernels.h
@@ -516,7 +516,7 @@ namespace TiledArray {
 
       const auto volume = tensor1.range().volume();
 
-      math::reduce_op(reduce_op, join_op,volume, identity,
+      math::reduce_op(reduce_op, join_op, identity, volume, identity,
           tensor1.data(), tensors.data()...);
 
       return identity;

--- a/src/TiledArray/tensor/kernels.h
+++ b/src/TiledArray/tensor/kernels.h
@@ -587,7 +587,7 @@ namespace TiledArray {
       Scalar result = identity;
       for(decltype(tensor1.range().volume()) i = 0ul; i < volume; i += stride) {
         Scalar temp = identity;
-        math::reduce_op(reduce_op,join_op, stride, temp,
+        math::reduce_op(reduce_op,join_op, identity, stride, temp,
             tensor1.data() + tensor1.range().ordinal(i),
             (tensors.data() + tensors.range().ordinal(i))...);
         join_op(result, temp);


### PR DESCRIPTION
tested with 2 mpi process using ta_test
to see performance, run the vector example

the grain size is set to 8 to trigger tbb split in ta_test
in reality, the partition is controlled at runtime by tbb::auto_partitioner()