### PR TITLE
LazyArrayTile<Tile,...> ::eval_type should be Tile, not Tile::eval_type

### DIFF
--- a/src/TiledArray/dist_eval/array_eval.h
+++ b/src/TiledArray/dist_eval/array_eval.h
@@ -44,6 +44,7 @@ namespace TiledArray {
       typedef LazyArrayTile<Tile, Op> LazyArrayTile_; ///< This class type
       typedef Op op_type; ///< The operation that will modify this tile
       typedef Tile tile_type; ///< The input tile type
+      typedef tile_type eval_type;
 
     private:
       mutable tile_type tile_; ///< The input tile
@@ -87,7 +88,7 @@ namespace TiledArray {
       bool is_consumable() const { return consume_ || op_->permutation(); }
 
       /// Convert tile to evaluation type
-      operator tile_type() const {
+      explicit operator tile_type() const {
         return (consume_ ? op_->consume(tile_) : (*op_)(tile_));
       }
 

--- a/src/TiledArray/type_traits.h
+++ b/src/TiledArray/type_traits.h
@@ -64,11 +64,6 @@ namespace TiledArray {
       static constexpr bool is_consumable = false;
     }; // struct eval_trait
 
-    template <typename Tile, typename Op>
-    struct eval_trait_base<LazyArrayTile<Tile, Op>, void> :
-      public eval_trait<Tile>
-    { }; // struct eval_trait
-
     template <typename T>
     struct eval_trait_base<T, typename std::enable_if<
         detail::is_type<typename T::eval_type>::value>::type>


### PR DESCRIPTION
This breaks for `LazyArrayTile<MyLazyTile,....>` since evaling it tries to cast directly `LazyArrayTile<MyLazyTile,....>` -> `MyLazyTile::eval_type`, instead of `LazyArrayTile<MyLazyTile,....>` -> `MyLazyTile` -> `MyLazyTile::eval_type`