### PR TITLE
change the default to NOT search CMAKE_INSTALL_PREFIX for MADNESS etc…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,8 @@ else()
   set(CMAKE_MACOSX_RPATH FALSE)
 endif()
 
+# miscellaneous cmake platform-neutral and platform-specific configuration =============================
+set(CMAKE_FIND_NO_INSTALL_PREFIX TRUE)  # do not search in CMAKE_INSTALL_PREFIX 
 set(CMAKE_SKIP_RPATH FALSE)
 set(CMAKE_SKIP_BUILD_RPATH  FALSE)
 set(CMAKE_SKIP_INSTALL_RPATH FALSE)


### PR DESCRIPTION
…. Will not affect average user, but helps developers to avoid stale MADworld.