### PR TITLE
mock-up of "forced result type" approach

### DIFF
--- a/src/TiledArray/array.h
+++ b/src/TiledArray/array.h
@@ -52,6 +52,7 @@ namespace TiledArray {
     typedef DistArray<Tile, Policy> DistArray_; ///< This object's type
     typedef TiledArray::detail::ArrayImpl<Tile, Policy> impl_type;
     typedef typename detail::numeric_type<Tile>::type element_type; ///< The tile element type
+    typedef Policy policy_type; ///< Policy type
     typedef typename impl_type::trange_type trange_type; ///< Tile range type
     typedef typename impl_type::range_type range_type; ///< Range type for array tiling
     typedef typename impl_type::shape_type shape_type; ///< Shape type for array tiling

--- a/src/TiledArray/expressions/add_expr.h
+++ b/src/TiledArray/expressions/add_expr.h
@@ -423,6 +423,30 @@ namespace TiledArray {
           conj_op(-expr.factor().factor()));
     }
 
+
+    namespace experimental {
+      template <typename Left, typename Right>
+      struct ExprTrait<AddExpr<Left, Right>> {
+	typedef Left left_type; ///< The left-hand expression type
+	typedef Right right_type; ///< The right-hand expression type
+
+	///< Expression engine type
+	template <typename Result>
+	struct engine {
+	  typedef AddEngine<Result,
+	      typename TiledArray::expressions::ExprTrait<Left>::engine_type,
+	      typename TiledArray::expressions::ExprTrait<Right>::engine_type>
+	      type;
+
+	  typedef numeric_t<typename EngineTrait<type>::eval_type>
+	      numeric_type; ///< Addition result numeric type
+	  typedef scalar_t<typename EngineTrait<type>::eval_type>
+	      scalar_type; ///< Addition result scalar type
+	};
+      };
+
+    } // namespace experimental
+
   }  // namespace expressions
 } // namespace TiledArray
 

--- a/src/TiledArray/expressions/binary_expr.h
+++ b/src/TiledArray/expressions/binary_expr.h
@@ -72,6 +72,52 @@ namespace TiledArray {
 
     }; // class BinaryExpr
 
+
+    namespace experimental {
+
+      /// Binary expression object
+
+      /// \tparam Derived The derived class type
+      template <typename Derived>
+      class BinaryExpr : public Expr<Derived> {
+      public:
+        typedef typename ExprTrait<Derived>::left_type left_type; ///< The left-hand expression type
+        typedef typename ExprTrait<Derived>::right_type right_type; ///< The right-hand expression type
+
+      private:
+
+        left_type left_; ///< The left-hand argument
+        right_type right_; ///< The right-hand argument
+
+        // Not allowed
+        BinaryExpr<Derived>& operator=(const BinaryExpr<Derived>&);
+
+      public:
+
+        /// Binary expression constructor
+        BinaryExpr(const left_type& left, const right_type& right) :
+          left_(left), right_(right)
+        { }
+
+        /// Copy constructor
+        BinaryExpr(const BinaryExpr<Derived>& other) :
+          left_(other.left()), right_(other.right())
+        { }
+
+        /// Left-hand expression argument accessor
+
+        /// \return A const reference to the left-hand expression object
+        const left_type& left() const { return left_; }
+
+        /// Right-hand expression argument accessor
+
+        /// \return A const reference to the right-hand expression object
+        const right_type& right() const { return right_; }
+
+      }; // class BinaryExpr
+
+    } // namespace experimental
+
   }  // namespace expressions
 } // namespace TiledArray
 

--- a/src/TiledArray/tile_op/add.h
+++ b/src/TiledArray/tile_op/add.h
@@ -394,6 +394,188 @@ namespace TiledArray {
 
   }; // class ScalAdd
 
+
+  // contains code for mixed-type expressions with result type enforcement
+  namespace experimental {
+
+    /// Tile addition operation
+
+    /// This addition operation will add the content two tiles, and accepts an
+    /// optional permute argument.
+    /// \tparam Result The result type
+    /// \tparam Left The left-hand argument type
+    /// \tparam Right The right-hand argument type
+    /// \tparam LeftConsumable If \c true , will try to consume the left-hand argument when necessary.
+    /// \tparam RightConsumable If \c true , will try to consume the right-hand argument when necessary.
+    /// \note Input tiles can be consumed only if their type matches the result type.
+    template <typename Result, typename Left, typename Right, bool LeftConsumable,
+        bool RightConsumable>
+    class Add {
+    public:
+
+      typedef Add<Result, Left, Right, LeftConsumable, RightConsumable> Add_;
+      typedef Left left_type; ///< Left-hand argument base type
+      typedef Right right_type; ///< Right-hand argument base type
+      typedef Result result_type; ///< Result type
+
+      /// indicates whether it is *possible* to consume the left tile
+      static constexpr bool left_is_consumable =
+          LeftConsumable && std::is_same<result_type, left_type>::value;
+      /// indicates whether it is *possible* to consume the right tile
+      static constexpr bool right_is_consumable =
+          RightConsumable && std::is_same<result_type, right_type>::value;
+
+    private:
+
+      // Permuting tile evaluation function
+      // These operations cannot consume the argument tile since this operation
+      // requires temporary storage space.
+
+      static result_type eval(const left_type& first, const right_type& second,
+          const Permutation& perm)
+      {
+        using TiledArray::add;
+        typedef decltype(add(std::declval<left_type>(), std::declval<right_type>(), std::declval<Permutation>()))
+            add_result_type;
+        Cast<result_type, add_result_type> cast;
+        return cast(add(first, second, perm));
+      }
+
+      static result_type eval(ZeroTensor, const right_type& second,
+          const Permutation& perm)
+      {
+        Permute<result_type,right_type> permute;
+        return permute(second, perm);
+      }
+
+      static result_type eval(const left_type& first, ZeroTensor,
+          const Permutation& perm)
+      {
+        Permute<result_type,left_type> permute;
+        return permute(first, perm);
+      }
+
+      // Non-permuting tile evaluation functions
+      // The compiler will select the correct functions based on the consumability
+      // of the arguments.
+
+      template <bool LC, bool RC,
+          typename std::enable_if<!(LC || RC)>::type* = nullptr>
+      static result_type eval(const left_type& first, const right_type& second) {
+        using TiledArray::add;
+        typedef decltype(add(std::declval<left_type>(), std::declval<right_type>()))
+            add_result_type;
+        Cast<result_type, add_result_type> cast;
+        return cast(add(first, second));
+      }
+
+      template <bool LC, bool RC,
+          typename std::enable_if<LC>::type* = nullptr>
+      static result_type eval(left_type& first, const right_type& second) {
+        using TiledArray::add_to;
+        return add_to(first, second);
+      }
+
+      template <bool LC, bool RC,
+          typename std::enable_if<!LC && RC>::type* = nullptr>
+      static result_type eval(const left_type& first, right_type& second) {
+        using TiledArray::add_to;
+        return add_to(second, first);
+      }
+
+      template <bool LC, bool RC,
+          typename std::enable_if<!RC>::type* = nullptr>
+      static result_type eval(const ZeroTensor&, const right_type& second) {
+        TiledArray::Clone<result_type,right_type> clone;
+        return clone(second);
+      }
+
+      template <bool LC, bool RC,
+          typename std::enable_if<RC>::type* = nullptr>
+      static result_type eval(const ZeroTensor&, right_type& second) {
+        return second;
+      }
+
+      template <bool LC, bool RC,
+          typename std::enable_if<!LC>::type* = nullptr>
+      static result_type eval(const left_type& first, const ZeroTensor&) {
+        TiledArray::Clone<result_type,left_type> clone;
+        return clone(first);
+      }
+
+      template <bool LC, bool RC,
+          typename std::enable_if<LC>::type* = nullptr>
+      static result_type eval(left_type& first, const ZeroTensor&) {
+        return first;
+      }
+
+    public:
+
+      /// Add-and-permute operator
+
+      /// Compute the sum of two tiles and permute the result. One of the argument
+      /// tiles may be replaced with `ZeroTensor` argument, in which case the
+      /// argument's element values are assumed to be `0`.
+      /// \tparam L The left-hand tile argument type
+      /// \tparam R The right-hand tile argument type
+      /// \param left The left-hand tile argument
+      /// \param right The right-hand tile argument
+      /// \param perm The permutation applied to the result tile
+      /// \return The permuted and scaled sum of `left` and `right`.
+      template <typename L, typename R>
+      result_type operator()(L&& left, R&& right, const Permutation& perm) const {
+        return eval(std::forward<L>(left), std::forward<R>(right), perm);
+      }
+
+      /// Add operator
+
+      /// Compute the sum of two tiles. One of the argument tiles may be replaced
+      /// with `ZeroTensor` argument, in which case the argument's element values
+      /// are assumed to be `0`.
+      /// \tparam L The left-hand tile argument type
+      /// \tparam R The right-hand tile argument type
+      /// \param left The left-hand tile argument
+      /// \param right The right-hand tile argument
+      /// \return The scaled sum of `left` and `right`.
+      template <typename L, typename R>
+      result_type operator()(L&& left, R&& right) const {
+        return Add_::template eval<left_is_consumable, right_is_consumable>(
+            std::forward<L>(left), std::forward<R>(right));
+      }
+
+      /// Add right to left
+
+      /// Add the right tile to the left. The right tile may be replaced with
+      /// `ZeroTensor` argument, in which case the argument's element values are
+      /// assumed to be `0`.
+      /// \tparam R The right-hand tile argument type
+      /// \param left The left-hand tile argument
+      /// \param right The right-hand tile argument
+      /// \return The sum of `left` and `right`.
+      template <typename R>
+      result_type consume_left(left_type& left, R&& right) const {
+        constexpr auto can_consume = is_consumable_tile<left_type>::value && std::is_same<result_type,left_type>::value;
+        return Add_::template eval<can_consume,false>(left, std::forward<R>(right));
+      }
+
+      /// Add left to right
+
+      /// Add the left tile to the right. The left tile may be replaced with
+      /// `ZeroTensor` argument, in which case the argument's element values are
+      /// assumed to be `0`.
+      /// \tparam L The left-hand tile argument type
+      /// \param left The left-hand tile argument
+      /// \param right The right-hand tile argument
+      /// \return The sum of `left` and `right`.
+      template <typename L>
+      result_type consume_right(L&& left, right_type& right) const {
+        constexpr auto can_consume = is_consumable_tile<right_type>::value && std::is_same<result_type,right_type>::value;
+        return Add_::template eval<false,can_consume>(std::forward<L>(left), right);
+      }
+
+    }; // class Add
+  }
+
 } // namespace TiledArray
 
 #endif // TILEDARRAY_TILE_OP_ADD_H__INCLUDED

--- a/tests/expressions_mixed.cpp
+++ b/tests/expressions_mixed.cpp
@@ -149,25 +149,24 @@ const TiledRange MixedExpressionsFixture::trange2 =
 
 BOOST_FIXTURE_TEST_SUITE( mixed_expressions_suite, MixedExpressionsFixture )
 
-BOOST_AUTO_TEST_CASE( tensor_factories )
-{
-  const auto& ca = a;
-  const std::array<int,2> lobound{{3,3}};
-  const std::array<int,2> upbound{{5,5}};
-
-  BOOST_CHECK_NO_THROW(w("a,b") = u("b,a"));
-  BOOST_CHECK_NO_THROW(v("a,b") = w("b,a"));
-  BOOST_CHECK_NO_THROW(u("a,b") = v("b,a"));
-}
+//BOOST_AUTO_TEST_CASE( tensor_factories )
+//{
+//  const auto& ca = a;
+//  const std::array<int,2> lobound{{3,3}};
+//  const std::array<int,2> upbound{{5,5}};
+//
+//  BOOST_CHECK_NO_THROW(w("a,b") = u("b,a"));
+//  BOOST_CHECK_NO_THROW(v("a,b") = w("b,a"));
+//  BOOST_CHECK_NO_THROW(u("a,b") = v("b,a"));
+//}
 
 BOOST_AUTO_TEST_CASE( add_factories )
 {
   // compile error: adding dense + sparse = dense
-  // BOOST_CHECK_NO_THROW(w("a,b") = u("a,b") + v("a,b"));
+  BOOST_CHECK_NO_THROW(w("a,b") = u("a,b") + v("a,b"));
 
   // ok
   BOOST_CHECK_NO_THROW(u1("a,b") = u("a,b") + v("a,b"));
-
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
only MINIMALLY tested for D = A + B, where add(A,B) produces C != D

summary: result type gets forced down the expression _engine_ tree at runtime (expression tree itself is immutable) ... see a version of `Expr<>::eval_to` that forces result type onto the subexpression engine by creating a new result-type-dependent engine. This can then be used to call result-dependent version of add; in experimental::Add (see add.h) I just do a cast from freestanding add() versions that produces wrong result types. The user will have to provide a `BinaryBrait<Result,Arg1,Arg2>` with appropriate add() implementations.

@justusc what do you think? Such approach should be relatively easy to implement throughout. I also envision something along the lines of 

`D("1,2,3") = result_tile_cast<my_tile_type>(A("1,2,3") + B("1,3,2")) + C("3,2,1")`

P.S. This is not meant for merging into mixed-expressions, just wanted a convenient place for discussion.
