### PR TITLE
systematic replacement of deprecated functions

### DIFF
--- a/examples/cc/ccd.cpp
+++ b/examples/cc/ccd.cpp
@@ -98,22 +98,22 @@ int main(int argc, char** argv) {
     if(world.rank() == 0)
       std::cout << " done.\n";
 
-    TiledArray::TSpArrayD t_aa_vvoo(world, v_aa_vvoo.trange(), v_aa_vvoo.get_shape());
+    TiledArray::TSpArrayD t_aa_vvoo(world, v_aa_vvoo.trange(), v_aa_vvoo.shape());
     for(auto it = t_aa_vvoo.range().begin(); it != t_aa_vvoo.range().end(); ++it)
       if(t_aa_vvoo.is_local(*it) && (! t_aa_vvoo.is_zero(*it)))
         t_aa_vvoo.set(*it, 0.0);
 
-    TiledArray::TSpArrayD t_ab_vvoo(world, v_ab_vvoo.trange(), v_ab_vvoo.get_shape());
+    TiledArray::TSpArrayD t_ab_vvoo(world, v_ab_vvoo.trange(), v_ab_vvoo.shape());
     for(auto it = t_ab_vvoo.range().begin(); it != t_ab_vvoo.range().end(); ++it)
       if(t_ab_vvoo.is_local(*it) && (! t_ab_vvoo.is_zero(*it)))
         t_ab_vvoo.set(*it, 0.0);
 
-    TiledArray::TSpArrayD t_bb_vvoo(world, v_bb_vvoo.trange(), v_bb_vvoo.get_shape());
+    TiledArray::TSpArrayD t_bb_vvoo(world, v_bb_vvoo.trange(), v_bb_vvoo.shape());
     for(auto it = t_bb_vvoo.range().begin(); it != t_bb_vvoo.range().end(); ++it)
       if(t_bb_vvoo.is_local(*it) && (! t_bb_vvoo.is_zero(*it)))
         t_bb_vvoo.set(*it, 0.0);
 
-    TiledArray::TSpArrayD D_vvoo(world, v_ab_vvoo.trange(), v_ab_vvoo.get_shape());
+    TiledArray::TSpArrayD D_vvoo(world, v_ab_vvoo.trange(), v_ab_vvoo.shape());
     for(auto it = D_vvoo.range().begin(); it != D_vvoo.range().end(); ++it)
       if(D_vvoo.is_local(*it) && (! D_vvoo.is_zero(*it)))
         D_vvoo.set(*it, world.taskq.add(data, & InputData::make_D_vvoo_tile, D_vvoo.trange().make_tile_range(*it)));

--- a/examples/cc/ccd.cpp
+++ b/examples/cc/ccd.cpp
@@ -116,7 +116,7 @@ int main(int argc, char** argv) {
     TiledArray::TSpArrayD D_vvoo(world, v_ab_vvoo.trange(), v_ab_vvoo.shape());
     for(auto it = D_vvoo.range().begin(); it != D_vvoo.range().end(); ++it)
       if(D_vvoo.is_local(*it) && (! D_vvoo.is_zero(*it)))
-        D_vvoo.set(*it, world.taskq.add(data, & InputData::make_D_vvoo_tile, D_vvoo.trange().make_tile_range(*it)));
+        D_vvoo.set(*it, world.taskq.add(data, & InputData::make_D_vvoo_tile, D_vvoo.trange().make_tiles_range(*it)));
 
 
     world.gop.fence();

--- a/examples/cc/ccsd.cpp
+++ b/examples/cc/ccsd.cpp
@@ -132,12 +132,12 @@ int main(int argc, char** argv) {
 //    TArray2s D_vo(world, f_a_vo.trange(), f_a_vo.shape());
 //    for(TArray2s::range_type::const_iterator it = D_vo.range().begin(); it != D_vo.range().end(); ++it)
 //      if(D_vo.is_local(*it) && (! D_vo.is_zero(*it)))
-//        D_vo.set(*it, world.taskq.add(data, & InputData::make_D_vo_tile, D_vo.trange().make_tile_range(*it)));
+//        D_vo.set(*it, world.taskq.add(data, & InputData::make_D_vo_tile, D_vo.trange().make_tiles_range(*it)));
 //
 //    TArray4s D_vvoo(world, v_ab_vvoo.trange(), v_ab_vvoo.shape());
 //    for(TArray4s::range_type::const_iterator it = D_vvoo.range().begin(); it != D_vvoo.range().end(); ++it)
 //      if(D_vvoo.is_local(*it) && (! D_vvoo.is_zero(*it)))
-//        D_vvoo.set(*it, world.taskq.add(data, & InputData::make_D_vvoo_tile, D_vvoo.trange().make_tile_range(*it)));
+//        D_vvoo.set(*it, world.taskq.add(data, & InputData::make_D_vvoo_tile, D_vvoo.trange().make_tiles_range(*it)));
 
 
     world.gop.fence();

--- a/examples/cc/ccsd.cpp
+++ b/examples/cc/ccsd.cpp
@@ -114,27 +114,27 @@ int main(int argc, char** argv) {
 //      std::cout << " done.\n";
 //
 //
-//    TArray2s t_a_vo(world, f_a_vo.trange(), f_a_vo.get_shape());
+//    TArray2s t_a_vo(world, f_a_vo.trange(), f_a_vo.shape());
 //    t_a_vo.set_all_local(0.0);
 //
 //    TArray2s& t_b_vo = t_a_vo;
 //
-//    TArray4s t_aa_vvoo(world, v_aa_vvoo.trange(), v_aa_vvoo.get_shape());
+//    TArray4s t_aa_vvoo(world, v_aa_vvoo.trange(), v_aa_vvoo.shape());
 //    t_aa_vvoo.set_all_local(0.0);
 //
-//    TArray4s t_ab_vvoo(world, v_ab_vvoo.trange(), v_ab_vvoo.get_shape());
+//    TArray4s t_ab_vvoo(world, v_ab_vvoo.trange(), v_ab_vvoo.shape());
 //    t_ab_vvoo.set_all_local(0.0);
 //
-//    TArray4s t_bb_vvoo(world, v_bb_vvoo.trange(), v_bb_vvoo.get_shape());
+//    TArray4s t_bb_vvoo(world, v_bb_vvoo.trange(), v_bb_vvoo.shape());
 //    t_bb_vvoo.set_all_local(0.0);
 //
 //
-//    TArray2s D_vo(world, f_a_vo.trange(), f_a_vo.get_shape());
+//    TArray2s D_vo(world, f_a_vo.trange(), f_a_vo.shape());
 //    for(TArray2s::range_type::const_iterator it = D_vo.range().begin(); it != D_vo.range().end(); ++it)
 //      if(D_vo.is_local(*it) && (! D_vo.is_zero(*it)))
 //        D_vo.set(*it, world.taskq.add(data, & InputData::make_D_vo_tile, D_vo.trange().make_tile_range(*it)));
 //
-//    TArray4s D_vvoo(world, v_ab_vvoo.trange(), v_ab_vvoo.get_shape());
+//    TArray4s D_vvoo(world, v_ab_vvoo.trange(), v_ab_vvoo.shape());
 //    for(TArray4s::range_type::const_iterator it = D_vvoo.range().begin(); it != D_vvoo.range().end(); ++it)
 //      if(D_vvoo.is_local(*it) && (! D_vvoo.is_zero(*it)))
 //        D_vvoo.set(*it, world.taskq.add(data, & InputData::make_D_vvoo_tile, D_vvoo.trange().make_tile_range(*it)));

--- a/examples/cc/input_data.cpp
+++ b/examples/cc/input_data.cpp
@@ -156,7 +156,7 @@ InputData::make_f(TiledArray::World& w, const Spin s, const RangeOV ov1, const R
   // Set the tile data
   TiledArray::TSpArrayD::range_type::index index;
   for(array2d::const_iterator it = f_.begin(); it != f_.end(); ++it) {
-    if(f.trange().elements().includes(it->first)) {
+    if(f.trange().element_range().includes(it->first)) {
       index = f.trange().element_to_tile(it->first);
       if(f.is_local(index))
         f.find(index).get()[it->first] = it->second;
@@ -179,7 +179,7 @@ InputData::make_v_ab(TiledArray::World& w, const RangeOV ov1, const RangeOV ov2,
   // Set the tile data
   TiledArray::TSpArrayD::range_type::index index;
   for(array4d::const_iterator it = v_ab_.begin(); it != v_ab_.end(); ++it) {
-    if(v_ab.trange().elements().includes(it->first)) {
+    if(v_ab.trange().element_range().includes(it->first)) {
       index = v_ab.trange().element_to_tile(it->first);
       if(v_ab.is_local(index))
         v_ab.find(index).get()[it->first] = it->second;

--- a/examples/cc/input_data.cpp
+++ b/examples/cc/input_data.cpp
@@ -156,7 +156,7 @@ InputData::make_f(TiledArray::World& w, const Spin s, const RangeOV ov1, const R
   // Set the tile data
   TiledArray::TSpArrayD::range_type::index index;
   for(array2d::const_iterator it = f_.begin(); it != f_.end(); ++it) {
-    if(f.trange().element_range().includes(it->first)) {
+    if(f.trange().elements_range().includes(it->first)) {
       index = f.trange().element_to_tile(it->first);
       if(f.is_local(index))
         f.find(index).get()[it->first] = it->second;
@@ -179,7 +179,7 @@ InputData::make_v_ab(TiledArray::World& w, const RangeOV ov1, const RangeOV ov2,
   // Set the tile data
   TiledArray::TSpArrayD::range_type::index index;
   for(array4d::const_iterator it = v_ab_.begin(); it != v_ab_.end(); ++it) {
-    if(v_ab.trange().element_range().includes(it->first)) {
+    if(v_ab.trange().elements_range().includes(it->first)) {
       index = v_ab.trange().element_to_tile(it->first);
       if(v_ab.is_local(index))
         v_ab.find(index).get()[it->first] = it->second;

--- a/examples/cc/input_data.h
+++ b/examples/cc/input_data.h
@@ -80,11 +80,11 @@ private:
 
   template <typename R, typename T>
   TiledArray::SparseShape<float> make_sparse_shape(const R& r, const T& t) const {
-    TiledArray::Tensor<float> tile_norms(r.tiles(), 0.0f);
+    TiledArray::Tensor<float> tile_norms(r.tile_range(), 0.0f);
 
     // Find and store the tile for each element in the tensor.
     for(typename T::const_iterator it = t.begin(); it != t.end(); ++it) {
-      if (r.elements().includes(it->first)) {
+      if (r.element_range().includes(it->first)) {
         tile_norms[r.element_to_tile(it->first)] += it->second * it->second;
       }
     }

--- a/examples/cc/input_data.h
+++ b/examples/cc/input_data.h
@@ -80,11 +80,11 @@ private:
 
   template <typename R, typename T>
   TiledArray::SparseShape<float> make_sparse_shape(const R& r, const T& t) const {
-    TiledArray::Tensor<float> tile_norms(r.tile_range(), 0.0f);
+    TiledArray::Tensor<float> tile_norms(r.tiles_range(), 0.0f);
 
     // Find and store the tile for each element in the tensor.
     for(typename T::const_iterator it = t.begin(); it != t.end(); ++it) {
-      if (r.element_range().includes(it->first)) {
+      if (r.elements_range().includes(it->first)) {
         tile_norms[r.element_to_tile(it->first)] += it->second * it->second;
       }
     }

--- a/examples/demo/demo.cpp
+++ b/examples/demo/demo.cpp
@@ -46,10 +46,10 @@ int main(int argc, char* argv[]) {
   TA::TiledRange1 TR1{0, 4, 7, 10};
   TA::TiledRange TR{TR0, TR1};
   cout << TR << endl;
-  for(const auto& i: TR.elements()) {
+  for(const auto& i: TR.element_range()) {
     cout << i << endl;
   }
-  for(const auto& i: TR.tiles()) {
+  for(const auto& i: TR.tile_range()) {
     cout << i << endl;
   }
 
@@ -66,7 +66,7 @@ int main(int argc, char* argv[]) {
     cout << a0 << endl;
   world.gop.fence();
 
-  TA::Tensor<float> shape_tensor(TR.tiles());
+  TA::Tensor<float> shape_tensor(TR.tile_range());
   shape_tensor(0,0) = 1.0;
   shape_tensor(0,1) = 1.0;
   shape_tensor(1,1) = 1.0;

--- a/examples/demo/demo.cpp
+++ b/examples/demo/demo.cpp
@@ -46,10 +46,10 @@ int main(int argc, char* argv[]) {
   TA::TiledRange1 TR1{0, 4, 7, 10};
   TA::TiledRange TR{TR0, TR1};
   cout << TR << endl;
-  for(const auto& i: TR.element_range()) {
+  for(const auto& i: TR.elements_range()) {
     cout << i << endl;
   }
-  for(const auto& i: TR.tile_range()) {
+  for(const auto& i: TR.tiles_range()) {
     cout << i << endl;
   }
 
@@ -66,7 +66,7 @@ int main(int argc, char* argv[]) {
     cout << a0 << endl;
   world.gop.fence();
 
-  TA::Tensor<float> shape_tensor(TR.tile_range());
+  TA::Tensor<float> shape_tensor(TR.tiles_range());
   shape_tensor(0,0) = 1.0;
   shape_tensor(0,1) = 1.0;
   shape_tensor(1,1) = 1.0;

--- a/examples/dgemm/ta_band.cpp
+++ b/examples/dgemm/ta_band.cpp
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
     TiledArray::SparseShape<float>::threshold(0.5);
 
     // Construct shape
-    TiledArray::Tensor<float> shape_tensor(trange.tile_range(), 0.0f);
+    TiledArray::Tensor<float> shape_tensor(trange.tiles_range(), 0.0f);
     for(long i = 0l; i < num_blocks; ++i) {
       long j = std::max<long>(i - band_width + 1, 0);
       const long j_end = std::min<long>(i + band_width - 1, num_blocks);

--- a/examples/dgemm/ta_band.cpp
+++ b/examples/dgemm/ta_band.cpp
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
     TiledArray::SparseShape<float>::threshold(0.5);
 
     // Construct shape
-    TiledArray::Tensor<float> shape_tensor(trange.tiles(), 0.0f);
+    TiledArray::Tensor<float> shape_tensor(trange.tile_range(), 0.0f);
     for(long i = 0l; i < num_blocks; ++i) {
       long j = std::max<long>(i - band_width + 1, 0);
       const long j_end = std::min<long>(i + band_width - 1, num_blocks);

--- a/examples/dgemm/ta_cc_abcd.cpp
+++ b/examples/dgemm/ta_cc_abcd.cpp
@@ -275,12 +275,12 @@ TA::detail::DistEval<typename Op::result_type, Policy> make_contract_eval(
   for(unsigned int i = 0ul; i < left_middle; ++i) {
     ranges[(perm ? perm[pi++] : pi++)] = left.trange().data()[i];
     M *= left.range().extent_data()[i];
-    m *= left.trange().element_range().extent_data()[i];
+    m *= left.trange().elements_range().extent_data()[i];
   }
   for(std::size_t i = num_contract_ranks; i < right_end; ++i) {
     ranges[(perm ? perm[pi++] : pi++)] = right.trange().data()[i];
     N *= right.range().extent_data()[i];
-    n *= right.trange().element_range().extent_data()[i];
+    n *= right.trange().elements_range().extent_data()[i];
   }
 
   // Compute the number of tiles in the inner dimension.
@@ -339,7 +339,7 @@ void rand_fill_array(TA::DistArray<Tile, Policy>& array) {
   for (auto it : array) {
     // Construct a new tile with random data
     typename TA::DistArray<Tile, Policy>::value_type tile(
-        array.trange().make_tile_range(it.index()));
+        array.trange().make_tiles_range(it.index()));
     for (auto& tile_it : tile) tile_it = world.drand();
 
     // Set array tile
@@ -391,7 +391,7 @@ void tensor_contract_444(TA::DistArray<Tile, Policy>& tv,
   // result shape
   TA::TiledRange trange_tv({trange_occ, trange_occ, trange_uocc, trange_uocc});
   //
-  pmap.reset(new TA::detail::BlockedPmap(world, trange_tv.tile_range().volume()));
+  pmap.reset(new TA::detail::BlockedPmap(world, trange_tv.tiles_range().volume()));
   // 'contract' object is of type
   // PaRSEC's PTG object will do the job here:
   // 1. it will use t_eval and v_eval's Futures as input

--- a/examples/dgemm/ta_cc_abcd.cpp
+++ b/examples/dgemm/ta_cc_abcd.cpp
@@ -275,12 +275,12 @@ TA::detail::DistEval<typename Op::result_type, Policy> make_contract_eval(
   for(unsigned int i = 0ul; i < left_middle; ++i) {
     ranges[(perm ? perm[pi++] : pi++)] = left.trange().data()[i];
     M *= left.range().extent_data()[i];
-    m *= left.trange().elements().extent_data()[i];
+    m *= left.trange().element_range().extent_data()[i];
   }
   for(std::size_t i = num_contract_ranks; i < right_end; ++i) {
     ranges[(perm ? perm[pi++] : pi++)] = right.trange().data()[i];
     N *= right.range().extent_data()[i];
-    n *= right.trange().elements().extent_data()[i];
+    n *= right.trange().element_range().extent_data()[i];
   }
 
   // Compute the number of tiles in the inner dimension.
@@ -391,7 +391,7 @@ void tensor_contract_444(TA::DistArray<Tile, Policy>& tv,
   // result shape
   TA::TiledRange trange_tv({trange_occ, trange_occ, trange_uocc, trange_uocc});
   //
-  pmap.reset(new TA::detail::BlockedPmap(world, trange_tv.tiles().volume()));
+  pmap.reset(new TA::detail::BlockedPmap(world, trange_tv.tile_range().volume()));
   // 'contract' object is of type
   // PaRSEC's PTG object will do the job here:
   // 1. it will use t_eval and v_eval's Futures as input

--- a/examples/dgemm/ta_dense.cpp
+++ b/examples/dgemm/ta_dense.cpp
@@ -131,7 +131,7 @@ gemm_(TiledArray::World& world, const TiledArray::TiledRange& trange, long repea
 
   const bool do_memtrace = false;
 
-  const auto n = trange.element_range().extent()[0];
+  const auto n = trange.elements_range().extent()[0];
   const auto complex_T = TiledArray::detail::is_complex<T>::value;
   const double gflop = (complex_T ? 8 : 2) // 1 multiply takes 6/1 flops for complex/real
                                            // 1 add takes 2/1 flops for complex/real

--- a/examples/dgemm/ta_dense.cpp
+++ b/examples/dgemm/ta_dense.cpp
@@ -131,7 +131,7 @@ gemm_(TiledArray::World& world, const TiledArray::TiledRange& trange, long repea
 
   const bool do_memtrace = false;
 
-  const auto n = trange.elements().extent()[0];
+  const auto n = trange.element_range().extent()[0];
   const auto complex_T = TiledArray::detail::is_complex<T>::value;
   const double gflop = (complex_T ? 8 : 2) // 1 multiply takes 6/1 flops for complex/real
                                            // 1 add takes 2/1 flops for complex/real

--- a/examples/dgemm/ta_dense_new_tile.cpp
+++ b/examples/dgemm/ta_dense_new_tile.cpp
@@ -26,7 +26,7 @@ using Array_t = TiledArray::DistArray<Tile_t>;
 void set_tiles(double val, Array_t& a) {
     auto const& trange = a.trange();
 
-    auto pmap = a.get_pmap();
+    auto pmap = a.pmap();
     const auto end = pmap->end();
     for (auto it = pmap->begin(); it != end; ++it) {
         auto range = trange.make_tile_range(*it);

--- a/examples/dgemm/ta_dense_new_tile.cpp
+++ b/examples/dgemm/ta_dense_new_tile.cpp
@@ -29,7 +29,7 @@ void set_tiles(double val, Array_t& a) {
     auto pmap = a.pmap();
     const auto end = pmap->end();
     for (auto it = pmap->begin(); it != end; ++it) {
-        auto range = trange.make_tile_range(*it);
+        auto range = trange.make_tiles_range(*it);
         a.set(*it, Tile_t(TiledArray::Tensor<double>(range, val)));
     }
 }

--- a/examples/dgemm/ta_elem_dense.cpp
+++ b/examples/dgemm/ta_elem_dense.cpp
@@ -33,7 +33,7 @@ make_random_array(TiledArray::World &world, TiledArray::TiledRange &trange){
   typename TiledArray::TArrayD::iterator it = array.begin();
   for(; it != array.end(); ++it){
     typename TiledArray::TArrayD::value_type tile(
-                                array.trange().make_tile_range(it.ordinal()));
+                                array.trange().make_tiles_range(it.ordinal()));
     world.taskq.add(&random_tile_task<decltype(it), decltype(tile)>, it, tile);
   }
   return array;

--- a/examples/dgemm/ta_sparse.cpp
+++ b/examples/dgemm/ta_sparse.cpp
@@ -117,25 +117,25 @@ int main(int argc, char** argv) {
 
         // Construct shape
         TiledArray::Tensor<float>
-            a_tile_norms(trange.tile_range(), 0.0),
-            b_tile_norms(trange.tile_range(), 0.0);
+            a_tile_norms(trange.tiles_range(), 0.0),
+            b_tile_norms(trange.tiles_range(), 0.0);
         if(world.rank() == 0) {
           world.srand(time(NULL));
           for(long count = 0l; count < l_block_count; ++count) {
-            std::size_t index = world.rand() % trange.tile_range().volume();
+            std::size_t index = world.rand() % trange.tiles_range().volume();
 
             // Avoid setting the same tile to non-zero.
             while(a_tile_norms[index] > TiledArray::SparseShape<float>::threshold())
-              index = world.rand() % trange.tile_range().volume();
+              index = world.rand() % trange.tiles_range().volume();
 
             a_tile_norms[index] = std::sqrt(float(block_size * block_size));
           }
           for(long count = 0l; count < r_block_count; ++count) {
-            std::size_t index = world.rand() % trange.tile_range().volume();
+            std::size_t index = world.rand() % trange.tiles_range().volume();
 
             // Avoid setting the same tile to non-zero.
             while(b_tile_norms[index] > TiledArray::SparseShape<float>::threshold())
-              index = world.rand() % trange.tile_range().volume();
+              index = world.rand() % trange.tiles_range().volume();
 
             b_tile_norms[index] = std::sqrt(float(block_size * block_size));
           }

--- a/examples/dgemm/ta_sparse.cpp
+++ b/examples/dgemm/ta_sparse.cpp
@@ -117,25 +117,25 @@ int main(int argc, char** argv) {
 
         // Construct shape
         TiledArray::Tensor<float>
-            a_tile_norms(trange.tiles(), 0.0),
-            b_tile_norms(trange.tiles(), 0.0);
+            a_tile_norms(trange.tile_range(), 0.0),
+            b_tile_norms(trange.tile_range(), 0.0);
         if(world.rank() == 0) {
           world.srand(time(NULL));
           for(long count = 0l; count < l_block_count; ++count) {
-            std::size_t index = world.rand() % trange.tiles().volume();
+            std::size_t index = world.rand() % trange.tile_range().volume();
 
             // Avoid setting the same tile to non-zero.
             while(a_tile_norms[index] > TiledArray::SparseShape<float>::threshold())
-              index = world.rand() % trange.tiles().volume();
+              index = world.rand() % trange.tile_range().volume();
 
             a_tile_norms[index] = std::sqrt(float(block_size * block_size));
           }
           for(long count = 0l; count < r_block_count; ++count) {
-            std::size_t index = world.rand() % trange.tiles().volume();
+            std::size_t index = world.rand() % trange.tile_range().volume();
 
             // Avoid setting the same tile to non-zero.
             while(b_tile_norms[index] > TiledArray::SparseShape<float>::threshold())
-              index = world.rand() % trange.tiles().volume();
+              index = world.rand() % trange.tile_range().volume();
 
             b_tile_norms[index] = std::sqrt(float(block_size * block_size));
           }
@@ -177,14 +177,14 @@ int main(int argc, char** argv) {
             if(world.rank() == 0)
               std::cout << "Iteration " << i + 1 << "   time=" << time << "   GFLOPS="
                   << flop / time / 1.0e9 << "   apparent GFLOPS=" << app_flop / time / 1.0e9 << "\n";
-            std::cout << "C sparsity = " << c.get_shape().sparsity() << "\n";
+            std::cout << "C sparsity = " << c.shape().sparsity() << "\n";
 
           }
         } catch(...) {
           if(world.rank() == 0) {
             std::stringstream ss;
-            ss << "left shape  = " << a.get_shape().data() << "\n"
-               << "right shape = " << b.get_shape().data() << "\n";
+            ss << "left shape  = " << a.shape().data() << "\n"
+               << "right shape = " << b.shape().data() << "\n";
             printf(ss.str().c_str());
           }
           throw;

--- a/examples/dgemm/ta_sparse_grow.cpp
+++ b/examples/dgemm/ta_sparse_grow.cpp
@@ -102,8 +102,8 @@ int main(int argc, char** argv) {
 
       // Construct tile norm tensors
       TiledArray::Tensor<float>
-          a_tile_norms(trange.tiles(), 0.0f),
-          b_tile_norms(trange.tiles(), 0.0f);
+          a_tile_norms(trange.tile_range(), 0.0f),
+          b_tile_norms(trange.tile_range(), 0.0f);
 
       // Fill tile norm tensors
       if(world.rank() == 0) {
@@ -116,7 +116,7 @@ int main(int argc, char** argv) {
             // Find a new zero tile index.
             std::size_t index = 0ul;
             do {
-              index = world.rand() % trange.tiles().volume();
+              index = world.rand() % trange.tile_range().volume();
             } while(a_tile_norms[index] > TiledArray::SparseShape<float>::threshold());
 
             // Set index tile of matrix matrix a.
@@ -124,7 +124,7 @@ int main(int argc, char** argv) {
 
             // Find a new zero tile index.
             do {
-              index = world.rand() % trange.tiles().volume();
+              index = world.rand() % trange.tile_range().volume();
             } while(b_tile_norms[index] > TiledArray::SparseShape<float>::threshold());
 
             b_tile_norms[index] = tile_norm;

--- a/examples/dgemm/ta_sparse_grow.cpp
+++ b/examples/dgemm/ta_sparse_grow.cpp
@@ -102,8 +102,8 @@ int main(int argc, char** argv) {
 
       // Construct tile norm tensors
       TiledArray::Tensor<float>
-          a_tile_norms(trange.tile_range(), 0.0f),
-          b_tile_norms(trange.tile_range(), 0.0f);
+          a_tile_norms(trange.tiles_range(), 0.0f),
+          b_tile_norms(trange.tiles_range(), 0.0f);
 
       // Fill tile norm tensors
       if(world.rank() == 0) {
@@ -116,7 +116,7 @@ int main(int argc, char** argv) {
             // Find a new zero tile index.
             std::size_t index = 0ul;
             do {
-              index = world.rand() % trange.tile_range().volume();
+              index = world.rand() % trange.tiles_range().volume();
             } while(a_tile_norms[index] > TiledArray::SparseShape<float>::threshold());
 
             // Set index tile of matrix matrix a.
@@ -124,7 +124,7 @@ int main(int argc, char** argv) {
 
             // Find a new zero tile index.
             do {
-              index = world.rand() % trange.tile_range().volume();
+              index = world.rand() % trange.tiles_range().volume();
             } while(b_tile_norms[index] > TiledArray::SparseShape<float>::threshold());
 
             b_tile_norms[index] = tile_norm;

--- a/examples/fock/ta_k_build.cpp
+++ b/examples/fock/ta_k_build.cpp
@@ -139,7 +139,7 @@ int main(int argc, char** argv) {
 
   // make shapes
   auto make_shape = [](const TA::TiledRange& trange) -> TA::SparseShape<float> {
-    TA::Tensor<float> tile_norms(trange.tile_range());
+    TA::Tensor<float> tile_norms(trange.tiles_range());
     for(auto& tile_norm: tile_norms) tile_norm = 1.e20;
     //std::cout << "shape_norms = " << tile_norms << std::endl;
     TA::SparseShape<float> result(tile_norms, trange);

--- a/examples/fock/ta_k_build.cpp
+++ b/examples/fock/ta_k_build.cpp
@@ -139,7 +139,7 @@ int main(int argc, char** argv) {
 
   // make shapes
   auto make_shape = [](const TA::TiledRange& trange) -> TA::SparseShape<float> {
-    TA::Tensor<float> tile_norms(trange.tiles());
+    TA::Tensor<float> tile_norms(trange.tile_range());
     for(auto& tile_norm: tile_norms) tile_norm = 1.e20;
     //std::cout << "shape_norms = " << tile_norms << std::endl;
     TA::SparseShape<float> result(tile_norms, trange);

--- a/src/TiledArray/algebra/utils.h
+++ b/src/TiledArray/algebra/utils.h
@@ -48,7 +48,7 @@ namespace TiledArray {
   inline size_t size(const DistArray<Tile, Policy>& a) {
     // this is the number of tiles
     if (a.size() > 0) // assuming dense shape
-      return a.trange().element_range().volume();
+      return a.trange().elements_range().volume();
     else
       return 0;
   }
@@ -60,33 +60,33 @@ namespace TiledArray {
 
   template <typename Tile, typename Policy>
   inline void zero(DistArray<Tile,Policy>& a) {
-    const std::string vars = detail::dummy_annotation(a.trange().tile_range().rank());
+    const std::string vars = detail::dummy_annotation(a.trange().tiles_range().rank());
     a(vars) = typename DistArray<Tile,Policy>::element_type(0) * a(vars);
   }
 
   template <typename Tile, typename Policy>
   typename DistArray<Tile,Policy>::element_type
   inline minabs_value(const DistArray<Tile,Policy>& a) {
-    return a(detail::dummy_annotation(a.trange().tile_range().rank())).abs_min();
+    return a(detail::dummy_annotation(a.trange().tiles_range().rank())).abs_min();
   }
 
   template <typename Tile, typename Policy>
   inline typename DistArray<Tile,Policy>::element_type
   maxabs_value(const DistArray<Tile,Policy>& a) {
-    return a(detail::dummy_annotation(a.trange().tile_range().rank())).abs_max();
+    return a(detail::dummy_annotation(a.trange().tiles_range().rank())).abs_max();
   }
 
   template <typename Tile, typename Policy>
   inline void vec_multiply(DistArray<Tile,Policy>& a1,
                            const DistArray<Tile,Policy>& a2) {
-    const std::string vars = detail::dummy_annotation(a1.trange().tile_range().rank());
+    const std::string vars = detail::dummy_annotation(a1.trange().tiles_range().rank());
     a1(vars) = a1(vars) * a2(vars);
   }
 
   template <typename Tile, typename Policy>
   inline typename DistArray<Tile,Policy>::element_type
   dot_product(const DistArray<Tile,Policy>& a1, const DistArray<Tile,Policy>& a2) {
-    const std::string vars = detail::dummy_annotation(a1.trange().tile_range().rank());
+    const std::string vars = detail::dummy_annotation(a1.trange().tiles_range().rank());
     return a1(vars).dot(a2(vars)).get();
   }
 
@@ -106,7 +106,7 @@ namespace TiledArray {
   template <typename Tile, typename Policy>
   inline void scale(DistArray<Tile,Policy>& a,
                     typename DistArray<Tile,Policy>::element_type scaling_factor) {
-    const std::string vars = detail::dummy_annotation(a.trange().tile_range().rank());
+    const std::string vars = detail::dummy_annotation(a.trange().tiles_range().rank());
     a(vars) = scaling_factor * a(vars);
   }
 
@@ -114,7 +114,7 @@ namespace TiledArray {
   inline void axpy(DistArray<Tile,Policy>& y,
                    typename DistArray<Tile,Policy>::element_type a,
                    const DistArray<Tile,Policy>& x) {
-    const std::string vars = detail::dummy_annotation(y.trange().tile_range().rank());
+    const std::string vars = detail::dummy_annotation(y.trange().tiles_range().rank());
     y(vars) = y(vars) + a * x(vars);
   }
 
@@ -127,7 +127,7 @@ namespace TiledArray {
   template <typename Tile, typename Policy>
   inline typename DistArray<Tile,Policy>::element_type
   norm2(const DistArray<Tile,Policy>& a) {
-    return std::sqrt(a(detail::dummy_annotation(a.trange().tile_range().rank())).squared_norm());
+    return std::sqrt(a(detail::dummy_annotation(a.trange().tiles_range().rank())).squared_norm());
   }
 
   template <typename Tile, typename Policy>

--- a/src/TiledArray/algebra/utils.h
+++ b/src/TiledArray/algebra/utils.h
@@ -48,7 +48,7 @@ namespace TiledArray {
   inline size_t size(const DistArray<Tile, Policy>& a) {
     // this is the number of tiles
     if (a.size() > 0) // assuming dense shape
-      return a.trange().elements().volume();
+      return a.trange().element_range().volume();
     else
       return 0;
   }
@@ -60,33 +60,33 @@ namespace TiledArray {
 
   template <typename Tile, typename Policy>
   inline void zero(DistArray<Tile,Policy>& a) {
-    const std::string vars = detail::dummy_annotation(a.trange().tiles().rank());
+    const std::string vars = detail::dummy_annotation(a.trange().tile_range().rank());
     a(vars) = typename DistArray<Tile,Policy>::element_type(0) * a(vars);
   }
 
   template <typename Tile, typename Policy>
   typename DistArray<Tile,Policy>::element_type
   inline minabs_value(const DistArray<Tile,Policy>& a) {
-    return a(detail::dummy_annotation(a.trange().tiles().rank())).abs_min();
+    return a(detail::dummy_annotation(a.trange().tile_range().rank())).abs_min();
   }
 
   template <typename Tile, typename Policy>
   inline typename DistArray<Tile,Policy>::element_type
   maxabs_value(const DistArray<Tile,Policy>& a) {
-    return a(detail::dummy_annotation(a.trange().tiles().rank())).abs_max();
+    return a(detail::dummy_annotation(a.trange().tile_range().rank())).abs_max();
   }
 
   template <typename Tile, typename Policy>
   inline void vec_multiply(DistArray<Tile,Policy>& a1,
                            const DistArray<Tile,Policy>& a2) {
-    const std::string vars = detail::dummy_annotation(a1.trange().tiles().rank());
+    const std::string vars = detail::dummy_annotation(a1.trange().tile_range().rank());
     a1(vars) = a1(vars) * a2(vars);
   }
 
   template <typename Tile, typename Policy>
   inline typename DistArray<Tile,Policy>::element_type
   dot_product(const DistArray<Tile,Policy>& a1, const DistArray<Tile,Policy>& a2) {
-    const std::string vars = detail::dummy_annotation(a1.trange().tiles().rank());
+    const std::string vars = detail::dummy_annotation(a1.trange().tile_range().rank());
     return a1(vars).dot(a2(vars)).get();
   }
 
@@ -106,7 +106,7 @@ namespace TiledArray {
   template <typename Tile, typename Policy>
   inline void scale(DistArray<Tile,Policy>& a,
                     typename DistArray<Tile,Policy>::element_type scaling_factor) {
-    const std::string vars = detail::dummy_annotation(a.trange().tiles().rank());
+    const std::string vars = detail::dummy_annotation(a.trange().tile_range().rank());
     a(vars) = scaling_factor * a(vars);
   }
 
@@ -114,7 +114,7 @@ namespace TiledArray {
   inline void axpy(DistArray<Tile,Policy>& y,
                    typename DistArray<Tile,Policy>::element_type a,
                    const DistArray<Tile,Policy>& x) {
-    const std::string vars = detail::dummy_annotation(y.trange().tiles().rank());
+    const std::string vars = detail::dummy_annotation(y.trange().tile_range().rank());
     y(vars) = y(vars) + a * x(vars);
   }
 
@@ -127,7 +127,7 @@ namespace TiledArray {
   template <typename Tile, typename Policy>
   inline typename DistArray<Tile,Policy>::element_type
   norm2(const DistArray<Tile,Policy>& a) {
-    return std::sqrt(a(detail::dummy_annotation(a.trange().tiles().rank())).squared_norm());
+    return std::sqrt(a(detail::dummy_annotation(a.trange().tile_range().rank())).squared_norm());
   }
 
   template <typename Tile, typename Policy>

--- a/src/TiledArray/array_impl.h
+++ b/src/TiledArray/array_impl.h
@@ -107,12 +107,17 @@ namespace TiledArray {
         return index_;
       }
 
+      /// \deprecated use TileReference::range() instead
+      DEPRECATED range_type make_range() const {
+        return range(index_);
+      }
+
       /// Tile range factory function
 
       /// Construct a range object for the current tile
-      range_type make_range() const {
+      range_type range() const {
         TA_ASSERT(tensor_);
-        return tensor_->trange().make_tile_range(index_);
+        return tensor_->trange().tile(index_);
       }
     }; // class TileReference
 
@@ -356,13 +361,18 @@ namespace TiledArray {
         return *it_;
       }
 
+      /// \deprecated use TensorIterator::range()
+      DEPRECATED range_type make_range() const {
+        return range();
+      }
+
       /// Tile range factory function
 
       /// Construct a range object for the current tile
-      range_type make_range() const {
+      range_type range() const {
         TA_ASSERT(array_);
         TA_ASSERT(it_ != array_->pmap()->end());
-        return array_->trange().make_tile_range(*it_);
+        return array_->trange().tile(*it_);
       }
 
     }; // class TensorIterator

--- a/src/TiledArray/array_impl.h
+++ b/src/TiledArray/array_impl.h
@@ -107,18 +107,14 @@ namespace TiledArray {
         return index_;
       }
 
-      /// \deprecated use TileReference::range() instead
-      DEPRECATED range_type make_range() const {
-        return range(index_);
-      }
-
       /// Tile range factory function
 
       /// Construct a range object for the current tile
-      range_type range() const {
+      range_type make_range() const {
         TA_ASSERT(tensor_);
-        return tensor_->trange().tile(index_);
+        return tensor_->trange().make_tile_range(index_);
       }
+
     }; // class TileReference
 
     /// Tensor tile reference
@@ -361,18 +357,13 @@ namespace TiledArray {
         return *it_;
       }
 
-      /// \deprecated use TensorIterator::range()
-      DEPRECATED range_type make_range() const {
-        return range();
-      }
-
       /// Tile range factory function
 
       /// Construct a range object for the current tile
-      range_type range() const {
+      range_type make_range() const {
         TA_ASSERT(array_);
         TA_ASSERT(it_ != array_->pmap()->end());
-        return array_->trange().tile(*it_);
+        return array_->trange().make_tile_range(*it_);
       }
 
     }; // class TensorIterator
@@ -425,7 +416,7 @@ namespace TiledArray {
       ArrayImpl(World& world, const trange_type& trange, const shape_type& shape,
           const std::shared_ptr<pmap_interface>& pmap) :
         TensorImpl_(world, trange, shape, pmap),
-        data_(world, trange.tile_range().volume(), pmap)
+        data_(world, trange.tiles_range().volume(), pmap)
       { }
 
       /// Virtual destructor
@@ -440,7 +431,7 @@ namespace TiledArray {
       template <typename Index>
       future get(const Index& i) const {
         TA_ASSERT(! TensorImpl_::is_zero(i));
-        return data_.get(TensorImpl_::trange().tile_range().ordinal(i));
+        return data_.get(TensorImpl_::trange().tiles_range().ordinal(i));
       }
 
       /// Tile future accessor
@@ -466,7 +457,7 @@ namespace TiledArray {
       template <typename Index, typename Value>
       void set(const Index& i, const Value& value) {
         TA_ASSERT(! TensorImpl_::is_zero(i));
-        data_.set(TensorImpl_::trange().tile_range().ordinal(i), value);
+        data_.set(TensorImpl_::trange().tiles_range().ordinal(i), value);
       }
 
       /// Array begin iterator

--- a/src/TiledArray/array_impl.h
+++ b/src/TiledArray/array_impl.h
@@ -415,7 +415,7 @@ namespace TiledArray {
       ArrayImpl(World& world, const trange_type& trange, const shape_type& shape,
           const std::shared_ptr<pmap_interface>& pmap) :
         TensorImpl_(world, trange, shape, pmap),
-        data_(world, trange.tiles().volume(), pmap)
+        data_(world, trange.tile_range().volume(), pmap)
       { }
 
       /// Virtual destructor
@@ -430,7 +430,7 @@ namespace TiledArray {
       template <typename Index>
       future get(const Index& i) const {
         TA_ASSERT(! TensorImpl_::is_zero(i));
-        return data_.get(TensorImpl_::trange().tiles().ordinal(i));
+        return data_.get(TensorImpl_::trange().tile_range().ordinal(i));
       }
 
       /// Tile future accessor
@@ -456,7 +456,7 @@ namespace TiledArray {
       template <typename Index, typename Value>
       void set(const Index& i, const Value& value) {
         TA_ASSERT(! TensorImpl_::is_zero(i));
-        data_.set(TensorImpl_::trange().tiles().ordinal(i), value);
+        data_.set(TensorImpl_::trange().tile_range().ordinal(i), value);
       }
 
       /// Array begin iterator

--- a/src/TiledArray/conversions/clone.h
+++ b/src/TiledArray/conversions/clone.h
@@ -43,13 +43,13 @@ namespace TiledArray {
   clone(const DistArray<Tile, Policy>& arg) {
     typedef typename DistArray<Tile, Policy>::value_type value_type;
 
-    World& world = arg.get_world();
+    World& world = arg.world();
 
     // Make an empty result array
-    DistArray<Tile, Policy> result(world, arg.trange(), arg.get_shape(), arg.get_pmap());
+    DistArray<Tile, Policy> result(world, arg.trange(), arg.shape(), arg.pmap());
 
     // Iterate over local tiles of arg
-    for(auto index : * arg.get_pmap()) {
+    for(auto index : * arg.pmap()) {
       if(arg.is_zero(index))
         continue;
 

--- a/src/TiledArray/conversions/dense_to_sparse.h
+++ b/src/TiledArray/conversions/dense_to_sparse.h
@@ -17,7 +17,7 @@ namespace TiledArray {
       typedef DistArray<Tile, SparsePolicy> ArrayType;  // return type
 
       // Constructing a tensor to hold the norm of each tile in the Dense Array
-      TiledArray::Tensor<float> tile_norms(dense_array.trange().tiles(), 0.0);
+      TiledArray::Tensor<float> tile_norms(dense_array.trange().tile_range(), 0.0);
 
       const auto end = dense_array.end();
       const auto begin = dense_array.begin();
@@ -28,10 +28,10 @@ namespace TiledArray {
 
       // Construct a sparse shape the constructor will handle communicating the
       // norms of the local tiles to the other nodes
-      TiledArray::SparseShape<float> shape(dense_array.get_world(), tile_norms,
+      TiledArray::SparseShape<float> shape(dense_array.world(), tile_norms,
                                            dense_array.trange());
 
-      ArrayType sparse_array(dense_array.get_world(), dense_array.trange(),
+      ArrayType sparse_array(dense_array.world(), dense_array.trange(),
                              shape);
 
       // Loop over the local dense tiles and if that tile is in the

--- a/src/TiledArray/conversions/dense_to_sparse.h
+++ b/src/TiledArray/conversions/dense_to_sparse.h
@@ -17,7 +17,7 @@ namespace TiledArray {
       typedef DistArray<Tile, SparsePolicy> ArrayType;  // return type
 
       // Constructing a tensor to hold the norm of each tile in the Dense Array
-      TiledArray::Tensor<float> tile_norms(dense_array.trange().tile_range(), 0.0);
+      TiledArray::Tensor<float> tile_norms(dense_array.trange().tiles_range(), 0.0);
 
       const auto end = dense_array.end();
       const auto begin = dense_array.begin();

--- a/src/TiledArray/conversions/eigen.h
+++ b/src/TiledArray/conversions/eigen.h
@@ -295,7 +295,7 @@ namespace TiledArray {
     void counted_eigen_submatrix_to_tensor(const Eigen::MatrixBase<Derived>* matrix,
         A& array, const typename A::size_type i, madness::AtomicInt* counter)
     {
-      typename A::value_type tensor(array.trange().tile(i));
+      typename A::value_type tensor(array.trange().make_tile_range(i));
       eigen_submatrix_to_tensor(*matrix, tensor);
       array.set(i, tensor);
       (*counter)++;
@@ -365,16 +365,16 @@ namespace TiledArray {
     typedef typename A::size_type size_type;
     // Check that trange matches the dimensions of other
     if((matrix.cols() > 1) && (matrix.rows() > 1)) {
-      TA_USER_ASSERT(trange.tile_range().rank() == 2,
+      TA_USER_ASSERT(trange.tiles_range().rank() == 2,
           "TiledArray::eigen_to_array(): The number of dimensions in trange is not equal to that of the Eigen matrix.");
-      TA_USER_ASSERT(trange.element_range().extent_data()[0] == size_type(matrix.rows()),
+      TA_USER_ASSERT(trange.elements_range().extent_data()[0] == size_type(matrix.rows()),
           "TiledArray::eigen_to_array(): The number of rows in trange is not equal to the number of rows in the Eigen matrix.");
-      TA_USER_ASSERT(trange.element_range().extent_data()[1] == size_type(matrix.cols()),
+      TA_USER_ASSERT(trange.elements_range().extent_data()[1] == size_type(matrix.cols()),
           "TiledArray::eigen_to_array(): The number of columns in trange is not equal to the number of columns in the Eigen matrix.");
     } else {
-      TA_USER_ASSERT(trange.tile_range().rank() == 1,
+      TA_USER_ASSERT(trange.tiles_range().rank() == 1,
           "TiledArray::eigen_to_array(): The number of dimensions in trange must match that of the Eigen matrix.");
-      TA_USER_ASSERT(trange.element_range().extent_data()[0] == size_type(matrix.size()),
+      TA_USER_ASSERT(trange.elements_range().extent_data()[0] == size_type(matrix.size()),
           "TiledArray::eigen_to_array(): The size of trange must be equal to the matrix size.");
     }
 
@@ -386,7 +386,7 @@ namespace TiledArray {
     // Create a new tensor
     A array = (replicated && (world.size() > 1) ?
         A(world, trange, std::static_pointer_cast<typename A::pmap_interface>(
-            std::shared_ptr<detail::ReplicatedPmap>(new detail::ReplicatedPmap(world, trange.tile_range().volume())))) :
+            std::shared_ptr<detail::ReplicatedPmap>(new detail::ReplicatedPmap(world, trange.tiles_range().volume())))) :
         A(world, trange));
 
     // Spawn tasks to copy Eigen to an Array
@@ -432,7 +432,7 @@ namespace TiledArray {
     typedef Eigen::Matrix<typename Tile::value_type, Eigen::Dynamic, Eigen::Dynamic>
         EigenMatrix;
 
-    const auto rank = array.trange().tile_range().rank();
+    const auto rank = array.trange().tiles_range().rank();
 
     // Check that the array will fit in a matrix or vector
     TA_USER_ASSERT((rank == 2u) || (rank == 1u),
@@ -445,7 +445,7 @@ namespace TiledArray {
           "TiledArray::array_to_eigen(): Array cannot be assigned with an Eigen::Matrix when the number of MPI processes is greater than 1.");
 
     // Construct the Eigen matrix
-    const auto* restrict const array_extent = array.trange().element_range().extent_data();
+    const auto* restrict const array_extent = array.trange().elements_range().extent_data();
     EigenMatrix matrix(array_extent[0], (rank == 2 ? array_extent[1] : 1));
 
     // Spawn tasks to copy array tiles to the Eigen matrix
@@ -514,9 +514,9 @@ namespace TiledArray {
       const typename A::value_type::value_type* buffer, const std::size_t m,
       const std::size_t n, const bool replicated = false)
   {
-    TA_USER_ASSERT(trange.element_range().extent_data()[0] == m,
+    TA_USER_ASSERT(trange.elements_range().extent_data()[0] == m,
         "TiledArray::eigen_to_array(): The number of rows in trange is not equal to m.");
-    TA_USER_ASSERT(trange.element_range().extent_data()[1] == n,
+    TA_USER_ASSERT(trange.elements_range().extent_data()[1] == n,
         "TiledArray::eigen_to_array(): The number of columns in trange is not equal to n.");
 
     typedef Eigen::Matrix<typename A::value_type::value_type, Eigen::Dynamic,
@@ -570,9 +570,9 @@ namespace TiledArray {
       const typename A::value_type::value_type* buffer, const std::size_t m,
       const std::size_t n, const bool replicated = false)
   {
-    TA_USER_ASSERT(trange.element_range().extent_data()[0] == m,
+    TA_USER_ASSERT(trange.elements_range().extent_data()[0] == m,
         "TiledArray::eigen_to_array(): The number of rows in trange is not equal to m.");
-    TA_USER_ASSERT(trange.element_range().extent_data()[1] == n,
+    TA_USER_ASSERT(trange.elements_range().extent_data()[1] == n,
         "TiledArray::eigen_to_array(): The number of columns in trange is not equal to n.");
 
     typedef Eigen::Matrix<typename A::value_type::value_type, Eigen::Dynamic,

--- a/src/TiledArray/conversions/eigen.h
+++ b/src/TiledArray/conversions/eigen.h
@@ -295,7 +295,7 @@ namespace TiledArray {
     void counted_eigen_submatrix_to_tensor(const Eigen::MatrixBase<Derived>* matrix,
         A& array, const typename A::size_type i, madness::AtomicInt* counter)
     {
-      typename A::value_type tensor(array.trange().make_tile_range(i));
+      typename A::value_type tensor(array.trange().tile(i));
       eigen_submatrix_to_tensor(*matrix, tensor);
       array.set(i, tensor);
       (*counter)++;
@@ -365,16 +365,16 @@ namespace TiledArray {
     typedef typename A::size_type size_type;
     // Check that trange matches the dimensions of other
     if((matrix.cols() > 1) && (matrix.rows() > 1)) {
-      TA_USER_ASSERT(trange.tiles().rank() == 2,
+      TA_USER_ASSERT(trange.tile_range().rank() == 2,
           "TiledArray::eigen_to_array(): The number of dimensions in trange is not equal to that of the Eigen matrix.");
-      TA_USER_ASSERT(trange.elements().extent_data()[0] == size_type(matrix.rows()),
+      TA_USER_ASSERT(trange.element_range().extent_data()[0] == size_type(matrix.rows()),
           "TiledArray::eigen_to_array(): The number of rows in trange is not equal to the number of rows in the Eigen matrix.");
-      TA_USER_ASSERT(trange.elements().extent_data()[1] == size_type(matrix.cols()),
+      TA_USER_ASSERT(trange.element_range().extent_data()[1] == size_type(matrix.cols()),
           "TiledArray::eigen_to_array(): The number of columns in trange is not equal to the number of columns in the Eigen matrix.");
     } else {
-      TA_USER_ASSERT(trange.tiles().rank() == 1,
+      TA_USER_ASSERT(trange.tile_range().rank() == 1,
           "TiledArray::eigen_to_array(): The number of dimensions in trange must match that of the Eigen matrix.");
-      TA_USER_ASSERT(trange.elements().extent_data()[0] == size_type(matrix.size()),
+      TA_USER_ASSERT(trange.element_range().extent_data()[0] == size_type(matrix.size()),
           "TiledArray::eigen_to_array(): The size of trange must be equal to the matrix size.");
     }
 
@@ -386,7 +386,7 @@ namespace TiledArray {
     // Create a new tensor
     A array = (replicated && (world.size() > 1) ?
         A(world, trange, std::static_pointer_cast<typename A::pmap_interface>(
-            std::shared_ptr<detail::ReplicatedPmap>(new detail::ReplicatedPmap(world, trange.tiles().volume())))) :
+            std::shared_ptr<detail::ReplicatedPmap>(new detail::ReplicatedPmap(world, trange.tile_range().volume())))) :
         A(world, trange));
 
     // Spawn tasks to copy Eigen to an Array
@@ -400,7 +400,7 @@ namespace TiledArray {
     }
 
     // Wait until the write tasks are complete
-    array.get_world().await([&counter,n] () { return counter == n; });
+    array.world().await([&counter,n] () { return counter == n; });
 
     return array;
   }
@@ -432,7 +432,7 @@ namespace TiledArray {
     typedef Eigen::Matrix<typename Tile::value_type, Eigen::Dynamic, Eigen::Dynamic>
         EigenMatrix;
 
-    const auto rank = array.trange().tiles().rank();
+    const auto rank = array.trange().tile_range().rank();
 
     // Check that the array will fit in a matrix or vector
     TA_USER_ASSERT((rank == 2u) || (rank == 1u),
@@ -440,12 +440,12 @@ namespace TiledArray {
 
     // Check that this is not a distributed computing environment or that the
     // array is replicated
-    if(! array.get_pmap()->is_replicated())
-      TA_USER_ASSERT(array.get_world().size() == 1,
+    if(! array.pmap()->is_replicated())
+      TA_USER_ASSERT(array.world().size() == 1,
           "TiledArray::array_to_eigen(): Array cannot be assigned with an Eigen::Matrix when the number of MPI processes is greater than 1.");
 
     // Construct the Eigen matrix
-    const auto* restrict const array_extent = array.trange().elements().extent_data();
+    const auto* restrict const array_extent = array.trange().element_range().extent_data();
     EigenMatrix matrix(array_extent[0], (rank == 2 ? array_extent[1] : 1));
 
     // Spawn tasks to copy array tiles to the Eigen matrix
@@ -454,7 +454,7 @@ namespace TiledArray {
     std::size_t n = 0;
     for(std::size_t i = 0; i < array.size(); ++i) {
       if(! array.is_zero(i)) {
-        array.get_world().taskq.add(
+        array.world().taskq.add(
             & detail::counted_tensor_to_eigen_submatrix<EigenMatrix,
             typename DistArray<Tile, Policy>::value_type>,
             array.find(i), &matrix, &counter);
@@ -464,7 +464,7 @@ namespace TiledArray {
 
     // Wait until the above tasks are complete. Tasks will be processed by this
     // thread while waiting.
-    array.get_world().await([&counter,n] () { return counter == n; });
+    array.world().await([&counter,n] () { return counter == n; });
 
     return matrix;
   }
@@ -514,9 +514,9 @@ namespace TiledArray {
       const typename A::value_type::value_type* buffer, const std::size_t m,
       const std::size_t n, const bool replicated = false)
   {
-    TA_USER_ASSERT(trange.elements().extent_data()[0] == m,
+    TA_USER_ASSERT(trange.element_range().extent_data()[0] == m,
         "TiledArray::eigen_to_array(): The number of rows in trange is not equal to m.");
-    TA_USER_ASSERT(trange.elements().extent_data()[1] == n,
+    TA_USER_ASSERT(trange.element_range().extent_data()[1] == n,
         "TiledArray::eigen_to_array(): The number of columns in trange is not equal to n.");
 
     typedef Eigen::Matrix<typename A::value_type::value_type, Eigen::Dynamic,
@@ -570,9 +570,9 @@ namespace TiledArray {
       const typename A::value_type::value_type* buffer, const std::size_t m,
       const std::size_t n, const bool replicated = false)
   {
-    TA_USER_ASSERT(trange.elements().extent_data()[0] == m,
+    TA_USER_ASSERT(trange.element_range().extent_data()[0] == m,
         "TiledArray::eigen_to_array(): The number of rows in trange is not equal to m.");
-    TA_USER_ASSERT(trange.elements().extent_data()[1] == n,
+    TA_USER_ASSERT(trange.element_range().extent_data()[1] == n,
         "TiledArray::eigen_to_array(): The number of columns in trange is not equal to n.");
 
     typedef Eigen::Matrix<typename A::value_type::value_type, Eigen::Dynamic,

--- a/src/TiledArray/conversions/foreach.h
+++ b/src/TiledArray/conversions/foreach.h
@@ -145,7 +145,7 @@ namespace TiledArray {
       // Construct a tensor to hold updated tile norms for the result shape.
       TiledArray::Tensor<typename shape_type::value_type,
           Eigen::aligned_allocator<typename shape_type::value_type> >
-      tile_norms(arg.trange().tile_range(), 0);
+      tile_norms(arg.trange().tiles_range(), 0);
 
       // Construct the task function used to construct the result tiles.
       madness::AtomicInt counter; counter = 0;

--- a/src/TiledArray/conversions/foreach.h
+++ b/src/TiledArray/conversions/foreach.h
@@ -95,10 +95,10 @@ namespace TiledArray {
       typedef DistArray<ArgTile, DensePolicy> arg_array_type;
       typedef DistArray<ResultTile, DensePolicy> result_array_type;
 
-      World& world = arg.get_world();
+      World& world = arg.world();
 
       // Make an empty result array
-      result_array_type result(world, arg.trange(), arg.get_pmap());
+      result_array_type result(world, arg.trange(), arg.pmap());
 
       // Construct the task function for making result tiles.
       auto task = [&op](const_if_t<not inplace, typename arg_array_type::value_type>& arg_tile)
@@ -111,7 +111,7 @@ namespace TiledArray {
       };
 
       // Iterate over local tiles of arg
-      for (auto index: *(arg.get_pmap())) {
+      for (auto index: *(arg.pmap())) {
         // Spawn a task to evaluate the tile
         Future<typename result_array_type::value_type> tile =
             world.taskq.add(task, arg.find(index));
@@ -140,12 +140,12 @@ namespace TiledArray {
 
       // Create a vector to hold local tiles
       std::vector<datum_type> tiles;
-      tiles.reserve(arg.get_pmap()->size());
+      tiles.reserve(arg.pmap()->size());
 
       // Construct a tensor to hold updated tile norms for the result shape.
       TiledArray::Tensor<typename shape_type::value_type,
           Eigen::aligned_allocator<typename shape_type::value_type> >
-      tile_norms(arg.trange().tiles(), 0);
+      tile_norms(arg.trange().tile_range(), 0);
 
       // Construct the task function used to construct the result tiles.
       madness::AtomicInt counter; counter = 0;
@@ -162,10 +162,10 @@ namespace TiledArray {
         return std::move(result_tile);
       };
 
-      World& world = arg.get_world();
+      World& world = arg.world();
 
       // Get local tile index iterator
-      for(auto index: *(arg.get_pmap())) {
+      for(auto index: *(arg.pmap())) {
         if(arg.is_zero(index))
           continue;
         auto arg_tile = arg.find(index);
@@ -180,7 +180,7 @@ namespace TiledArray {
 
       // Construct the new array
       result_array_type result(world, arg.trange(),
-          shape_type(world, tile_norms, arg.trange()), arg.get_pmap());
+          shape_type(world, tile_norms, arg.trange()), arg.pmap());
       for(typename std::vector<datum_type>::const_iterator it = tiles.begin(); it != tiles.end(); ++it) {
         const size_type index = it->first;
         if(! result.is_zero(index))
@@ -271,7 +271,7 @@ namespace TiledArray {
     // The tile data is being modified in place, which means we may need to
     // fence to ensure no other threads are using the data.
     if(fence)
-      arg.get_world().gop.fence();
+      arg.world().gop.fence();
 
     arg = detail::foreach<Tile, Tile, Op, true>(arg, std::forward<Op>(op));
   }
@@ -375,7 +375,7 @@ namespace TiledArray {
     // The tile data is being modified in place, which means we may need to
     // fence to ensure no other threads are using the data.
     if(fence)
-      arg.get_world().gop.fence();
+      arg.world().gop.fence();
 
     // Set the arg with the new array
     arg = detail::foreach<Tile,Tile,Op,true>(arg, std::forward<Op>(op));

--- a/src/TiledArray/conversions/make_array.h
+++ b/src/TiledArray/conversions/make_array.h
@@ -78,7 +78,7 @@ namespace TiledArray {
     Array result(world, trange);
 
     // Iterate over local tiles of arg
-    for(const auto index : * result.get_pmap()) {
+    for(const auto index : * result.pmap()) {
 
       // Spawn a task to evaluate the tile
       auto tile =
@@ -146,7 +146,7 @@ namespace TiledArray {
     // Construct a tensor to hold updated tile norms for the result shape.
     TiledArray::Tensor<typename detail::shape_t<Array>::value_type,
         Eigen::aligned_allocator<typename detail::shape_t<Array>::value_type> >
-    tile_norms(trange.tiles(), 0);
+    tile_norms(trange.tile_range(), 0);
 
     // Construct the task function used to construct the result tiles.
     madness::AtomicInt counter; counter = 0;
@@ -219,7 +219,7 @@ namespace TiledArray {
   make_array(World& world, const detail::trange_t<Array>& trange, Op&& op) {
     return make_array<Array>(world, trange,
         detail::policy_t<Array>::default_pmap(world,
-        trange.tiles().volume()), op);
+        trange.tile_range().volume()), op);
   }
 
 } // namespace TiledArray

--- a/src/TiledArray/conversions/make_array.h
+++ b/src/TiledArray/conversions/make_array.h
@@ -86,7 +86,7 @@ namespace TiledArray {
             value_type tile;
             op(tile, range);
             return tile;
-          }, trange.make_tile_range(index));
+          }, trange.make_tiles_range(index));
 
       // Store result tile
       result.set(index, tile);
@@ -146,14 +146,14 @@ namespace TiledArray {
     // Construct a tensor to hold updated tile norms for the result shape.
     TiledArray::Tensor<typename detail::shape_t<Array>::value_type,
         Eigen::aligned_allocator<typename detail::shape_t<Array>::value_type> >
-    tile_norms(trange.tile_range(), 0);
+    tile_norms(trange.tiles_range(), 0);
 
     // Construct the task function used to construct the result tiles.
     madness::AtomicInt counter; counter = 0;
     int task_count = 0;
     auto task = [&](const size_type index) -> value_type {
       value_type tile;
-      tile_norms[index] = op(tile, trange.make_tile_range(index));
+      tile_norms[index] = op(tile, trange.make_tiles_range(index));
       ++counter;
       return tile;
     };
@@ -219,7 +219,7 @@ namespace TiledArray {
   make_array(World& world, const detail::trange_t<Array>& trange, Op&& op) {
     return make_array<Array>(world, trange,
         detail::policy_t<Array>::default_pmap(world,
-        trange.tile_range().volume()), op);
+        trange.tiles_range().volume()), op);
   }
 
 } // namespace TiledArray

--- a/src/TiledArray/conversions/sparse_to_dense.h
+++ b/src/TiledArray/conversions/sparse_to_dense.h
@@ -34,10 +34,10 @@ namespace TiledArray {
   DistArray<Tile, DensePolicy>
   to_dense(DistArray<Tile, SparsePolicy> const& sparse_array) {
       typedef DistArray<Tile, DensePolicy> ArrayType;
-      ArrayType dense_array(sparse_array.get_world(), sparse_array.trange());
+      ArrayType dense_array(sparse_array.world(), sparse_array.trange());
 
       typedef typename ArrayType::pmap_interface pmap_interface;
-      std::shared_ptr<pmap_interface> const& pmap = dense_array.get_pmap();
+      std::shared_ptr<pmap_interface> const& pmap = dense_array.pmap();
 
       typename pmap_interface::const_iterator end = pmap->end();
 

--- a/src/TiledArray/conversions/to_new_tile_type.h
+++ b/src/TiledArray/conversions/to_new_tile_type.h
@@ -46,14 +46,14 @@ namespace TiledArray {
     static_assert(!std::is_same<Tile, OutTileType>::value,
         "Can't call new tile type if tile type does not change.");
 
-    auto &world = old_array.get_world();
+    auto &world = old_array.world();
 
     // Create new array
-    OutArray new_array(world, old_array.trange(), old_array.get_shape(), old_array.get_pmap());
+    OutArray new_array(world, old_array.trange(), old_array.shape(), old_array.pmap());
 
-    using pmap_iter = decltype(old_array.get_pmap()->begin());
-    pmap_iter it = old_array.get_pmap()->begin();
-    pmap_iter end = old_array.get_pmap()->end();
+    using pmap_iter = decltype(old_array.pmap()->begin());
+    pmap_iter it = old_array.pmap()->begin();
+    pmap_iter end = old_array.pmap()->end();
 
     for(; it != end; ++it) {
       // Must check for zero because pmap_iter does not.

--- a/src/TiledArray/dist_array.h
+++ b/src/TiledArray/dist_array.h
@@ -135,10 +135,10 @@ namespace TiledArray {
 
       if(! pmap) {
         // Construct a default process map
-        pmap = Policy::default_pmap(world, trange.tiles().volume());
+        pmap = Policy::default_pmap(world, trange.tile_range().volume());
       } else {
         // Validate the process map
-        TA_USER_ASSERT(pmap->size() == trange.tiles().volume(),
+        TA_USER_ASSERT(pmap->size() == trange.tile_range().volume(),
             "Array::Array() -- The size of the process map is not equal to the number of tiles in the TiledRange object.");
         TA_USER_ASSERT(pmap->rank() == typename pmap_interface::size_type(world.rank()),
             "Array::Array() -- The rank of the process map is not equal to that of the world object.");
@@ -149,7 +149,7 @@ namespace TiledArray {
       // Validate the shape
       TA_USER_ASSERT(! shape.empty(),
           "Array::Array() -- The shape is not initialized.");
-      TA_USER_ASSERT(shape.validate(trange.tiles()),
+      TA_USER_ASSERT(shape.validate(trange.tile_range()),
           "Array::Array() -- The range of the shape is not equal to the tiles range.");
 
       return std::shared_ptr<impl_type>(new impl_type(world, trange, shape, pmap), lazy_deleter);
@@ -330,7 +330,7 @@ namespace TiledArray {
     typename std::enable_if<detail::is_input_iterator<InIter>::value>::type
     set(const Index& i, InIter first) {
       check_index(i);
-      pimpl_->set(i, value_type(pimpl_->trange().make_tile_range(i), first));
+      pimpl_->set(i, value_type(pimpl_->trange().tile(i), first));
     }
 
     /// Set a tile and fill it using a sequence
@@ -354,7 +354,7 @@ namespace TiledArray {
     template <typename Index>
     void set(const Index& i, const element_type& value = element_type()) {
       check_index(i);
-      pimpl_->set(i, value_type(pimpl_->trange().make_tile_range(i), value));
+      pimpl_->set(i, value_type(pimpl_->trange().tile(i), value));
     }
 
     /// Set a tile and fill it using a value
@@ -468,7 +468,7 @@ namespace TiledArray {
         if(! pimpl_->is_zero(index)) {
           Future<value_type> tile = pimpl_->world().taskq.add(
               [] (DistArray_& array, const size_type index, const Op& op) -> value_type
-              { return op(array.trange().make_tile_range(index)); },
+              { return op(array.trange().tile(index)); },
               *this, index, op);
           set(index, tile);
         }
@@ -491,12 +491,17 @@ namespace TiledArray {
       return pimpl_->range();
     }
 
+    /// \deprecated use DistArray::element_range()
+    DEPRECATED const typename trange_type::tile_range_type& elements() const {
+      return element_range();
+    }
+
     /// Element range accessor
 
     /// \return A const reference to the range object for the array elements
-    const typename trange_type::tile_range_type& elements() const {
+    const typename trange_type::tile_range_type& element_range() const {
       check_pimpl();
-      return pimpl_->trange().elements();
+      return pimpl_->trange().element_range();
     }
 
     size_type size() const {
@@ -513,12 +518,12 @@ namespace TiledArray {
 #ifndef NDEBUG
       const unsigned int n = 1u + std::count_if(vars.begin(), vars.end(),
           [](const char c) { return c == ','; });
-      if(bool(pimpl_) && n != pimpl_->trange().tiles().rank()) {
+      if(bool(pimpl_) && n != pimpl_->trange().tile_range().rank()) {
         if(World::get_default().rank() == 0) {
           TA_USER_ERROR_MESSAGE( \
               "The number of array annotation variables is not equal to the array dimension:" \
               << "\n    number of variables  = " << n \
-              << "\n    array dimension      = " << pimpl_->trange().tiles().rank() );
+              << "\n    array dimension      = " << pimpl_->trange().tile_range().rank() );
         }
 
         TA_EXCEPTION("The number of array annotation variables is not equal to the array dimension.");
@@ -536,12 +541,12 @@ namespace TiledArray {
 #ifndef NDEBUG
       const unsigned int n = 1u + std::count_if(vars.begin(), vars.end(),
           [](const char c) { return c == ','; });
-      if(bool(pimpl_) && n != pimpl_->trange().tiles().rank()) {
+      if(bool(pimpl_) && n != pimpl_->trange().tile_range().rank()) {
         if(World::get_default().rank() == 0) {
           TA_USER_ERROR_MESSAGE( \
               "The number of array annotation variables is not equal to the array dimension:" \
               << "\n    number of variables  = " << n \
-              << "\n    array dimension      = " << pimpl_->trange().tiles().rank() );
+              << "\n    array dimension      = " << pimpl_->trange().tile_range().rank() );
         }
 
         TA_EXCEPTION("The number of array annotation variables is not equal to the array dimension.");
@@ -685,7 +690,7 @@ namespace TiledArray {
       check_pimpl();
       TA_USER_ASSERT(pimpl_->range().includes(i),
           "The coordinate index used to access an array tile is out of range.");
-      TA_USER_ASSERT(i.size() == pimpl_->trange().tiles().rank(),
+      TA_USER_ASSERT(i.size() == pimpl_->trange().tile_range().rank(),
           "The number of elements in the coordinate index does not match the dimension of the array.");
     }
 

--- a/src/TiledArray/dist_eval/array_eval.h
+++ b/src/TiledArray/dist_eval/array_eval.h
@@ -178,7 +178,7 @@ namespace TiledArray {
           const std::vector<std::size_t>& upper_bound) :
         DistEvalImpl_(world, trange, shape, pmap, perm),
         array_(array), op_(std::make_shared<op_type>(op)),
-        block_range_(array.trange().tile_range(), lower_bound, upper_bound)
+        block_range_(array.trange().tiles_range(), lower_bound, upper_bound)
       { }
 
       /// Virtual destructor

--- a/src/TiledArray/dist_eval/array_eval.h
+++ b/src/TiledArray/dist_eval/array_eval.h
@@ -178,7 +178,7 @@ namespace TiledArray {
           const std::vector<std::size_t>& upper_bound) :
         DistEvalImpl_(world, trange, shape, pmap, perm),
         array_(array), op_(std::make_shared<op_type>(op)),
-        block_range_(array.trange().tiles(), lower_bound, upper_bound)
+        block_range_(array.trange().tile_range(), lower_bound, upper_bound)
       { }
 
       /// Virtual destructor
@@ -209,7 +209,7 @@ namespace TiledArray {
         } else {
           // Spawn a task to set the tile when the input tile is ready.
           Future<value_type> result =
-              TensorImpl_::get_world().taskq.add(shared_from_this(),
+              TensorImpl_::world().taskq.add(shared_from_this(),
               & ArrayEvalImpl_::make_tile, tile, consumable_tile,
               madness::TaskAttributes::hipri());
 

--- a/src/TiledArray/dist_eval/binary_eval.h
+++ b/src/TiledArray/dist_eval/binary_eval.h
@@ -102,7 +102,7 @@ namespace TiledArray {
                                                   // should have the same owner
 
         const madness::DistributedID key(DistEvalImpl_::id(), i);
-        return TensorImpl_::get_world().gop.template recv<value_type>(source, key);
+        return TensorImpl_::world().gop.template recv<value_type>(source, key);
       }
 
       /// Discard a tile that is not needed
@@ -163,7 +163,7 @@ namespace TiledArray {
             const size_type target_index = DistEvalImpl_::perm_index_to_target(source_index);
 
             // Schedule tile evaluation task
-            TensorImpl_::get_world().taskq.add(self,
+            TensorImpl_::world().taskq.add(self,
                 & BinaryEvalImpl_::template eval_tile<left_argument_type, right_argument_type>,
                 target_index, left_.get(source_index), right_.get(source_index));
 
@@ -179,15 +179,15 @@ namespace TiledArray {
             if(! TensorImpl_::is_zero(target_index)) {
               // Schedule tile evaluation task
               if(left_.is_zero(index)) {
-                TensorImpl_::get_world().taskq.add(self,
+                TensorImpl_::world().taskq.add(self,
                   & BinaryEvalImpl_::template eval_tile<const ZeroTensor, right_argument_type>,
                   target_index, ZeroTensor(), right_.get(index));
               } else if(right_.is_zero(index)) {
-                TensorImpl_::get_world().taskq.add(self,
+                TensorImpl_::world().taskq.add(self,
                   & BinaryEvalImpl_::template eval_tile<left_argument_type, const ZeroTensor>,
                   target_index, left_.get(index), ZeroTensor());
               } else {
-                TensorImpl_::get_world().taskq.add(self,
+                TensorImpl_::world().taskq.add(self,
                   & BinaryEvalImpl_::template eval_tile<left_argument_type, right_argument_type>,
                   target_index, left_.get(index), right_.get(index));
               }

--- a/src/TiledArray/dist_eval/contraction_eval.h
+++ b/src/TiledArray/dist_eval/contraction_eval.h
@@ -1243,11 +1243,11 @@ namespace TiledArray {
 
           // Compute the average memory requirement per iteration of this process
           const std::size_t local_memory_per_iter_left =
-              (left_.trange().element_range().volume() / left_.trange().tile_range().volume()) *
+              (left_.trange().elements_range().volume() / left_.trange().tiles_range().volume()) *
               sizeof(typename numeric_type<typename left_type::eval_type>::type) *
               proc_grid_.local_rows() * (1.0f - left_sparsity);
           const std::size_t local_memory_per_iter_right =
-              (right_.trange().element_range().volume() / right_.trange().tile_range().volume()) *
+              (right_.trange().elements_range().volume() / right_.trange().tiles_range().volume()) *
               sizeof(typename numeric_type<typename right_type::eval_type>::type) *
               proc_grid_.local_cols() * (1.0f - right_sparsity);
 

--- a/src/TiledArray/dist_eval/dist_eval.h
+++ b/src/TiledArray/dist_eval/dist_eval.h
@@ -73,7 +73,7 @@ namespace TiledArray {
       /// \param index An ordinal index in the source index space
       /// \return The ordinal index in the target index space
       size_type perm_index_to_target(size_type index) const {
-        TA_ASSERT(index < TensorImpl_::trange().tile_range().volume());
+        TA_ASSERT(index < TensorImpl_::trange().tiles_range().volume());
         return (source_to_target_ ? source_to_target_(index) : index);
       }
 
@@ -82,7 +82,7 @@ namespace TiledArray {
       /// \param index An ordinal index in the target index space
       /// \return The ordinal index in the source index space
       size_type perm_index_to_source(size_type index) const {
-        TA_ASSERT(index < TensorImpl_::trange().tile_range().volume());
+        TA_ASSERT(index < TensorImpl_::trange().tiles_range().volume());
         return (target_to_source_ ? target_to_source_(index) : index);
       }
 
@@ -110,9 +110,9 @@ namespace TiledArray {
 
         if(perm) {
           Permutation inv_perm(-perm);
-          range_type source_range = inv_perm * trange.tile_range();
+          range_type source_range = inv_perm * trange.tiles_range();
           source_to_target_ = PermIndex(source_range, perm);
-          target_to_source_ = PermIndex(trange.tile_range(), inv_perm);
+          target_to_source_ = PermIndex(trange.tiles_range(), inv_perm);
         }
       }
 

--- a/src/TiledArray/dist_eval/dist_eval.h
+++ b/src/TiledArray/dist_eval/dist_eval.h
@@ -73,7 +73,7 @@ namespace TiledArray {
       /// \param index An ordinal index in the source index space
       /// \return The ordinal index in the target index space
       size_type perm_index_to_target(size_type index) const {
-        TA_ASSERT(index < TensorImpl_::trange().tiles().volume());
+        TA_ASSERT(index < TensorImpl_::trange().tile_range().volume());
         return (source_to_target_ ? source_to_target_(index) : index);
       }
 
@@ -82,7 +82,7 @@ namespace TiledArray {
       /// \param index An ordinal index in the target index space
       /// \return The ordinal index in the source index space
       size_type perm_index_to_source(size_type index) const {
-        TA_ASSERT(index < TensorImpl_::trange().tiles().volume());
+        TA_ASSERT(index < TensorImpl_::trange().tile_range().volume());
         return (target_to_source_ ? target_to_source_(index) : index);
       }
 
@@ -110,9 +110,9 @@ namespace TiledArray {
 
         if(perm) {
           Permutation inv_perm(-perm);
-          range_type source_range = inv_perm * trange.tiles();
+          range_type source_range = inv_perm * trange.tile_range();
           source_to_target_ = PermIndex(source_range, perm);
-          target_to_source_ = PermIndex(trange.tiles(), inv_perm);
+          target_to_source_ = PermIndex(trange.tile_range(), inv_perm);
         }
       }
 
@@ -146,7 +146,7 @@ namespace TiledArray {
       void set_tile(size_type i, const value_type& value) {
         // Store value
         madness::DistributedID id(id_, i);
-        TensorImpl_::get_world().gop.send(TensorImpl_::owner(i), id, value);
+        TensorImpl_::world().gop.send(TensorImpl_::owner(i), id, value);
 
         // Record the assignment of a tile
         DistEvalImpl_::notify();
@@ -161,7 +161,7 @@ namespace TiledArray {
       void set_tile(size_type i, Future<value_type> f) {
         // Store value
         madness::DistributedID id(id_, i);
-        TensorImpl_::get_world().gop.send(TensorImpl_::owner(i), id, f);
+        TensorImpl_::world().gop.send(TensorImpl_::owner(i), id, f);
 
         // Record the assignment of a tile
         f.register_callback(this);
@@ -175,12 +175,12 @@ namespace TiledArray {
         const int task_count = task_count_;
         if(task_count > 0) {
           try {
-            TensorImpl_::get_world().await([this,task_count] ()
+            TensorImpl_::world().await([this,task_count] ()
                 { return this->set_counter_ == task_count; });
           } catch(...) {
             std::stringstream ss;
             ss << "!! ERROR TiledArray: Aborting due to exception.\n"
-               << "!! ERROR TiledArray: rank=" << TensorImpl_::get_world().rank()
+               << "!! ERROR TiledArray: rank=" << TensorImpl_::world().rank()
                << " id=" << id_ << " " << set_counter_ << " of " << task_count << " tiles set\n";
             std::cout << ss.str().c_str();
             throw;
@@ -339,7 +339,7 @@ namespace TiledArray {
       /// World object accessor
 
       /// \return A reference to the world object
-      World& get_world() const { return pimpl_->get_world(); }
+      World& world() const { return pimpl_->world(); }
 
       /// Unique object id
 

--- a/src/TiledArray/dist_eval/unary_eval.h
+++ b/src/TiledArray/dist_eval/unary_eval.h
@@ -82,7 +82,7 @@ namespace TiledArray {
         TA_ASSERT(! TensorImpl_::is_zero(i));
         const size_type source = arg_.owner(DistEvalImpl_::perm_index_to_source(i));
         const madness::DistributedID key(DistEvalImpl_::id(), i);
-        return TensorImpl_::get_world().gop.template recv<value_type>(source, key);
+        return TensorImpl_::world().gop.template recv<value_type>(source, key);
       }
 
       /// Discard a tile that is not needed
@@ -141,7 +141,7 @@ namespace TiledArray {
             const size_type target_index = DistEvalImpl_::perm_index_to_target(index);
 
             // Schedule tile evaluation task
-            TensorImpl_::get_world().taskq.add(self, & UnaryEvalImpl_::eval_tile,
+            TensorImpl_::world().taskq.add(self, & UnaryEvalImpl_::eval_tile,
                 target_index, arg_.get(index));
 
             ++task_count;

--- a/src/TiledArray/distributed_storage.h
+++ b/src/TiledArray/distributed_storage.h
@@ -150,7 +150,7 @@ namespace TiledArray {
 
       /// \return A shared pointer to the process map.
       /// \throw nothing
-      const std::shared_ptr<pmap_interface>& get_pmap() const { return pmap_; }
+      const std::shared_ptr<pmap_interface>& pmap() const { return pmap_; }
 
       /// Element owner
 

--- a/src/TiledArray/elemental.h
+++ b/src/TiledArray/elemental.h
@@ -46,7 +46,7 @@ namespace TiledArray {
 
     // Construct the elemental matrix
     using T = typename Tile::value_type;
-    auto sizes = array.trange().elements().extent_data();
+    auto sizes = array.trange().element_range().extent_data();
     elem::DistMatrix<T> mat(sizes[0], sizes[1], grid);
     elem::Zero(mat);
 
@@ -95,8 +95,8 @@ namespace TiledArray {
   void elem_to_array(DistArray<Tile> &array, elem::DistMatrix<typename Tile::value_type> &mat){
 	using T = typename Tile::value_type;
     TA_USER_ASSERT(array.range().rank()==2u, "TiledArray::elem_to_array(): requires the array to have dimension 2");
-    TA_USER_ASSERT((array.trange().elements().extent()[0]==mat.Height()) &&
-                   (array.trange().elements().extent()[1] == mat.Width()),
+    TA_USER_ASSERT((array.trange().element_range().extent()[0]==mat.Height()) &&
+                   (array.trange().element_range().extent()[1] == mat.Width()),
                    "TiledArray::elem_to_array(): requires the shape of the elem matrix and the array to be the same.");
 
     // Make interface and attach mat

--- a/src/TiledArray/elemental.h
+++ b/src/TiledArray/elemental.h
@@ -46,7 +46,7 @@ namespace TiledArray {
 
     // Construct the elemental matrix
     using T = typename Tile::value_type;
-    auto sizes = array.trange().element_range().extent_data();
+    auto sizes = array.trange().elements_range().extent_data();
     elem::DistMatrix<T> mat(sizes[0], sizes[1], grid);
     elem::Zero(mat);
 
@@ -95,8 +95,8 @@ namespace TiledArray {
   void elem_to_array(DistArray<Tile> &array, elem::DistMatrix<typename Tile::value_type> &mat){
 	using T = typename Tile::value_type;
     TA_USER_ASSERT(array.range().rank()==2u, "TiledArray::elem_to_array(): requires the array to have dimension 2");
-    TA_USER_ASSERT((array.trange().element_range().extent()[0]==mat.Height()) &&
-                   (array.trange().element_range().extent()[1] == mat.Width()),
+    TA_USER_ASSERT((array.trange().elements_range().extent()[0]==mat.Height()) &&
+                   (array.trange().elements_range().extent()[1] == mat.Width()),
                    "TiledArray::elem_to_array(): requires the shape of the elem matrix and the array to be the same.");
 
     // Make interface and attach mat

--- a/src/TiledArray/expressions/blk_tsr_engine.h
+++ b/src/TiledArray/expressions/blk_tsr_engine.h
@@ -155,7 +155,7 @@ namespace TiledArray {
 
       /// \return The result tiled range
       trange_type make_trange() const {
-        const unsigned int rank = array_.trange().tiles().rank();
+        const unsigned int rank = array_.trange().tile_range().rank();
 
         std::vector<TiledRange1> trange_data;
         trange_data.reserve(rank);
@@ -191,7 +191,7 @@ namespace TiledArray {
 
       /// \return The result tiled range
       trange_type make_trange(const Permutation& perm) const {
-        const unsigned int rank = array_.trange().tiles().rank();
+        const unsigned int rank = array_.trange().tile_range().rank();
 
         std::vector<TiledRange1> trange_data;
         trange_data.reserve(rank);
@@ -231,7 +231,7 @@ namespace TiledArray {
           const std::shared_ptr<pmap_interface>& pmap)
       {
         ExprEngine_::init_distribution(world,
-            (pmap ? pmap : policy::default_pmap(*world, trange_.tiles().volume())));
+            (pmap ? pmap : policy::default_pmap(*world, trange_.tile_range().volume())));
       }
 
       /// Construct the distributed evaluator for array
@@ -318,7 +318,7 @@ namespace TiledArray {
 
       /// \return The result shape
       shape_type make_shape() {
-        return array_.get_shape().block(lower_bound_, upper_bound_);
+        return array_.shape().block(lower_bound_, upper_bound_);
       }
 
       /// Permuting shape factory function
@@ -326,14 +326,14 @@ namespace TiledArray {
       /// \param perm The permutation to be applied to the array
       /// \return The result shape
       shape_type make_shape(const Permutation& perm) {
-        return array_.get_shape().block(lower_bound_, upper_bound_, perm);
+        return array_.shape().block(lower_bound_, upper_bound_, perm);
       }
 
       /// Non-permuting tile operation factory function
 
       /// \return The tile operation
       op_type make_tile_op() const {
-        const unsigned int rank = trange_.tiles().rank();
+        const unsigned int rank = trange_.tile_range().rank();
 
         // Construct and allocate memory for the shift range
         std::vector<long> range_shift;
@@ -358,7 +358,7 @@ namespace TiledArray {
       /// \param perm The permutation to be applied to tiles
       /// \return The tile operation
       op_type make_tile_op(const Permutation& perm) const {
-        const unsigned int rank = trange_.tiles().rank();
+        const unsigned int rank = trange_.tile_range().rank();
 
         // Construct and allocate memory for the shift range
         std::vector<long> range_shift(rank, 0l);
@@ -448,7 +448,7 @@ namespace TiledArray {
 
       /// \return The result shape
       shape_type make_shape() {
-        return array_.get_shape().block(lower_bound_, upper_bound_, factor_);
+        return array_.shape().block(lower_bound_, upper_bound_, factor_);
       }
 
       /// Permuting shape factory function
@@ -457,14 +457,14 @@ namespace TiledArray {
       /// \return The result shape
       shape_type
       make_shape(const Permutation& perm) {
-        return array_.get_shape().block(lower_bound_, upper_bound_, factor_, perm);
+        return array_.shape().block(lower_bound_, upper_bound_, factor_, perm);
       }
 
       /// Non-permuting tile operation factory function
 
       /// \return The tile operation
       op_type make_tile_op() const {
-        const unsigned int rank = trange_.tiles().rank();
+        const unsigned int rank = trange_.tile_range().rank();
 
         // Construct and allocate memory for the shift range
         std::vector<long> range_shift;
@@ -489,7 +489,7 @@ namespace TiledArray {
       /// \param perm The permutation to be applied to tiles
       /// \return The tile operation
       op_type make_tile_op(const Permutation& perm) const {
-        const unsigned int rank = trange_.tiles().rank();
+        const unsigned int rank = trange_.tile_range().rank();
 
         // Construct and allocate memory for the shift range
         std::vector<long> range_shift(rank, 0l);

--- a/src/TiledArray/expressions/blk_tsr_engine.h
+++ b/src/TiledArray/expressions/blk_tsr_engine.h
@@ -155,7 +155,7 @@ namespace TiledArray {
 
       /// \return The result tiled range
       trange_type make_trange() const {
-        const unsigned int rank = array_.trange().tile_range().rank();
+        const unsigned int rank = array_.trange().tiles_range().rank();
 
         std::vector<TiledRange1> trange_data;
         trange_data.reserve(rank);
@@ -191,7 +191,7 @@ namespace TiledArray {
 
       /// \return The result tiled range
       trange_type make_trange(const Permutation& perm) const {
-        const unsigned int rank = array_.trange().tile_range().rank();
+        const unsigned int rank = array_.trange().tiles_range().rank();
 
         std::vector<TiledRange1> trange_data;
         trange_data.reserve(rank);
@@ -231,7 +231,7 @@ namespace TiledArray {
           const std::shared_ptr<pmap_interface>& pmap)
       {
         ExprEngine_::init_distribution(world,
-            (pmap ? pmap : policy::default_pmap(*world, trange_.tile_range().volume())));
+            (pmap ? pmap : policy::default_pmap(*world, trange_.tiles_range().volume())));
       }
 
       /// Construct the distributed evaluator for array
@@ -333,7 +333,7 @@ namespace TiledArray {
 
       /// \return The tile operation
       op_type make_tile_op() const {
-        const unsigned int rank = trange_.tile_range().rank();
+        const unsigned int rank = trange_.tiles_range().rank();
 
         // Construct and allocate memory for the shift range
         std::vector<long> range_shift;
@@ -358,7 +358,7 @@ namespace TiledArray {
       /// \param perm The permutation to be applied to tiles
       /// \return The tile operation
       op_type make_tile_op(const Permutation& perm) const {
-        const unsigned int rank = trange_.tile_range().rank();
+        const unsigned int rank = trange_.tiles_range().rank();
 
         // Construct and allocate memory for the shift range
         std::vector<long> range_shift(rank, 0l);
@@ -464,7 +464,7 @@ namespace TiledArray {
 
       /// \return The tile operation
       op_type make_tile_op() const {
-        const unsigned int rank = trange_.tile_range().rank();
+        const unsigned int rank = trange_.tiles_range().rank();
 
         // Construct and allocate memory for the shift range
         std::vector<long> range_shift;
@@ -489,7 +489,7 @@ namespace TiledArray {
       /// \param perm The permutation to be applied to tiles
       /// \return The tile operation
       op_type make_tile_op(const Permutation& perm) const {
-        const unsigned int rank = trange_.tile_range().rank();
+        const unsigned int rank = trange_.tiles_range().rank();
 
         // Construct and allocate memory for the shift range
         std::vector<long> range_shift(rank, 0l);

--- a/src/TiledArray/expressions/blk_tsr_expr.h
+++ b/src/TiledArray/expressions/blk_tsr_expr.h
@@ -116,14 +116,14 @@ namespace TiledArray {
       std::vector<std::size_t> upper_bound_; ///< Upper bound of the tile block
 
       void check_valid() const {
-        const unsigned int rank = array_.trange().tile_range().rank();
+        const unsigned int rank = array_.trange().tiles_range().rank();
         // Check the dimension of the lower block bound
         if(TiledArray::detail::size(lower_bound_) != rank) {
           if(World::get_default().rank() == 0) {
             TA_USER_ERROR_MESSAGE( \
                 "The size lower bound of the block is not equal to rank of " \
                 "the array: " \
-                << "\n    array rank  = " << array_.trange().tile_range().rank() \
+                << "\n    array rank  = " << array_.trange().tiles_range().rank() \
                 << "\n    lower bound = " << lower_bound_ );
 
             TA_EXCEPTION("The size lower bound of the block is not equal to " \
@@ -147,17 +147,17 @@ namespace TiledArray {
 
         const bool lower_bound_check =
             std::equal(std::begin(lower_bound_), std::end(lower_bound_),
-                    array_.trange().tile_range().lobound_data(),
+                    array_.trange().tiles_range().lobound_data(),
                     [] (std::size_t l, std::size_t r) { return l >= r; });
         const bool upper_bound_check =
             std::equal(std::begin(upper_bound_), std::end(upper_bound_),
-                    array_.trange().tile_range().upbound_data(),
+                    array_.trange().tiles_range().upbound_data(),
                     [] (std::size_t l, std::size_t r) { return l <= r; });
         if(! (lower_bound_check && upper_bound_check)) {
           if(World::get_default().rank() == 0) {
             TA_USER_ERROR_MESSAGE( \
                 "The block range is not a sub-block of the array range: " \
-                << "\n    array range = " << array_.trange().tile_range() \
+                << "\n    array range = " << array_.trange().tiles_range() \
                 << "\n    block range = [ " << lower_bound_  << " , " << upper_bound_ << " )");
           }
 

--- a/src/TiledArray/expressions/blk_tsr_expr.h
+++ b/src/TiledArray/expressions/blk_tsr_expr.h
@@ -116,14 +116,14 @@ namespace TiledArray {
       std::vector<std::size_t> upper_bound_; ///< Upper bound of the tile block
 
       void check_valid() const {
-        const unsigned int rank = array_.trange().tiles().rank();
+        const unsigned int rank = array_.trange().tile_range().rank();
         // Check the dimension of the lower block bound
         if(TiledArray::detail::size(lower_bound_) != rank) {
           if(World::get_default().rank() == 0) {
             TA_USER_ERROR_MESSAGE( \
                 "The size lower bound of the block is not equal to rank of " \
                 "the array: " \
-                << "\n    array rank  = " << array_.trange().tiles().rank() \
+                << "\n    array rank  = " << array_.trange().tile_range().rank() \
                 << "\n    lower bound = " << lower_bound_ );
 
             TA_EXCEPTION("The size lower bound of the block is not equal to " \
@@ -147,17 +147,17 @@ namespace TiledArray {
 
         const bool lower_bound_check =
             std::equal(std::begin(lower_bound_), std::end(lower_bound_),
-                    array_.trange().tiles().lobound_data(),
+                    array_.trange().tile_range().lobound_data(),
                     [] (std::size_t l, std::size_t r) { return l >= r; });
         const bool upper_bound_check =
             std::equal(std::begin(upper_bound_), std::end(upper_bound_),
-                    array_.trange().tiles().upbound_data(),
+                    array_.trange().tile_range().upbound_data(),
                     [] (std::size_t l, std::size_t r) { return l <= r; });
         if(! (lower_bound_check && upper_bound_check)) {
           if(World::get_default().rank() == 0) {
             TA_USER_ERROR_MESSAGE( \
                 "The block range is not a sub-block of the array range: " \
-                << "\n    array range = " << array_.trange().tiles() \
+                << "\n    array range = " << array_.trange().tile_range() \
                 << "\n    block range = [ " << lower_bound_  << " , " << upper_bound_ << " )");
           }
 

--- a/src/TiledArray/expressions/cont_engine.h
+++ b/src/TiledArray/expressions/cont_engine.h
@@ -395,13 +395,13 @@ namespace TiledArray {
 
         // Get pointers to the argument sizes
         const size_type* restrict const left_tiles_size =
-            left_.trange().tile_range().extent_data();
+            left_.trange().tiles_range().extent_data();
         const size_type* restrict const left_element_size =
-            left_.trange().element_range().extent_data();
+            left_.trange().elements_range().extent_data();
         const size_type* restrict const right_tiles_size =
-            right_.trange().tile_range().extent_data();
+            right_.trange().tiles_range().extent_data();
         const size_type* restrict const right_element_size =
-            right_.trange().element_range().extent_data();
+            right_.trange().elements_range().extent_data();
 
         // Compute the fused sizes of the contraction
         size_type M = 1ul, m = 1ul, N = 1ul, n = 1ul;
@@ -457,9 +457,9 @@ namespace TiledArray {
 
         // Get left and right tile extents.
         const auto* restrict const left_extent =
-            left_.trange().tile_range().extent_data();
+            left_.trange().tiles_range().extent_data();
         const auto* restrict const right_extent =
-            right_.trange().tile_range().extent_data();
+            right_.trange().tiles_range().extent_data();
 
         // Check that the contracted dimensions are coformal (equal).
         for(unsigned int l = left_outer_rank, r = 0ul; l < left_rank; ++l, ++r) {

--- a/src/TiledArray/expressions/cont_engine.h
+++ b/src/TiledArray/expressions/cont_engine.h
@@ -395,13 +395,13 @@ namespace TiledArray {
 
         // Get pointers to the argument sizes
         const size_type* restrict const left_tiles_size =
-            left_.trange().tiles().extent_data();
+            left_.trange().tile_range().extent_data();
         const size_type* restrict const left_element_size =
-            left_.trange().elements().extent_data();
+            left_.trange().element_range().extent_data();
         const size_type* restrict const right_tiles_size =
-            right_.trange().tiles().extent_data();
+            right_.trange().tile_range().extent_data();
         const size_type* restrict const right_element_size =
-            right_.trange().elements().extent_data();
+            right_.trange().element_range().extent_data();
 
         // Compute the fused sizes of the contraction
         size_type M = 1ul, m = 1ul, N = 1ul, n = 1ul;
@@ -457,9 +457,9 @@ namespace TiledArray {
 
         // Get left and right tile extents.
         const auto* restrict const left_extent =
-            left_.trange().tiles().extent_data();
+            left_.trange().tile_range().extent_data();
         const auto* restrict const right_extent =
-            right_.trange().tiles().extent_data();
+            right_.trange().tile_range().extent_data();
 
         // Check that the contracted dimensions are coformal (equal).
         for(unsigned int l = left_outer_rank, r = 0ul; l < left_rank; ++l, ++r) {

--- a/src/TiledArray/expressions/expr.h
+++ b/src/TiledArray/expressions/expr.h
@@ -120,7 +120,7 @@ namespace TiledArray {
       template <typename A, typename I, typename T>
       typename std::enable_if<is_lazy_tile<T>::value>::type
       set_tile(A& array, const I index, const Future<T>& tile) const {
-        array.set(index, array.get_world().taskq.add(
+        array.set(index, array.world().taskq.add(
               & Expr_::template eval_tile<typename A::value_type, T>, tile));
       }
 
@@ -154,7 +154,7 @@ namespace TiledArray {
       void set_tile(A& array, const I index, const Future<T>& tile,
           const std::shared_ptr<Op>& op) const
       {
-        array.set(index, array.get_world().taskq.add(
+        array.set(index, array.world().taskq.add(
               & Expr_::template eval_tile<typename A::value_type, T, Op>, tile, op));
       }
 
@@ -189,13 +189,13 @@ namespace TiledArray {
 
         // Get the target world.
         World& world = (tsr.array().is_initialized() ?
-            tsr.array().get_world() :
+            tsr.array().world() :
             World::get_default());
 
         // Get the output process map.
         std::shared_ptr<typename TsrExpr<A, Alias>::array_type::pmap_interface> pmap;
         if(tsr.array().is_initialized())
-          pmap = tsr.array().get_pmap();
+          pmap = tsr.array().pmap();
 
         // Get result variable list.
         VariableList target_vars(tsr.vars());
@@ -209,7 +209,7 @@ namespace TiledArray {
         dist_eval.eval();
 
         // Create the result array
-        A result(dist_eval.get_world(), dist_eval.trange(),
+        A result(dist_eval.world(), dist_eval.trange(),
             dist_eval.shape(), dist_eval.pmap());
 
         // Move the data from dist_eval into the result array. There is no
@@ -259,7 +259,7 @@ namespace TiledArray {
 #endif // NDEBUG
 
         // Get the target world.
-        World& world = tsr.array().get_world();
+        World& world = tsr.array().world();
 
         // Get the output process map.
         std::shared_ptr<typename BlkTsrExpr<A, Alias>::array_type::pmap_interface> pmap;
@@ -277,8 +277,8 @@ namespace TiledArray {
 
         // Create the result array
         A result(world, tsr.array().trange(),
-            tsr.array().get_shape().update_block(tsr.lower_bound(), tsr.upper_bound(),
-            dist_eval.shape()), tsr.array().get_pmap());
+            tsr.array().shape().update_block(tsr.lower_bound(), tsr.upper_bound(),
+            dist_eval.shape()), tsr.array().pmap());
 
         // NOTE: The tiles from the original array and the sub-block are copied
         // in two separate steps because the two tensors have different data
@@ -287,11 +287,11 @@ namespace TiledArray {
         // Copy tiles from the original array to the result array that are not
         // included in the sub-block assignment. There is no communication in
         // this step.
-        const BlockRange blk_range(tsr.array().trange().tiles(),
+        const BlockRange blk_range(tsr.array().trange().tile_range(),
             tsr.lower_bound(), tsr.upper_bound());
-        for(const auto index : *tsr.array().get_pmap()) {
+        for(const auto index : *tsr.array().pmap()) {
           if(! tsr.array().is_zero(index)) {
-            if(! blk_range.includes(tsr.array().trange().tiles().idx(index)))
+            if(! blk_range.includes(tsr.array().trange().tile_range().idx(index)))
               result.set(index, tsr.array().find(index));
           }
         }
@@ -301,7 +301,7 @@ namespace TiledArray {
         // sub-block distribution to the array distribution.
         {
           const std::vector<long> shift =
-              tsr.array().trange().make_tile_range(tsr.lower_bound()).lobound();
+              tsr.array().trange().tile(tsr.lower_bound()).lobound();
 
           std::shared_ptr<op_type> shift_op =
               std::make_shared<op_type>(shift_op_type(shift));

--- a/src/TiledArray/expressions/expr.h
+++ b/src/TiledArray/expressions/expr.h
@@ -287,11 +287,11 @@ namespace TiledArray {
         // Copy tiles from the original array to the result array that are not
         // included in the sub-block assignment. There is no communication in
         // this step.
-        const BlockRange blk_range(tsr.array().trange().tile_range(),
+        const BlockRange blk_range(tsr.array().trange().tiles_range(),
             tsr.lower_bound(), tsr.upper_bound());
         for(const auto index : *tsr.array().pmap()) {
           if(! tsr.array().is_zero(index)) {
-            if(! blk_range.includes(tsr.array().trange().tile_range().idx(index)))
+            if(! blk_range.includes(tsr.array().trange().tiles_range().idx(index)))
               result.set(index, tsr.array().find(index));
           }
         }
@@ -301,7 +301,7 @@ namespace TiledArray {
         // sub-block distribution to the array distribution.
         {
           const std::vector<long> shift =
-              tsr.array().trange().tile(tsr.lower_bound()).lobound();
+              tsr.array().trange().make_tile_range(tsr.lower_bound()).lobound();
 
           std::shared_ptr<op_type> shift_op =
               std::make_shared<op_type>(shift_op_type(shift));

--- a/src/TiledArray/expressions/expr_engine.h
+++ b/src/TiledArray/expressions/expr_engine.h
@@ -105,7 +105,7 @@ namespace TiledArray {
           // If process map is not valid, use the process map constructed by the
           // expression engine.
           if((typename pmap_interface::size_type(world.size()) != pmap->procs()) ||
-              (trange_.tiles().volume() != pmap->size()))
+              (trange_.tile_range().volume() != pmap->size()))
             pmap.reset();
         }
 
@@ -150,7 +150,7 @@ namespace TiledArray {
         TA_ASSERT(world);
         TA_ASSERT(pmap);
         TA_ASSERT(pmap->procs() == typename pmap_interface::size_type(world->size()));
-        TA_ASSERT(pmap->size() == trange_.tiles().volume());
+        TA_ASSERT(pmap->size() == trange_.tile_range().volume());
 
         world_ = world;
         pmap_ = pmap;

--- a/src/TiledArray/expressions/expr_engine.h
+++ b/src/TiledArray/expressions/expr_engine.h
@@ -105,7 +105,7 @@ namespace TiledArray {
           // If process map is not valid, use the process map constructed by the
           // expression engine.
           if((typename pmap_interface::size_type(world.size()) != pmap->procs()) ||
-              (trange_.tile_range().volume() != pmap->size()))
+              (trange_.tiles_range().volume() != pmap->size()))
             pmap.reset();
         }
 
@@ -150,7 +150,7 @@ namespace TiledArray {
         TA_ASSERT(world);
         TA_ASSERT(pmap);
         TA_ASSERT(pmap->procs() == typename pmap_interface::size_type(world->size()));
-        TA_ASSERT(pmap->size() == trange_.tile_range().volume());
+        TA_ASSERT(pmap->size() == trange_.tiles_range().volume());
 
         world_ = world;
         pmap_ = pmap;

--- a/src/TiledArray/expressions/leaf_engine.h
+++ b/src/TiledArray/expressions/leaf_engine.h
@@ -122,7 +122,7 @@ namespace TiledArray {
       void init_distribution(World* world,
           const std::shared_ptr<pmap_interface>& pmap)
       {
-        ExprEngine_::init_distribution(world, (pmap ? pmap : array_.get_pmap()));
+        ExprEngine_::init_distribution(world, (pmap ? pmap : array_.pmap()));
       }
 
 
@@ -142,14 +142,14 @@ namespace TiledArray {
       /// Non-permuting shape factory function
 
       /// \return The result shape
-      shape_type make_shape() { return array_.get_shape(); }
+      shape_type make_shape() { return array_.shape(); }
 
       /// Permuting shape factory function
 
       /// \param perm The permutation to be applied to the array
       /// \return The result shape
       shape_type
-      make_shape(const Permutation& perm) { return array_.get_shape().perm(perm); }
+      make_shape(const Permutation& perm) { return array_.shape().perm(perm); }
 
 
       /// Construct the distributed evaluator for array

--- a/src/TiledArray/expressions/scal_tsr_engine.h
+++ b/src/TiledArray/expressions/scal_tsr_engine.h
@@ -107,14 +107,14 @@ namespace TiledArray {
       /// Non-permuting shape factory function
 
       /// \return The result shape
-      shape_type make_shape() { return LeafEngine_::array_.get_shape().scale(factor_); }
+      shape_type make_shape() { return LeafEngine_::array_.shape().scale(factor_); }
 
       /// Permuting shape factory function
 
       /// \param perm The permutation to be applied to the array
       /// \return The result shape
       shape_type make_shape(const Permutation& perm) {
-        return LeafEngine_::array_.get_shape().scale(factor_, perm);
+        return LeafEngine_::array_.shape().scale(factor_, perm);
       }
 
       /// Non-permuting tile operation factory function

--- a/src/TiledArray/reduce_task.h
+++ b/src/TiledArray/reduce_task.h
@@ -443,7 +443,7 @@ namespace TiledArray {
         /// World accessor
 
         /// \return The world that owns this task.
-        World& get_world() const { return world_; }
+        World& world() const { return world_; }
 
       }; // class ReduceTaskImpl
 
@@ -534,7 +534,7 @@ namespace TiledArray {
         Future<result_type> result = pimpl_->result();
 
         pimpl_->dec();
-        World& world = pimpl_->get_world();
+        World& world = pimpl_->world();
         world.taskq.add(pimpl_);
 
         pimpl_ = nullptr;

--- a/src/TiledArray/replicator.h
+++ b/src/TiledArray/replicator.h
@@ -152,17 +152,17 @@ namespace TiledArray {
     public:
 
       Replicator(const A& source, const A destination) :
-        wobj_type(source.get_world()), madness::Spinlock(),
+        wobj_type(source.world()), madness::Spinlock(),
         destination_(destination), indices_(), data_(), sent_(),
-        world_(source.get_world()), callbacks_(), probe_(false)
+        world_(source.world()), callbacks_(), probe_(false)
       {
         sent_ = 0;
 
         // Generate a list of local tiles from other.
-        typename A::pmap_interface::const_iterator end = source.get_pmap()->end();
-        typename A::pmap_interface::const_iterator it = source.get_pmap()->begin();
-        indices_.reserve(source.get_pmap()->local_size());
-        data_.reserve(source.get_pmap()->local_size());
+        typename A::pmap_interface::const_iterator end = source.pmap()->end();
+        typename A::pmap_interface::const_iterator it = source.pmap()->begin();
+        indices_.reserve(source.pmap()->local_size());
+        data_.reserve(source.pmap()->local_size());
         if(source.is_dense()) {
           // When dense, all tiles are present
           for(; it != end; ++it) {

--- a/src/TiledArray/sparse_shape.h
+++ b/src/TiledArray/sparse_shape.h
@@ -159,13 +159,13 @@ namespace TiledArray {
     static std::shared_ptr<vector_type>
     initialize_size_vectors(const TiledRange& trange) {
       // Allocate memory for size vectors
-      const unsigned int dim = trange.tiles().rank();
+      const unsigned int dim = trange.tile_range().rank();
       std::shared_ptr<vector_type> size_vectors(new vector_type[dim],
           std::default_delete<vector_type[]>());
 
       // Initialize the size vectors
       for(unsigned int i = 0ul; i != dim; ++i) {
-        const size_type n = trange.data()[i].tiles().second - trange.data()[i].tiles().first;
+        const size_type n = trange.data()[i].tile_range().second - trange.data()[i].tile_range().first;
 
         size_vectors.get()[i] = vector_type(n, & (* trange.data()[i].begin()),
             [] (const TiledRange1::range_type& tile)
@@ -216,7 +216,7 @@ namespace TiledArray {
       zero_tile_count_(0ul)
     {
       TA_ASSERT(! tile_norms_.empty());
-      TA_ASSERT(tile_norms_.range() == trange.tiles());
+      TA_ASSERT(tile_norms_.range() == trange.tile_range());
 
       normalize();
     }
@@ -236,7 +236,7 @@ namespace TiledArray {
       zero_tile_count_(0ul)
     {
       TA_ASSERT(! tile_norms_.empty());
-      TA_ASSERT(tile_norms_.range() == trange.tiles());
+      TA_ASSERT(tile_norms_.range() == trange.tile_range());
 
       // Do global initialization of norm data
       world.gop.sum(tile_norms_.data(), tile_norms_.size());

--- a/src/TiledArray/sparse_shape.h
+++ b/src/TiledArray/sparse_shape.h
@@ -159,13 +159,13 @@ namespace TiledArray {
     static std::shared_ptr<vector_type>
     initialize_size_vectors(const TiledRange& trange) {
       // Allocate memory for size vectors
-      const unsigned int dim = trange.tile_range().rank();
+      const unsigned int dim = trange.tiles_range().rank();
       std::shared_ptr<vector_type> size_vectors(new vector_type[dim],
           std::default_delete<vector_type[]>());
 
       // Initialize the size vectors
       for(unsigned int i = 0ul; i != dim; ++i) {
-        const size_type n = trange.data()[i].tile_range().second - trange.data()[i].tile_range().first;
+        const size_type n = trange.data()[i].tiles_range().second - trange.data()[i].tiles_range().first;
 
         size_vectors.get()[i] = vector_type(n, & (* trange.data()[i].begin()),
             [] (const TiledRange1::range_type& tile)
@@ -216,7 +216,7 @@ namespace TiledArray {
       zero_tile_count_(0ul)
     {
       TA_ASSERT(! tile_norms_.empty());
-      TA_ASSERT(tile_norms_.range() == trange.tile_range());
+      TA_ASSERT(tile_norms_.range() == trange.tiles_range());
 
       normalize();
     }
@@ -236,7 +236,7 @@ namespace TiledArray {
       zero_tile_count_(0ul)
     {
       TA_ASSERT(! tile_norms_.empty());
-      TA_ASSERT(tile_norms_.range() == trange.tile_range());
+      TA_ASSERT(tile_norms_.range() == trange.tiles_range());
 
       // Do global initialization of norm data
       world.gop.sum(tile_norms_.data(), tile_norms_.size());

--- a/src/TiledArray/tensor_impl.h
+++ b/src/TiledArray/tensor_impl.h
@@ -68,10 +68,10 @@ namespace TiledArray {
       {
         // Validate input data.
         TA_ASSERT(pmap_);
-        TA_ASSERT(pmap_->size() == trange_.tiles().volume());
+        TA_ASSERT(pmap_->size() == trange_.tile_range().volume());
         TA_ASSERT(pmap_->rank() == typename pmap_interface::size_type(world_.rank()));
         TA_ASSERT(pmap_->procs() == typename pmap_interface::size_type(world_.size()));
-        TA_ASSERT(shape_.validate(trange_.tiles()));
+        TA_ASSERT(shape_.validate(trange_.tile_range()));
       }
 
       /// Virtual destructor
@@ -87,13 +87,13 @@ namespace TiledArray {
 
       /// \return The size array of the tensor tiles
       /// \throw nothing
-      const range_type& range() const { return trange_.tiles(); }
+      const range_type& range() const { return trange_.tile_range(); }
 
       /// Tensor tile volume accessor
 
       /// \return The number of tiles in the tensor
       /// \throw nothing
-      size_type size() const { return trange_.tiles().volume(); }
+      size_type size() const { return trange_.tile_range().volume(); }
 
       /// Local element count
 
@@ -113,8 +113,8 @@ namespace TiledArray {
       /// \throw TiledArray::Exception When the process map has not been set
       template <typename Index>
       ProcessID owner(const Index& i) const {
-        TA_ASSERT(trange_.tiles().includes(i));
-        return pmap_->owner(trange_.tiles().ordinal(i));
+        TA_ASSERT(trange_.tile_range().includes(i));
+        return pmap_->owner(trange_.tile_range().ordinal(i));
       }
 
       /// Query for a locally owned tile
@@ -125,8 +125,8 @@ namespace TiledArray {
       /// \throw TiledArray::Exception When the process map has not been set
       template <typename Index>
       bool is_local(const Index& i) const {
-        TA_ASSERT(trange_.tiles().includes(i));
-        return pmap_->is_local(trange_.tiles().ordinal(i));
+        TA_ASSERT(trange_.tile_range().includes(i));
+        return pmap_->is_local(trange_.tile_range().ordinal(i));
       }
 
       /// Query for a zero tile
@@ -138,8 +138,8 @@ namespace TiledArray {
       /// range
       template <typename Index>
       bool is_zero(const Index& i) const {
-        TA_ASSERT(trange_.tiles().includes(i));
-        return shape_.is_zero(trange_.tiles().ordinal(i));
+        TA_ASSERT(trange_.tile_range().includes(i));
+        return shape_.is_zero(trange_.tile_range().ordinal(i));
       }
 
       /// Query the density of the tensor

--- a/src/TiledArray/tensor_impl.h
+++ b/src/TiledArray/tensor_impl.h
@@ -68,10 +68,10 @@ namespace TiledArray {
       {
         // Validate input data.
         TA_ASSERT(pmap_);
-        TA_ASSERT(pmap_->size() == trange_.tile_range().volume());
+        TA_ASSERT(pmap_->size() == trange_.tiles_range().volume());
         TA_ASSERT(pmap_->rank() == typename pmap_interface::size_type(world_.rank()));
         TA_ASSERT(pmap_->procs() == typename pmap_interface::size_type(world_.size()));
-        TA_ASSERT(shape_.validate(trange_.tile_range()));
+        TA_ASSERT(shape_.validate(trange_.tiles_range()));
       }
 
       /// Virtual destructor
@@ -87,13 +87,13 @@ namespace TiledArray {
 
       /// \return The size array of the tensor tiles
       /// \throw nothing
-      const range_type& range() const { return trange_.tile_range(); }
+      const range_type& range() const { return trange_.tiles_range(); }
 
       /// Tensor tile volume accessor
 
       /// \return The number of tiles in the tensor
       /// \throw nothing
-      size_type size() const { return trange_.tile_range().volume(); }
+      size_type size() const { return trange_.tiles_range().volume(); }
 
       /// Local element count
 
@@ -113,8 +113,8 @@ namespace TiledArray {
       /// \throw TiledArray::Exception When the process map has not been set
       template <typename Index>
       ProcessID owner(const Index& i) const {
-        TA_ASSERT(trange_.tile_range().includes(i));
-        return pmap_->owner(trange_.tile_range().ordinal(i));
+        TA_ASSERT(trange_.tiles_range().includes(i));
+        return pmap_->owner(trange_.tiles_range().ordinal(i));
       }
 
       /// Query for a locally owned tile
@@ -125,8 +125,8 @@ namespace TiledArray {
       /// \throw TiledArray::Exception When the process map has not been set
       template <typename Index>
       bool is_local(const Index& i) const {
-        TA_ASSERT(trange_.tile_range().includes(i));
-        return pmap_->is_local(trange_.tile_range().ordinal(i));
+        TA_ASSERT(trange_.tiles_range().includes(i));
+        return pmap_->is_local(trange_.tiles_range().ordinal(i));
       }
 
       /// Query for a zero tile
@@ -138,8 +138,8 @@ namespace TiledArray {
       /// range
       template <typename Index>
       bool is_zero(const Index& i) const {
-        TA_ASSERT(trange_.tile_range().includes(i));
-        return shape_.is_zero(trange_.tile_range().ordinal(i));
+        TA_ASSERT(trange_.tiles_range().includes(i));
+        return shape_.is_zero(trange_.tiles_range().ordinal(i));
       }
 
       /// Query the density of the tensor

--- a/src/TiledArray/tiled_range.h
+++ b/src/TiledArray/tiled_range.h
@@ -48,11 +48,11 @@ namespace TiledArray {
 
       // Find the start and finish of the over all tiles and element ranges.
       for(unsigned int i = 0; i < rank; ++i) {
-        start.push_back(ranges_[i].tiles().first);
-        finish.push_back(ranges_[i].tiles().second);
+        start.push_back(ranges_[i].tile_range().first);
+        finish.push_back(ranges_[i].tile_range().second);
 
-        start_element.push_back(ranges_[i].elements().first);
-        finish_element.push_back(ranges_[i].elements().second);
+        start_element.push_back(ranges_[i].element_range().first);
+        finish_element.push_back(ranges_[i].element_range().second);
       }
       range_type(start, finish).swap(range_);
       tile_range_type(start_element, finish_element).swap(element_range_);
@@ -147,31 +147,21 @@ namespace TiledArray {
       return element_range();
     }
 
-    /// Construct a range for the given ordinal index.
-
-    /// \param i The ordinal index of the tile range to be constructed
-    /// \throw std::runtime_error Throws if i is not included in the range
-    /// \return The constructed range object
     /// \deprecated use TiledRange::tile() instead
     DEPRECATED  tile_range_type make_tile_range(const size_type& i) const {
       return tile(i);
     }
 
-    /// Construct a range for the given ordinal index.
+    /// Construct a range for the tile indexed by the given ordinal index.
 
     /// \param i The ordinal index of the tile range to be constructed
     /// \throw std::runtime_error Throws if i is not included in the range
     /// \return The constructed range object
     tile_range_type tile(const size_type& i) const {
-      TA_ASSERT(range_.includes(i));
-      return make_tile_range(tiles().idx(i));
+      TA_ASSERT(tile_range().includes(i));
+      return tile(tile_range().idx(i));
     }
 
-    /// Construct a range for the given tile index.
-
-    /// \param index The index of the tile range to be constructed
-    /// \throw std::runtime_error Throws if i is not included in the range
-    /// \return The constructed range object
     /// \deprecated use TiledRange::tile() instead
     template <typename Index>
     DEPRECATED typename std::enable_if<!std::is_integral<Index>::value,
@@ -180,7 +170,7 @@ namespace TiledArray {
       return tile(index);
     }
 
-    /// Construct a range for the given tile index.
+    /// Construct a range for the tile indexed by the given index.
 
     /// \param index The index of the tile range to be constructed
     /// \throw std::runtime_error Throws if i is not included in the range
@@ -205,7 +195,7 @@ namespace TiledArray {
       return tile_range_type(lower, upper);
     }
 
-    /// Construct a range for the given tile index.
+    /// Construct a range for the tile indexed by the given index.
 
     /// \param index The tile index, given as a \c std::initializer_list
     /// \throw std::runtime_error Throws if i is not included in the range
@@ -272,7 +262,7 @@ namespace TiledArray {
   /// being used by other objects will be permuted. The owner of those
   /// objects are
   inline TiledRange operator *(const Permutation& p, const TiledRange& r) {
-    TA_ASSERT(r.tiles().rank() == p.dim());
+    TA_ASSERT(r.tile_range().rank() == p.dim());
     TiledRange::Ranges data = p * r.data();
 
     return TiledRange(data.begin(), data.end());
@@ -283,8 +273,8 @@ namespace TiledArray {
 
   /// Returns true when all tile and element ranges are the same.
   inline bool operator ==(const TiledRange& r1, const TiledRange& r2) {
-    return (r1.tiles().rank() == r2.tiles().rank()) &&
-        (r1.tiles() == r2.tiles()) && (r1.elements() == r2.elements()) &&
+    return (r1.tile_range().rank() == r2.tile_range().rank()) &&
+        (r1.tile_range() == r2.tile_range()) && (r1.element_range() == r2.element_range()) &&
         std::equal(r1.data().begin(), r1.data().end(), r2.data().begin());
   }
 
@@ -293,8 +283,8 @@ namespace TiledArray {
   }
 
   inline std::ostream& operator<<(std::ostream& out, const TiledRange& rng) {
-    out << "(" << " tiles = " << rng.tiles()
-        << ", elements = " << rng.elements() << " )";
+    out << "(" << " tiles = " << rng.tile_range()
+        << ", elements = " << rng.element_range() << " )";
     return out;
   }
 

--- a/src/TiledArray/tiled_range.h
+++ b/src/TiledArray/tiled_range.h
@@ -48,54 +48,54 @@ namespace TiledArray {
 
       // Find the start and finish of the over all tiles and element ranges.
       for(unsigned int i = 0; i < rank; ++i) {
-        start.push_back(ranges_[i].tile_range().first);
-        finish.push_back(ranges_[i].tile_range().second);
+        start.push_back(ranges_[i].tiles_range().first);
+        finish.push_back(ranges_[i].tiles_range().second);
 
-        start_element.push_back(ranges_[i].element_range().first);
-        finish_element.push_back(ranges_[i].element_range().second);
+        start_element.push_back(ranges_[i].elements_range().first);
+        finish_element.push_back(ranges_[i].elements_range().second);
       }
       range_type(start, finish).swap(range_);
-      tile_range_type(start_element, finish_element).swap(element_range_);
+      tiles_range_type(start_element, finish_element).swap(elements_range_);
     }
 
   public:
     // typedefs
     typedef TiledRange TiledRange_;
     typedef Range range_type;
-    typedef Range tile_range_type;
+    typedef Range tiles_range_type;
     typedef std::size_t size_type;
     typedef range_type::index index;
     typedef range_type::size_array size_array;
     typedef std::vector<TiledRange1> Ranges;
 
     /// Default constructor
-    TiledRange() : range_(), element_range_(), ranges_() { }
+    TiledRange() : range_(), elements_range_(), ranges_() { }
 
     /// Constructed with a set of ranges pointed to by [ first, last ).
     template <typename InIter>
     TiledRange(InIter first, InIter last) :
-      range_(), element_range_(), ranges_(first, last)
+      range_(), elements_range_(), ranges_(first, last)
     {
       init();
     }
 
     /// Constructed with a set of ranges pointed to by [ first, last ).
     TiledRange(const std::initializer_list<std::initializer_list<size_type> >& list) :
-      range_(), element_range_(), ranges_(list.begin(), list.end())
+      range_(), elements_range_(), ranges_(list.begin(), list.end())
     {
       init();
     }
 
     /// Constructed with an initializer_list of TiledRange1's
     TiledRange(const std::initializer_list<TiledRange1>& list) :
-      range_(), element_range_(), ranges_(list.begin(), list.end())
+      range_(), elements_range_(), ranges_(list.begin(), list.end())
     {
       init();
     }
 
     /// Copy constructor
     TiledRange(const TiledRange_& other) :
-        range_(other.range_), element_range_(other.element_range_), ranges_(other.ranges_)
+        range_(other.range_), elements_range_(other.elements_range_), ranges_(other.ranges_)
     { }
 
     /// TiledRange assignment operator
@@ -120,36 +120,42 @@ namespace TiledArray {
     /// Access the tile range
 
     /// \return A const reference to the tile range object
-    const range_type& tile_range() const {
+    const range_type& tiles_range() const {
       return range_;
     }
 
     /// Access the tile range
 
     /// \return A const reference to the tile range object
-    /// \deprecated use TiledRange::tile_range() instead
+    /// \deprecated use TiledRange::tiles_range() instead
     DEPRECATED const range_type& tiles() const {
-      return tile_range();
+      return tiles_range();
     }
 
     /// Access the element range
 
     /// \return A const reference to the element range object
-    const tile_range_type& element_range() const {
-      return element_range_;
+    const tiles_range_type& elements_range() const {
+      return elements_range_;
     }
 
     /// Access the element range
 
     /// \return A const reference to the element range object
-    /// \deprecated use TiledRange::element_range() instead
-    DEPRECATED const tile_range_type& elements() const {
-      return element_range();
+    /// \deprecated use TiledRange::elements_range() instead
+    DEPRECATED const tiles_range_type& elements() const {
+      return elements_range();
     }
 
-    /// \deprecated use TiledRange::tile() instead
-    DEPRECATED  tile_range_type make_tile_range(const size_type& i) const {
-      return tile(i);
+    /// Constructs a range for the tile indexed by the given ordinal index.
+
+    /// \param i The ordinal index of the tile range to be constructed
+    /// \throw std::runtime_error Throws if i is not included in the range
+    /// \return The constructed range object
+    /// \note alias to TiledRange::make_tile_range() , introduced for consitency
+    ///       with TiledRange1::tile()
+    tiles_range_type tile(const size_type& i) const {
+      return make_tile_range(i);
     }
 
     /// Construct a range for the tile indexed by the given ordinal index.
@@ -157,17 +163,23 @@ namespace TiledArray {
     /// \param i The ordinal index of the tile range to be constructed
     /// \throw std::runtime_error Throws if i is not included in the range
     /// \return The constructed range object
-    tile_range_type tile(const size_type& i) const {
-      TA_ASSERT(tile_range().includes(i));
-      return tile(tile_range().idx(i));
+    tiles_range_type make_tile_range(const size_type& i) const {
+      TA_ASSERT(tiles_range().includes(i));
+      return make_tile_range(tiles_range().idx(i));
     }
 
-    /// \deprecated use TiledRange::tile() instead
+    /// Construct a range for the tile indexed by the given index.
+
+    /// \param index The index of the tile range to be constructed
+    /// \throw std::runtime_error Throws if i is not included in the range
+    /// \return The constructed range object
+    /// \note alias to TiledRange::make_tile_range() , introduced for consitency
+    ///       with TiledRange1::tile()
     template <typename Index>
-    DEPRECATED typename std::enable_if<!std::is_integral<Index>::value,
-                                       tile_range_type>::type
-    make_tile_range(const Index& index) const {
-      return tile(index);
+    typename std::enable_if<!std::is_integral<Index>::value,
+                            tiles_range_type>::type
+    tile(const Index& index) const {
+      return make_tile_range(index);
     }
 
     /// Construct a range for the tile indexed by the given index.
@@ -176,13 +188,13 @@ namespace TiledArray {
     /// \throw std::runtime_error Throws if i is not included in the range
     /// \return The constructed range object
     template <typename Index>
-    typename std::enable_if<! std::is_integral<Index>::value, tile_range_type>::type
-    tile(const Index& index) const {
+    typename std::enable_if<! std::is_integral<Index>::value, tiles_range_type>::type
+    make_tile_range(const Index& index) const {
       const auto rank = range_.rank();
       TA_ASSERT(index.size() == rank);
       TA_ASSERT(range_.includes(index));
-      typename tile_range_type::index lower;
-      typename tile_range_type::index upper;
+      typename tiles_range_type::index lower;
+      typename tiles_range_type::index upper;
       lower.reserve(rank);
       upper.reserve(rank);
       unsigned d = 0;
@@ -192,7 +204,20 @@ namespace TiledArray {
         ++d;
       }
 
-      return tile_range_type(lower, upper);
+      return tiles_range_type(lower, upper);
+    }
+
+    /// Construct a range for the tile indexed by the given index.
+
+    /// \param index The tile index, given as a \c std::initializer_list
+    /// \throw std::runtime_error Throws if i is not included in the range
+    /// \return The constructed range object
+    /// \note alias to TiledRange::make_tile_range() , introduced for consitency
+    ///       with TiledRange1::tile()
+    template <typename Integer>
+    tiles_range_type
+    tile(const std::initializer_list<Integer>& index) const {
+      return make_tile_range(index);
     }
 
     /// Construct a range for the tile indexed by the given index.
@@ -201,9 +226,9 @@ namespace TiledArray {
     /// \throw std::runtime_error Throws if i is not included in the range
     /// \return The constructed range object
     template <typename Integer>
-    tile_range_type
-    tile(const std::initializer_list<Integer>& index) const {
-      return tile<std::initializer_list<Integer>>(index);
+    tiles_range_type
+    make_tile_range(const std::initializer_list<Integer>& index) const {
+      return make_tile_range<std::initializer_list<Integer>>(index);
     }
 
     /// Convert an element index to a tile index
@@ -246,13 +271,13 @@ namespace TiledArray {
 
     void swap(TiledRange_& other) {
       range_.swap(other.range_);
-      element_range_.swap(other.element_range_);
+      elements_range_.swap(other.elements_range_);
       std::swap(ranges_, other.ranges_);
     }
 
   private:
     range_type range_; ///< Stores information on tile indexing for the range.
-    tile_range_type element_range_; ///< Stores information on element indexing for the range.
+    tiles_range_type elements_range_; ///< Stores information on element indexing for the range.
     Ranges ranges_; ///< Stores tile boundaries for each dimension.
   };
 
@@ -262,7 +287,7 @@ namespace TiledArray {
   /// being used by other objects will be permuted. The owner of those
   /// objects are
   inline TiledRange operator *(const Permutation& p, const TiledRange& r) {
-    TA_ASSERT(r.tile_range().rank() == p.dim());
+    TA_ASSERT(r.tiles_range().rank() == p.dim());
     TiledRange::Ranges data = p * r.data();
 
     return TiledRange(data.begin(), data.end());
@@ -273,8 +298,8 @@ namespace TiledArray {
 
   /// Returns true when all tile and element ranges are the same.
   inline bool operator ==(const TiledRange& r1, const TiledRange& r2) {
-    return (r1.tile_range().rank() == r2.tile_range().rank()) &&
-        (r1.tile_range() == r2.tile_range()) && (r1.element_range() == r2.element_range()) &&
+    return (r1.tiles_range().rank() == r2.tiles_range().rank()) &&
+        (r1.tiles_range() == r2.tiles_range()) && (r1.elements_range() == r2.elements_range()) &&
         std::equal(r1.data().begin(), r1.data().end(), r2.data().begin());
   }
 
@@ -283,8 +308,8 @@ namespace TiledArray {
   }
 
   inline std::ostream& operator<<(std::ostream& out, const TiledRange& rng) {
-    out << "(" << " tiles = " << rng.tile_range()
-        << ", elements = " << rng.element_range() << " )";
+    out << "(" << " tiles = " << rng.tiles_range()
+        << ", elements = " << rng.elements_range() << " )";
     return out;
   }
 

--- a/src/TiledArray/tiled_range1.h
+++ b/src/TiledArray/tiled_range1.h
@@ -114,11 +114,21 @@ namespace TiledArray {
       return result;
     }
 
-    /// Tiles range accessor
-    const range_type& tiles() const { return range_; }
+    /// \deprecated use TiledRange1::tile_range()
+    DEPRECATED const range_type& tiles() const { return range_; }
+
+    /// Tile range accessor
+
+    /// \return a reference to the tile index range
+    const range_type& tile_range() const { return range_; }
+
+    /// \deprecated use TiledRange1::element_range()
+    const range_type& elements() const { return element_range_; }
 
     /// Elements range accessor
-    const range_type& elements() const { return element_range_; }
+
+    /// \return a reference to the element index range
+    const range_type& element_range() const { return element_range_; }
 
     /// Tile range extent accessor
     size_type tile_extent() const { return range_.second - range_.first; }
@@ -210,7 +220,7 @@ namespace TiledArray {
   /// Equality operator
   inline bool operator ==(const TiledRange1& r1, const TiledRange1& r2) {
     return std::equal(r1.begin(), r1.end(), r2.begin()) &&
-        (r1.tiles() == r2.tiles()) && (r1.elements() == r2.elements());
+        (r1.tile_range() == r2.tile_range()) && (r1.element_range() == r2.element_range());
   }
 
   /// Inequality operator
@@ -220,8 +230,8 @@ namespace TiledArray {
 
   /// TiledRange1 ostream operator
   inline std::ostream& operator <<(std::ostream& out, const TiledRange1& rng) {
-    out << "( tiles = [ " << rng.tiles().first << ", " << rng.tiles().second
-        << " ), elements = [ " << rng.elements().first << ", " << rng.elements().second << " ) )";
+    out << "( tiles = [ " << rng.tile_range().first << ", " << rng.tile_range().second
+        << " ), elements = [ " << rng.element_range().first << ", " << rng.element_range().second << " ) )";
     return out;
   }
 

--- a/src/TiledArray/tiled_range1.h
+++ b/src/TiledArray/tiled_range1.h
@@ -42,8 +42,8 @@ namespace TiledArray {
 
     /// Default constructor, range of 0 tiles and elements.
     TiledRange1() :
-        range_(0,0), element_range_(0,0),
-        tile_ranges_(1, range_type(0,0)), elem2tile_(1, 0)
+        range_(0,0), elements_range_(0,0),
+        tiles_ranges_(1, range_type(0,0)), elem2tile_(1, 0)
     {
       init_map_();
     }
@@ -53,7 +53,7 @@ namespace TiledArray {
     template <typename RandIter,
         typename std::enable_if<detail::is_random_iterator<RandIter>::value>::type* = nullptr>
     TiledRange1(RandIter first, RandIter last) :
-        range_(), element_range_(), tile_ranges_(), elem2tile_()
+        range_(), elements_range_(), tiles_ranges_(), elem2tile_()
     {
       init_tiles_(first, last, 0);
       init_map_();
@@ -61,8 +61,8 @@ namespace TiledArray {
 
     /// Copy constructor
     TiledRange1(const TiledRange1& rng) :
-        range_(rng.range_), element_range_(rng.element_range_),
-        tile_ranges_(rng.tile_ranges_), elem2tile_(rng.elem2tile_)
+        range_(rng.range_), elements_range_(rng.elements_range_),
+        tiles_ranges_(rng.tiles_ranges_), elem2tile_(rng.elem2tile_)
     { }
 
     /// Construct a 1D tiled range.
@@ -100,41 +100,41 @@ namespace TiledArray {
     }
 
     /// Returns an iterator to the first tile in the range.
-    const_iterator begin() const { return tile_ranges_.begin(); }
+    const_iterator begin() const { return tiles_ranges_.begin(); }
 
     /// Returns an iterator to the end of the range.
-    const_iterator end() const { return tile_ranges_.end(); }
+    const_iterator end() const { return tiles_ranges_.end(); }
 
     /// Return tile iterator associated with ordinal_index
     const_iterator find(const size_type& e) const{
-      if(! includes(element_range_, e))
-        return tile_ranges_.end();
-      const_iterator result = tile_ranges_.begin();
+      if(! includes(elements_range_, e))
+        return tiles_ranges_.end();
+      const_iterator result = tiles_ranges_.begin();
       result += element2tile(e);
       return result;
     }
 
-    /// \deprecated use TiledRange1::tile_range()
+    /// \deprecated use TiledRange1::tiles_range()
     DEPRECATED const range_type& tiles() const { return range_; }
 
     /// Tile range accessor
 
     /// \return a reference to the tile index range
-    const range_type& tile_range() const { return range_; }
+    const range_type& tiles_range() const { return range_; }
 
-    /// \deprecated use TiledRange1::element_range()
-    const range_type& elements() const { return element_range_; }
+    /// \deprecated use TiledRange1::elements_range()
+    const range_type& elements() const { return elements_range_; }
 
     /// Elements range accessor
 
     /// \return a reference to the element index range
-    const range_type& element_range() const { return element_range_; }
+    const range_type& elements_range() const { return elements_range_; }
 
     /// Tile range extent accessor
     size_type tile_extent() const { return range_.second - range_.first; }
 
     /// Elements range extent accessor
-    size_type extent() const { return element_range_.second - element_range_.first; }
+    size_type extent() const { return elements_range_.second - elements_range_.first; }
 
     /// Tile range accessor
 
@@ -143,18 +143,18 @@ namespace TiledArray {
     /// \throw std::out_of_range When \c i \c >= \c tiles().size()
     const range_type& tile(const size_type i) const {
       TA_ASSERT(includes(range_, i));
-      return tile_ranges_[i - range_.first];
+      return tiles_ranges_[i - range_.first];
     }
 
     const size_type& element2tile(const size_type& i) const {
-      TA_ASSERT( includes(element_range_, i) );
-      return elem2tile_[i - element_range_.first];
+      TA_ASSERT( includes(elements_range_, i) );
+      return elem2tile_[i - elements_range_.first];
     }
 
     void swap(TiledRange1& other) { // no throw
       std::swap(range_, other.range_);
-      std::swap(element_range_, other.element_range_);
-      std::swap(tile_ranges_, other.tile_ranges_);
+      std::swap(elements_range_, other.elements_range_);
+      std::swap(tiles_ranges_, other.tiles_ranges_);
       std::swap(elem2tile_, other.elem2tile_);
     }
 
@@ -182,32 +182,32 @@ namespace TiledArray {
 #endif // NDEBUG
       range_.first = start_tile_index;
       range_.second = start_tile_index + last - first - 1;
-      element_range_.first = *first;
-      element_range_.second = *(last - 1);
+      elements_range_.first = *first;
+      elements_range_.second = *(last - 1);
       for (; first != (last - 1); ++first)
-        tile_ranges_.push_back(range_type(*first, *(first + 1)));
+        tiles_ranges_.push_back(range_type(*first, *(first + 1)));
     }
 
     /// Initialize secondary data
     void init_map_() {
       // check for 0 size range.
-      if((element_range_.second - element_range_.first) == 0)
+      if((elements_range_.second - elements_range_.first) == 0)
         return;
 
       // initialize elem2tile map
-      elem2tile_.resize(element_range_.second - element_range_.first);
+      elem2tile_.resize(elements_range_.second - elements_range_.first);
       const size_type end = range_.second - range_.first;
       for(size_type t = 0; t < end; ++t)
-        for(size_type e = tile_ranges_[t].first; e < tile_ranges_[t].second; ++e)
-          elem2tile_[e - element_range_.first] = t + range_.first;
+        for(size_type e = tiles_ranges_[t].first; e < tiles_ranges_[t].second; ++e)
+          elem2tile_[e - elements_range_.first] = t + range_.first;
     }
 
     friend std::ostream& operator <<(std::ostream&, const TiledRange1&);
 
     // TiledRange1 data
     range_type range_; ///< stores the overall dimensions of the tiles.
-    range_type element_range_; ///< stores overall element dimensions.
-    std::vector<range_type> tile_ranges_; ///< stores the dimensions of each tile.
+    range_type elements_range_; ///< stores overall element dimensions.
+    std::vector<range_type> tiles_ranges_; ///< stores the dimensions of each tile.
     std::vector<size_type> elem2tile_; ///< maps element index to tile index (secondary data).
 
   }; // class TiledRange1
@@ -220,7 +220,7 @@ namespace TiledArray {
   /// Equality operator
   inline bool operator ==(const TiledRange1& r1, const TiledRange1& r2) {
     return std::equal(r1.begin(), r1.end(), r2.begin()) &&
-        (r1.tile_range() == r2.tile_range()) && (r1.element_range() == r2.element_range());
+        (r1.tiles_range() == r2.tiles_range()) && (r1.elements_range() == r2.elements_range());
   }
 
   /// Inequality operator
@@ -230,8 +230,8 @@ namespace TiledArray {
 
   /// TiledRange1 ostream operator
   inline std::ostream& operator <<(std::ostream& out, const TiledRange1& rng) {
-    out << "( tiles = [ " << rng.tile_range().first << ", " << rng.tile_range().second
-        << " ), elements = [ " << rng.element_range().first << ", " << rng.element_range().second << " ) )";
+    out << "( tiles = [ " << rng.tiles_range().first << ", " << rng.tiles_range().second
+        << " ), elements = [ " << rng.elements_range().first << ", " << rng.elements_range().second << " ) )";
     return out;
   }
 

--- a/tests/array_impl.cpp
+++ b/tests/array_impl.cpp
@@ -34,7 +34,7 @@ struct ArrayImplBaseFixture : public SparseShapeFixture {
   typedef Tensor<int> value_type;
   typedef detail::ArrayImpl<value_type, DensePolicy> array_impl_base;
   ArrayImplBaseFixture() :
-    pmap(new detail::HashPmap(* GlobalFixture::world, tr.tiles().volume()))
+    pmap(new detail::HashPmap(* GlobalFixture::world, tr.tile_range().volume()))
   { }
 
   std::shared_ptr<array_impl_base::pmap_interface> pmap;
@@ -69,13 +69,13 @@ BOOST_AUTO_TEST_CASE( constructor_dense_policy )
   array_impl_base x(* GlobalFixture::world, tr, dense_shape_type(), pmap);
 
   // Check that the initial conditions are correct after constructution.
-  BOOST_CHECK_EQUAL(& x.get_world(), GlobalFixture::world);
+  BOOST_CHECK_EQUAL(& x.world(), GlobalFixture::world);
   BOOST_CHECK(x.pmap() == pmap);
-  BOOST_CHECK_EQUAL(x.range(), tr.tiles());
+  BOOST_CHECK_EQUAL(x.range(), tr.tile_range());
   BOOST_CHECK_EQUAL(x.trange(), tr);
-  BOOST_CHECK_EQUAL(x.size(), tr.tiles().volume());
+  BOOST_CHECK_EQUAL(x.size(), tr.tile_range().volume());
   BOOST_CHECK(x.is_dense());
-  for(std::size_t i = 0; i < tr.tiles().volume(); ++i)
+  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i)
     BOOST_CHECK(! x.is_zero(i));
 }
 
@@ -85,13 +85,13 @@ BOOST_AUTO_TEST_CASE( constructor_shape_policy )
   sp_array_impl_base x(* GlobalFixture::world, tr, make_shape(tr, 0.5, 23), pmap);
 
   // Check that the initial conditions are correct after constructution.
-  BOOST_CHECK_EQUAL(& x.get_world(), GlobalFixture::world);
+  BOOST_CHECK_EQUAL(& x.world(), GlobalFixture::world);
   BOOST_CHECK(x.pmap() == pmap);
-  BOOST_CHECK_EQUAL(x.range(), tr.tiles());
+  BOOST_CHECK_EQUAL(x.range(), tr.tile_range());
   BOOST_CHECK_EQUAL(x.trange(), tr);
-  BOOST_CHECK_EQUAL(x.size(), tr.tiles().volume());
+  BOOST_CHECK_EQUAL(x.size(), tr.tile_range().volume());
   BOOST_CHECK(! x.is_dense());
-  for(std::size_t i = 0; i < tr.tiles().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
     if(x.shape()[i] < SparseShape<float>::threshold()) {
       BOOST_CHECK(x.is_zero(i));
     } else {
@@ -103,12 +103,12 @@ BOOST_AUTO_TEST_CASE( constructor_shape_policy )
 BOOST_AUTO_TEST_CASE( tile_get_and_set_w_value )
 {
   // Get each tile before it is set
-  for(std::size_t i = 0; i < tr.tiles().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
     if(GlobalFixture::world->rank() == 0) {
       const ProcessID owner = impl.owner(i);
 
       // Set each tile on node 0
-      BOOST_CHECK_NO_THROW(impl.set(i, value_type(impl.trange().make_tile_range(i), owner)));
+      BOOST_CHECK_NO_THROW(impl.set(i, value_type(impl.trange().tile(i), owner)));
 
       // Get the tile future (may or may not be remote) and wait for the data to arrive.
       Future<value_type> tile = impl.get(i);
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE( tile_get_and_set_w_value )
 BOOST_AUTO_TEST_CASE( tile_get_and_set_w_future )
 {
   // Get each tile before it is set
-  for(std::size_t i = 0; i < tr.tiles().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
     if(GlobalFixture::world->rank() == 0) {
       const ProcessID owner = impl.owner(i);
       Future<value_type> tile;
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE( tile_get_and_set_w_future )
       BOOST_CHECK_NO_THROW(impl.set(i, tile));
 
       // Get the tile future (may or may not be remote) and wait for the data to arrive.
-      tile.set(value_type(impl.trange().make_tile_range(i), owner));
+      tile.set(value_type(impl.trange().tile(i), owner));
       GlobalFixture::world->gop.fence();
 
       // Check that the future has been set and the data is what we expect.
@@ -171,13 +171,13 @@ BOOST_AUTO_TEST_CASE( tile_iterator_w_value )
 {
   // Set local tiles via iterators
   for(array_impl_base::iterator it = impl.begin(); it != impl.end(); ++it) {
-    BOOST_CHECK_NO_THROW(*it = value_type(impl.trange().make_tile_range(it.ordinal()), impl.owner(it.ordinal())));
+    BOOST_CHECK_NO_THROW(*it = value_type(impl.trange().tile(it.ordinal()), impl.owner(it.ordinal())));
   }
 
   GlobalFixture::world->gop.fence();
 
   // Get each tile before it is set
-  for(std::size_t i = 0; i < tr.tiles().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
     if(GlobalFixture::world->rank() == 0) {
       // Get the tile future (may or may not be remote) and wait for the data to arrive.
       value_type tile = impl.get(i);
@@ -206,13 +206,13 @@ BOOST_AUTO_TEST_CASE( tile_iterator_w_future )
   for(array_impl_base::iterator it = impl.begin(); it != impl.end(); ++it) {
     Future<value_type> tile;
     BOOST_CHECK_NO_THROW(*it = tile);
-    tile.set(value_type(impl.trange().make_tile_range(it.ordinal()), GlobalFixture::world->rank()));
+    tile.set(value_type(impl.trange().tile(it.ordinal()), GlobalFixture::world->rank()));
   }
 
   GlobalFixture::world->gop.fence();
 
   // Get each tile before it is set
-  for(std::size_t i = 0; i < tr.tiles().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
     if(GlobalFixture::world->rank() == 0) {
       // Get the tile, which may be local or remote.
       Future<value_type> tile = impl.get(i);

--- a/tests/array_impl.cpp
+++ b/tests/array_impl.cpp
@@ -34,7 +34,7 @@ struct ArrayImplBaseFixture : public SparseShapeFixture {
   typedef Tensor<int> value_type;
   typedef detail::ArrayImpl<value_type, DensePolicy> array_impl_base;
   ArrayImplBaseFixture() :
-    pmap(new detail::HashPmap(* GlobalFixture::world, tr.tile_range().volume()))
+    pmap(new detail::HashPmap(* GlobalFixture::world, tr.tiles_range().volume()))
   { }
 
   std::shared_ptr<array_impl_base::pmap_interface> pmap;
@@ -71,11 +71,11 @@ BOOST_AUTO_TEST_CASE( constructor_dense_policy )
   // Check that the initial conditions are correct after constructution.
   BOOST_CHECK_EQUAL(& x.world(), GlobalFixture::world);
   BOOST_CHECK(x.pmap() == pmap);
-  BOOST_CHECK_EQUAL(x.range(), tr.tile_range());
+  BOOST_CHECK_EQUAL(x.range(), tr.tiles_range());
   BOOST_CHECK_EQUAL(x.trange(), tr);
-  BOOST_CHECK_EQUAL(x.size(), tr.tile_range().volume());
+  BOOST_CHECK_EQUAL(x.size(), tr.tiles_range().volume());
   BOOST_CHECK(x.is_dense());
-  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i)
+  for(std::size_t i = 0; i < tr.tiles_range().volume(); ++i)
     BOOST_CHECK(! x.is_zero(i));
 }
 
@@ -87,11 +87,11 @@ BOOST_AUTO_TEST_CASE( constructor_shape_policy )
   // Check that the initial conditions are correct after constructution.
   BOOST_CHECK_EQUAL(& x.world(), GlobalFixture::world);
   BOOST_CHECK(x.pmap() == pmap);
-  BOOST_CHECK_EQUAL(x.range(), tr.tile_range());
+  BOOST_CHECK_EQUAL(x.range(), tr.tiles_range());
   BOOST_CHECK_EQUAL(x.trange(), tr);
-  BOOST_CHECK_EQUAL(x.size(), tr.tile_range().volume());
+  BOOST_CHECK_EQUAL(x.size(), tr.tiles_range().volume());
   BOOST_CHECK(! x.is_dense());
-  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tiles_range().volume(); ++i) {
     if(x.shape()[i] < SparseShape<float>::threshold()) {
       BOOST_CHECK(x.is_zero(i));
     } else {
@@ -103,12 +103,12 @@ BOOST_AUTO_TEST_CASE( constructor_shape_policy )
 BOOST_AUTO_TEST_CASE( tile_get_and_set_w_value )
 {
   // Get each tile before it is set
-  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tiles_range().volume(); ++i) {
     if(GlobalFixture::world->rank() == 0) {
       const ProcessID owner = impl.owner(i);
 
       // Set each tile on node 0
-      BOOST_CHECK_NO_THROW(impl.set(i, value_type(impl.trange().tile(i), owner)));
+      BOOST_CHECK_NO_THROW(impl.set(i, value_type(impl.trange().make_tile_range(i), owner)));
 
       // Get the tile future (may or may not be remote) and wait for the data to arrive.
       Future<value_type> tile = impl.get(i);
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE( tile_get_and_set_w_value )
 BOOST_AUTO_TEST_CASE( tile_get_and_set_w_future )
 {
   // Get each tile before it is set
-  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tiles_range().volume(); ++i) {
     if(GlobalFixture::world->rank() == 0) {
       const ProcessID owner = impl.owner(i);
       Future<value_type> tile;
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE( tile_get_and_set_w_future )
       BOOST_CHECK_NO_THROW(impl.set(i, tile));
 
       // Get the tile future (may or may not be remote) and wait for the data to arrive.
-      tile.set(value_type(impl.trange().tile(i), owner));
+      tile.set(value_type(impl.trange().make_tile_range(i), owner));
       GlobalFixture::world->gop.fence();
 
       // Check that the future has been set and the data is what we expect.
@@ -171,13 +171,13 @@ BOOST_AUTO_TEST_CASE( tile_iterator_w_value )
 {
   // Set local tiles via iterators
   for(array_impl_base::iterator it = impl.begin(); it != impl.end(); ++it) {
-    BOOST_CHECK_NO_THROW(*it = value_type(impl.trange().tile(it.ordinal()), impl.owner(it.ordinal())));
+    BOOST_CHECK_NO_THROW(*it = value_type(impl.trange().make_tile_range(it.ordinal()), impl.owner(it.ordinal())));
   }
 
   GlobalFixture::world->gop.fence();
 
   // Get each tile before it is set
-  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tiles_range().volume(); ++i) {
     if(GlobalFixture::world->rank() == 0) {
       // Get the tile future (may or may not be remote) and wait for the data to arrive.
       value_type tile = impl.get(i);
@@ -206,13 +206,13 @@ BOOST_AUTO_TEST_CASE( tile_iterator_w_future )
   for(array_impl_base::iterator it = impl.begin(); it != impl.end(); ++it) {
     Future<value_type> tile;
     BOOST_CHECK_NO_THROW(*it = tile);
-    tile.set(value_type(impl.trange().tile(it.ordinal()), GlobalFixture::world->rank()));
+    tile.set(value_type(impl.trange().make_tile_range(it.ordinal()), GlobalFixture::world->rank()));
   }
 
   GlobalFixture::world->gop.fence();
 
   // Get each tile before it is set
-  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tiles_range().volume(); ++i) {
     if(GlobalFixture::world->rank() == 0) {
       // Get the tile, which may be local or remote.
       Future<value_type> tile = impl.get(i);

--- a/tests/dist_array.cpp
+++ b/tests/dist_array.cpp
@@ -28,7 +28,7 @@
 using namespace TiledArray;
 
 ArrayFixture::ArrayFixture() :
-    shape_tensor(tr.tiles(), 0.0),
+    shape_tensor(tr.tile_range(), 0.0),
     world(*GlobalFixture::world),
     a(world, tr)
 {
@@ -38,7 +38,7 @@ ArrayFixture::ArrayFixture() :
 
   world.gop.fence();
 
-  for(std::size_t i = 0; i < tr.tiles().volume(); ++i)
+  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i)
     if(i % 3)
       shape_tensor[i] = 1.0;
 }
@@ -73,13 +73,13 @@ BOOST_AUTO_TEST_CASE( constructors )
 BOOST_AUTO_TEST_CASE( all_owned )
 {
   std::size_t count = 0ul;
-  for(std::size_t i = 0ul; i < tr.tiles().volume(); ++i)
+  for(std::size_t i = 0ul; i < tr.tile_range().volume(); ++i)
     if(a.owner(i) == GlobalFixture::world->rank())
       ++count;
   world.gop.sum(count);
 
   // Check that all tiles are in the array
-  BOOST_CHECK_EQUAL(tr.tiles().volume(), count);
+  BOOST_CHECK_EQUAL(tr.tile_range().volume(), count);
 }
 
 BOOST_AUTO_TEST_CASE( owner )
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE( fill_tiles )
       Future<ArrayN::value_type> tile = a.find(*it);
 
       // Check that the range for the constructed tile is correct.
-      BOOST_CHECK_EQUAL(tile.get().range(), tr.make_tile_range(*it));
+      BOOST_CHECK_EQUAL(tile.get().range(), tr.tile(*it));
 
       for(ArrayN::value_type::iterator it = tile.get().begin(); it != tile.get().end(); ++it)
         BOOST_CHECK_EQUAL(*it, 0);
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE( assign_tiles )
   ArrayN a(world, tr);
 
   for(ArrayN::range_type::const_iterator it = a.range().begin(); it != a.range().end(); ++it) {
-    ArrayN::trange_type::tile_range_type range = a.trange().make_tile_range(*it);
+    ArrayN::trange_type::tile_range_type range = a.trange().tile(*it);
     if(a.is_local(*it)) {
       if(data.size() < range.volume())
         data.resize(range.volume(), 1);
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE( assign_tiles )
       BOOST_CHECK(tile.probe());
 
       // Check that the range for the constructed tile is correct.
-      BOOST_CHECK_EQUAL(tile.get().range(), tr.make_tile_range(*it));
+      BOOST_CHECK_EQUAL(tile.get().range(), tr.tile(*it));
 
       for(ArrayN::value_type::iterator it = tile.get().begin(); it != tile.get().end(); ++it)
         BOOST_CHECK_EQUAL(*it, 1);
@@ -226,10 +226,10 @@ BOOST_AUTO_TEST_CASE( clone )
 
   // Check array data are equal
   BOOST_CHECK(!(ca.id() == a.id()));
-  BOOST_CHECK_EQUAL(ca.get_world().id(), a.get_world().id());
+  BOOST_CHECK_EQUAL(ca.world().id(), a.world().id());
   BOOST_CHECK_EQUAL(ca.trange(), a.trange());
-  BOOST_CHECK_EQUAL_COLLECTIONS(ca.get_pmap()->begin(), ca.get_pmap()->end(),
-      a.get_pmap()->begin(), a.get_pmap()->end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(ca.pmap()->begin(), ca.pmap()->end(),
+      a.pmap()->begin(), a.pmap()->end());
 
   // Check that array tiles are equal
   for(typename ArrayN::size_type index = 0ul; index < a.size(); ++index) {
@@ -256,22 +256,22 @@ BOOST_AUTO_TEST_CASE( clone )
 BOOST_AUTO_TEST_CASE( make_replicated )
 {
   // Get a copy of the original process map
-  std::shared_ptr<ArrayN::pmap_interface> distributed_pmap = a.get_pmap();
+  std::shared_ptr<ArrayN::pmap_interface> distributed_pmap = a.pmap();
 
   // Convert array to a replicated array.
   BOOST_REQUIRE_NO_THROW(a.make_replicated());
 
   if(GlobalFixture::world->size() == 1)
-    BOOST_CHECK(! a.get_pmap()->is_replicated());
+    BOOST_CHECK(! a.pmap()->is_replicated());
   else
-    BOOST_CHECK(a.get_pmap()->is_replicated());
+    BOOST_CHECK(a.pmap()->is_replicated());
 
   // Check that all the data is local
   for(std::size_t i = 0; i < a.size(); ++i) {
     BOOST_CHECK(a.is_local(i));
-    BOOST_CHECK_EQUAL(a.get_pmap()->owner(i), GlobalFixture::world->rank());
+    BOOST_CHECK_EQUAL(a.pmap()->owner(i), GlobalFixture::world->rank());
     Future<ArrayN::value_type> tile = a.find(i);
-    BOOST_CHECK_EQUAL(tile.get().range(), a.trange().make_tile_range(i));
+    BOOST_CHECK_EQUAL(tile.get().range(), a.trange().tile(i));
     for(ArrayN::value_type::const_iterator it = tile.get().begin(); it != tile.get().end(); ++it)
       BOOST_CHECK_EQUAL(*it, distributed_pmap->owner(i) + 1);
   }

--- a/tests/dist_eval_array_eval.cpp
+++ b/tests/dist_eval_array_eval.cpp
@@ -38,7 +38,7 @@ struct ArrayEvalImplFixture : public TiledRangeFixture {
   ArrayEvalImplFixture() : array(*GlobalFixture::world, tr) {
     // Fill array with random data
     for(TArrayI::iterator it = array.begin(); it != array.end(); ++it) {
-      TArrayI::value_type tile(array.trange().make_tile_range(it.index()));
+      TArrayI::value_type tile(array.trange().tile(it.index()));
       for(TArrayI::value_type::iterator tile_it = tile.begin(); tile_it != tile.end(); ++tile_it)
         *tile_it = GlobalFixture::world->rand() % 101;
       *it = tile;
@@ -92,26 +92,26 @@ BOOST_FIXTURE_TEST_SUITE( array_eval_suite, ArrayEvalImplFixture )
 
 BOOST_AUTO_TEST_CASE( constructor )
 {
-  BOOST_REQUIRE_NO_THROW(make_array_eval(array, array.get_world(),
-      DenseShape(), array.get_pmap(), Permutation(), make_array_scal(3)));
+  BOOST_REQUIRE_NO_THROW(make_array_eval(array, array.world(),
+      DenseShape(), array.pmap(), Permutation(), make_array_scal(3)));
 
-  auto dist_eval = make_array_eval(array, array.get_world(),
-      DenseShape(), array.get_pmap(), Permutation(), make_array_scal(3));
+  auto dist_eval = make_array_eval(array, array.world(),
+      DenseShape(), array.pmap(), Permutation(), make_array_scal(3));
 
-  BOOST_CHECK_EQUAL(& dist_eval.get_world(), GlobalFixture::world);
-  BOOST_CHECK(dist_eval.pmap() == array.get_pmap());
-  BOOST_CHECK_EQUAL(dist_eval.range(), tr.tiles());
+  BOOST_CHECK_EQUAL(& dist_eval.world(), GlobalFixture::world);
+  BOOST_CHECK(dist_eval.pmap() == array.pmap());
+  BOOST_CHECK_EQUAL(dist_eval.range(), tr.tile_range());
   BOOST_CHECK_EQUAL(dist_eval.trange(), tr);
-  BOOST_CHECK_EQUAL(dist_eval.size(), tr.tiles().volume());
+  BOOST_CHECK_EQUAL(dist_eval.size(), tr.tile_range().volume());
   BOOST_CHECK(dist_eval.is_dense());
-  for(std::size_t i = 0; i < tr.tiles().volume(); ++i)
+  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i)
     BOOST_CHECK(! dist_eval.is_zero(i));
 }
 
 BOOST_AUTO_TEST_CASE( eval_scale )
 {
-  auto dist_eval = make_array_eval(array, array.get_world(),
-      DenseShape(), array.get_pmap(), Permutation(), make_scal(3));
+  auto dist_eval = make_array_eval(array, array.world(),
+      DenseShape(), array.pmap(), Permutation(), make_scal(3));
   using dist_eval_type = decltype(dist_eval);
 
   BOOST_REQUIRE_NO_THROW(dist_eval.eval());
@@ -147,8 +147,8 @@ BOOST_AUTO_TEST_CASE( eval_permute )
   const Permutation perm(p.begin(), p.end());
 
   // Construct and evaluate
-  auto dist_eval = make_array_eval(array, array.get_world(),
-      DenseShape(), array.get_pmap(), perm, make_array_noop(perm));
+  auto dist_eval = make_array_eval(array, array.world(),
+      DenseShape(), array.pmap(), perm, make_array_noop(perm));
   using dist_eval_type = decltype(dist_eval);
 
   BOOST_REQUIRE_NO_THROW(dist_eval.eval());

--- a/tests/dist_eval_array_eval.cpp
+++ b/tests/dist_eval_array_eval.cpp
@@ -38,7 +38,7 @@ struct ArrayEvalImplFixture : public TiledRangeFixture {
   ArrayEvalImplFixture() : array(*GlobalFixture::world, tr) {
     // Fill array with random data
     for(TArrayI::iterator it = array.begin(); it != array.end(); ++it) {
-      TArrayI::value_type tile(array.trange().tile(it.index()));
+      TArrayI::value_type tile(array.trange().make_tile_range(it.index()));
       for(TArrayI::value_type::iterator tile_it = tile.begin(); tile_it != tile.end(); ++tile_it)
         *tile_it = GlobalFixture::world->rand() % 101;
       *it = tile;
@@ -100,11 +100,11 @@ BOOST_AUTO_TEST_CASE( constructor )
 
   BOOST_CHECK_EQUAL(& dist_eval.world(), GlobalFixture::world);
   BOOST_CHECK(dist_eval.pmap() == array.pmap());
-  BOOST_CHECK_EQUAL(dist_eval.range(), tr.tile_range());
+  BOOST_CHECK_EQUAL(dist_eval.range(), tr.tiles_range());
   BOOST_CHECK_EQUAL(dist_eval.trange(), tr);
-  BOOST_CHECK_EQUAL(dist_eval.size(), tr.tile_range().volume());
+  BOOST_CHECK_EQUAL(dist_eval.size(), tr.tiles_range().volume());
   BOOST_CHECK(dist_eval.is_dense());
-  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i)
+  for(std::size_t i = 0; i < tr.tiles_range().volume(); ++i)
     BOOST_CHECK(! dist_eval.is_zero(i));
 }
 

--- a/tests/dist_eval_binary_eval.cpp
+++ b/tests/dist_eval_binary_eval.cpp
@@ -37,13 +37,13 @@ struct BinaryEvalFixture : public TiledRangeFixture {
   {
     // Fill array with random data
     for(TArrayI::iterator it = left.begin(); it != left.end(); ++it) {
-      TArrayI::value_type tile(left.trange().tile(it.index()));
+      TArrayI::value_type tile(left.trange().make_tile_range(it.index()));
       for(TArrayI::value_type::iterator tile_it = tile.begin(); tile_it != tile.end(); ++tile_it)
         *tile_it = GlobalFixture::world->rand() % 101;
       *it = tile;
     }
     for(TArrayI::iterator it = right.begin(); it != right.end(); ++it) {
-      TArrayI::value_type tile(right.trange().tile(it.index()));
+      TArrayI::value_type tile(right.trange().make_tile_range(it.index()));
       for(TArrayI::value_type::iterator tile_it = tile.begin(); tile_it != tile.end(); ++tile_it)
         *tile_it = GlobalFixture::world->rand() % 101;
       *it = tile;
@@ -124,11 +124,11 @@ BOOST_AUTO_TEST_CASE( constructor )
 
   BOOST_CHECK_EQUAL(& binary.world(), GlobalFixture::world);
   BOOST_CHECK(binary.pmap() == left_arg.pmap());
-  BOOST_CHECK_EQUAL(binary.range(), tr.tile_range());
+  BOOST_CHECK_EQUAL(binary.range(), tr.tiles_range());
   BOOST_CHECK_EQUAL(binary.trange(), tr);
-  BOOST_CHECK_EQUAL(binary.size(), tr.tile_range().volume());
+  BOOST_CHECK_EQUAL(binary.size(), tr.tiles_range().volume());
   BOOST_CHECK(binary.is_dense());
-  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i)
+  for(std::size_t i = 0; i < tr.tiles_range().volume(); ++i)
     BOOST_CHECK(! binary.is_zero(i));
 }
 
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE( eval )
     BOOST_REQUIRE_NO_THROW(eval_tile = tile.get());
 
     // Check that the result tile is correctly modified.
-    BOOST_CHECK_EQUAL(eval_tile.range(), dist_eval.trange().tile(index));
+    BOOST_CHECK_EQUAL(eval_tile.range(), dist_eval.trange().make_tile_range(index));
     BOOST_CHECK_EQUAL(eval_tile.range(), left_tile.range());
     for(std::size_t i = 0ul; i < eval_tile.size(); ++i) {
       BOOST_CHECK_EQUAL(eval_tile[i], left_tile[i] + right_tile[i]);
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE( perm_eval )
     BOOST_REQUIRE_NO_THROW(eval_tile = tile.get());
 
     // Check that the result tile is correctly modified.
-    BOOST_CHECK_EQUAL(eval_tile.range(), dist_eval.trange().tile(index));
+    BOOST_CHECK_EQUAL(eval_tile.range(), dist_eval.trange().make_tile_range(index));
     BOOST_CHECK_EQUAL(eval_tile.range(), perm * left_tile.range());
     for(std::size_t i = 0ul; i < eval_tile.size(); ++i) {
       BOOST_CHECK_EQUAL(eval_tile[perm * left_tile.range().idx(i)], left_tile[i] + right_tile[i]);

--- a/tests/dist_eval_contraction_eval.cpp
+++ b/tests/dist_eval_contraction_eval.cpp
@@ -42,13 +42,13 @@ struct ContractionEvalFixture : public SparseShapeFixture {
   ContractionEvalFixture() :
     left(*GlobalFixture::world, tr),
     right(*GlobalFixture::world, tr),
-    proc_grid(*GlobalFixture::world, tr.tiles().extent_data()[0], tr.tiles().extent_data()[tr.tiles().rank() - 1],
-        tr.elements().extent_data()[0], tr.elements().extent_data()[tr.elements().rank() - 1u]),
-    left_arg(make_array_eval(left, left.get_world(), DenseShape(),
-        proc_grid.make_row_phase_pmap(tr.tiles().volume() / tr.tiles().extent_data()[0]),
+    proc_grid(*GlobalFixture::world, tr.tile_range().extent_data()[0], tr.tile_range().extent_data()[tr.tile_range().rank() - 1],
+        tr.element_range().extent_data()[0], tr.element_range().extent_data()[tr.element_range().rank() - 1u]),
+    left_arg(make_array_eval(left, left.world(), DenseShape(),
+        proc_grid.make_row_phase_pmap(tr.tile_range().volume() / tr.tile_range().extent_data()[0]),
         Permutation(), make_array_noop())),
-    right_arg(make_array_eval(right, right.get_world(), DenseShape(),
-        proc_grid.make_col_phase_pmap(tr.tiles().volume() / tr.tiles().extent_data()[tr.tiles().rank() - 1u]),
+    right_arg(make_array_eval(right, right.world(), DenseShape(),
+        proc_grid.make_col_phase_pmap(tr.tile_range().volume() / tr.tile_range().extent_data()[tr.tile_range().rank() - 1u]),
         Permutation(), make_array_noop())),
     result_tr()
   {
@@ -60,7 +60,7 @@ struct ContractionEvalFixture : public SparseShapeFixture {
         {{ left.trange().data().front(), right.trange().data().back() }};
     result_tr = TiledRange(tranges.begin(), tranges.end());
 
-    pmap.reset(new detail::BlockedPmap(* GlobalFixture::world, result_tr.tiles().volume()));
+    pmap.reset(new detail::BlockedPmap(* GlobalFixture::world, result_tr.tile_range().volume()));
   }
 
   ~ContractionEvalFixture() {
@@ -91,7 +91,7 @@ struct ContractionEvalFixture : public SparseShapeFixture {
     // Iterate over local, non-zero tiles
     for(typename DistArray<Tile, Policy>::iterator it = array.begin(); it != array.end(); ++it) {
       // Construct a new tile with random data
-      typename DistArray<Tile, Policy>::value_type tile(array.trange().make_tile_range(it.index()));
+      typename DistArray<Tile, Policy>::value_type tile(array.trange().tile(it.index()));
       for(typename DistArray<Tile, Policy>::value_type::iterator tile_it = tile.begin(); tile_it != tile.end(); ++tile_it)
         *tile_it = GlobalFixture::world->rand() % 27;
 
@@ -112,11 +112,11 @@ struct ContractionEvalFixture : public SparseShapeFixture {
     int i = dim - 1;
     for(; i >= middle; --i) {
       weight[i] = MN[1];
-      MN[1] *= array.trange().elements().extent_data()[i];
+      MN[1] *= array.trange().element_range().extent_data()[i];
     }
     for(; i >= 0; --i) {
       weight[i] = MN[0];
-      MN[0] *= array.trange().elements().extent_data()[i];
+      MN[0] *= array.trange().element_range().extent_data()[i];
     }
 
     // Construct the result matrix
@@ -201,12 +201,12 @@ struct ContractionEvalFixture : public SparseShapeFixture {
     for(unsigned int i = 0ul; i < left_middle; ++i) {
       ranges[(perm ? perm[pi++] : pi++)] = left.trange().data()[i];
       M *= left.range().extent_data()[i];
-      m *= left.trange().elements().extent_data()[i];
+      m *= left.trange().element_range().extent_data()[i];
     }
     for(std::size_t i = num_contract_ranks; i < right_end; ++i) {
       ranges[(perm ? perm[pi++] : pi++)] = right.trange().data()[i];
       N *= right.range().extent_data()[i];
-      n *= right.trange().elements().extent_data()[i];
+      n *= right.trange().element_range().extent_data()[i];
     }
 
     // Compute the number of tiles in the inner dimension.
@@ -255,22 +255,22 @@ BOOST_FIXTURE_TEST_SUITE( dist_eval_contraction_eval_suite, ContractionEvalFixtu
 BOOST_AUTO_TEST_CASE( constructor )
 {
 
-  BOOST_REQUIRE_NO_THROW(make_contract_eval(left_arg, right_arg, left.get_world(),
+  BOOST_REQUIRE_NO_THROW(make_contract_eval(left_arg, right_arg, left.world(),
       DenseShape(), pmap, Permutation(), make_contract(2u,
-      left_arg.trange().tiles().rank(), right_arg.trange().tiles().rank())));
+      left_arg.trange().tile_range().rank(), right_arg.trange().tile_range().rank())));
 
 
   auto contract = make_contract_eval(left_arg, right_arg,
-      left_arg.get_world(), DenseShape(), pmap, Permutation(), make_contract(2u,
-      left_arg.trange().tiles().rank(), right_arg.trange().tiles().rank()));
+      left_arg.world(), DenseShape(), pmap, Permutation(), make_contract(2u,
+      left_arg.trange().tile_range().rank(), right_arg.trange().tile_range().rank()));
 
-  BOOST_CHECK_EQUAL(& contract.get_world(), GlobalFixture::world);
+  BOOST_CHECK_EQUAL(& contract.world(), GlobalFixture::world);
   BOOST_CHECK(contract.pmap() == pmap);
-  BOOST_CHECK_EQUAL(contract.range(), result_tr.tiles());
+  BOOST_CHECK_EQUAL(contract.range(), result_tr.tile_range());
   BOOST_CHECK_EQUAL(contract.trange(), result_tr);
-  BOOST_CHECK_EQUAL(contract.size(), result_tr.tiles().volume());
+  BOOST_CHECK_EQUAL(contract.size(), result_tr.tile_range().volume());
   BOOST_CHECK(contract.is_dense());
-  for(std::size_t i = 0; i < result_tr.tiles().volume(); ++i)
+  for(std::size_t i = 0; i < result_tr.tile_range().volume(); ++i)
     BOOST_CHECK(! contract.is_zero(i));
 
 }
@@ -279,8 +279,8 @@ BOOST_AUTO_TEST_CASE( constructor )
 BOOST_AUTO_TEST_CASE( eval )
 {
   auto contract = make_contract_eval(left_arg, right_arg,
-      left_arg.get_world(), DenseShape(), pmap, Permutation(), make_contract(2u,
-      left_arg.trange().tiles().rank(), right_arg.trange().tiles().rank()));
+      left_arg.world(), DenseShape(), pmap, Permutation(), make_contract(2u,
+      left_arg.trange().tile_range().rank(), right_arg.trange().tile_range().rank()));
   using dist_eval_type = decltype(contract);
 
 
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE( eval )
 
     if(!eval_tile.empty()) {
       // Check that the result tile is correctly modified.
-      BOOST_CHECK_EQUAL(eval_tile.range(), contract.trange().make_tile_range(index));
+      BOOST_CHECK_EQUAL(eval_tile.range(), contract.trange().tile(index));
       BOOST_CHECK(eigen_map(eval_tile) == reference.block(eval_tile.range().lobound_data()[0],
           eval_tile.range().lobound_data()[1], eval_tile.range().extent_data()[0], eval_tile.range().extent_data()[1]));
     }
@@ -322,8 +322,8 @@ BOOST_AUTO_TEST_CASE( perm_eval )
   Permutation perm({1,0});
 
   auto contract = make_contract_eval(left_arg, right_arg,
-      left_arg.get_world(), DenseShape(), pmap, perm, make_contract(2u,
-      left_arg.trange().tiles().rank(), right_arg.trange().tiles().rank(),
+      left_arg.world(), DenseShape(), pmap, perm, make_contract(2u,
+      left_arg.trange().tile_range().rank(), right_arg.trange().tile_range().rank(),
       perm));
   using dist_eval_type = decltype(contract);
 
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE( perm_eval )
 
     if(!eval_tile.empty()) {
       // Check that the result tile is correctly modified.
-      BOOST_CHECK_EQUAL(eval_tile.range(), contract.trange().make_tile_range(index));
+      BOOST_CHECK_EQUAL(eval_tile.range(), contract.trange().tile(index));
       BOOST_CHECK(eigen_map(eval_tile) == reference.block(eval_tile.range().lobound_data()[0],
           eval_tile.range().lobound_data()[1], eval_tile.range().extent_data()[0], eval_tile.range().extent_data()[1]));
     }
@@ -371,20 +371,20 @@ BOOST_AUTO_TEST_CASE( sparse_eval )
   rand_fill_array(right);
   right.truncate();
 
-  auto left_arg = make_array_eval(left, left.get_world(), left.get_shape(),
-      proc_grid.make_row_phase_pmap(tr.tiles().volume() / tr.tiles().extent_data()[0]),
+  auto left_arg = make_array_eval(left, left.world(), left.shape(),
+      proc_grid.make_row_phase_pmap(tr.tile_range().volume() / tr.tile_range().extent_data()[0]),
       Permutation(), make_array_noop());
-  auto right_arg = make_array_eval(right, right.get_world(), right.get_shape(),
-      proc_grid.make_col_phase_pmap(tr.tiles().volume() / tr.tiles().extent_data()[tr.tiles().rank() - 1]),
+  auto right_arg = make_array_eval(right, right.world(), right.shape(),
+      proc_grid.make_col_phase_pmap(tr.tile_range().volume() / tr.tile_range().extent_data()[tr.tile_range().rank() - 1]),
       Permutation(), make_array_noop());
-  auto op = make_contract(2u, left_arg.trange().tiles().rank(),
-      right_arg.trange().tiles().rank());
+  auto op = make_contract(2u, left_arg.trange().tile_range().rank(),
+      right_arg.trange().tile_range().rank());
 
   const SparseShape<float> result_shape =
       left_arg.shape().gemm(right_arg.shape(), 1, op.gemm_helper());
 
   auto contract = make_contract_eval(left_arg, right_arg,
-      left_arg.get_world(), result_shape, pmap, Permutation(), op);
+      left_arg.world(), result_shape, pmap, Permutation(), op);
   using dist_eval_type = decltype(contract);
 
   // Check evaluation
@@ -400,7 +400,7 @@ BOOST_AUTO_TEST_CASE( sparse_eval )
   for(auto index : *contract.pmap()) {
     // Skip zero tiles
     if(contract.is_zero(index)) {
-      dist_eval_type::range_type range = contract.trange().make_tile_range(index);
+      dist_eval_type::range_type range = contract.trange().tile(index);
 
       BOOST_CHECK((reference.block(range.lobound_data()[0], range.lobound_data()[1],
           range.extent_data()[0], range.extent_data()[1]).array() == 0).all());
@@ -417,7 +417,7 @@ BOOST_AUTO_TEST_CASE( sparse_eval )
 
       if(!eval_tile.empty()) {
         // Check that the result tile is correctly modified.
-        BOOST_CHECK_EQUAL(eval_tile.range(), contract.trange().make_tile_range(index));
+        BOOST_CHECK_EQUAL(eval_tile.range(), contract.trange().tile(index));
         BOOST_CHECK(eigen_map(eval_tile) == reference.block(eval_tile.range().lobound_data()[0],
             eval_tile.range().lobound_data()[1], eval_tile.range().extent_data()[0], eval_tile.range().extent_data()[1]));
       }

--- a/tests/dist_eval_unary_eval.cpp
+++ b/tests/dist_eval_unary_eval.cpp
@@ -48,7 +48,7 @@ struct UnaryEvalImplFixture : public TiledRangeFixture {
   {
     // Fill array with random data
     for(TArrayI::iterator it = array.begin(); it != array.end(); ++it) {
-      TensorI tile(array.trange().tile(it.index()));
+      TensorI tile(array.trange().make_tile_range(it.index()));
       for(TensorI::iterator tile_it = tile.begin(); tile_it != tile.end(); ++tile_it)
         *tile_it = GlobalFixture::world->rand() % 101;
       *it = tile;
@@ -126,11 +126,11 @@ BOOST_AUTO_TEST_CASE( constructor )
 
   BOOST_CHECK_EQUAL(& unary.world(), GlobalFixture::world);
   BOOST_CHECK(unary.pmap() == arg.pmap());
-  BOOST_CHECK_EQUAL(unary.range(), tr.tile_range());
+  BOOST_CHECK_EQUAL(unary.range(), tr.tiles_range());
   BOOST_CHECK_EQUAL(unary.trange(), tr);
-  BOOST_CHECK_EQUAL(unary.size(), tr.tile_range().volume());
+  BOOST_CHECK_EQUAL(unary.size(), tr.tiles_range().volume());
   BOOST_CHECK(unary.is_dense());
-  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i)
+  for(std::size_t i = 0; i < tr.tiles_range().volume(); ++i)
     BOOST_CHECK(! unary.is_zero(i));
 
   BOOST_REQUIRE_NO_THROW(make_unary_eval(unary, unary.world(),
@@ -142,11 +142,11 @@ BOOST_AUTO_TEST_CASE( constructor )
 
   BOOST_CHECK_EQUAL(& unary2.world(), GlobalFixture::world);
   BOOST_CHECK(unary2.pmap() == arg.pmap());
-  BOOST_CHECK_EQUAL(unary2.range(), tr.tile_range());
+  BOOST_CHECK_EQUAL(unary2.range(), tr.tiles_range());
   BOOST_CHECK_EQUAL(unary2.trange(), tr);
-  BOOST_CHECK_EQUAL(unary2.size(), tr.tile_range().volume());
+  BOOST_CHECK_EQUAL(unary2.size(), tr.tiles_range().volume());
   BOOST_CHECK(unary2.is_dense());
-  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i)
+  for(std::size_t i = 0; i < tr.tiles_range().volume(); ++i)
     BOOST_CHECK(! unary2.is_zero(i));
 }
 
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE( eval )
     BOOST_REQUIRE_NO_THROW(eval_tile = tile.get());
 
     // Check that the result tile is correctly modified.
-    BOOST_CHECK_EQUAL(eval_tile.range(), dist_eval.trange().tile(index));
+    BOOST_CHECK_EQUAL(eval_tile.range(), dist_eval.trange().make_tile_range(index));
     BOOST_CHECK_EQUAL(eval_tile.range(), array_tile.range());
     for(std::size_t i = 0ul; i < eval_tile.size(); ++i) {
       BOOST_CHECK_EQUAL(eval_tile[i], 3 * array_tile[i]);
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE( double_eval )
     BOOST_REQUIRE_NO_THROW(eval_tile = tile.get());
 
     // Check that the result tile is correctly modified.
-    BOOST_CHECK_EQUAL(eval_tile.range(), dist_eval2.trange().tile(index));
+    BOOST_CHECK_EQUAL(eval_tile.range(), dist_eval2.trange().make_tile_range(index));
     BOOST_CHECK_EQUAL(eval_tile.range(), array_tile.range());
     for(std::size_t i = 0ul; i < eval_tile.size(); ++i) {
       BOOST_CHECK_EQUAL(eval_tile[i], 5 * 3 * array_tile[i]);
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE( perm_eval )
     BOOST_REQUIRE_NO_THROW(eval_tile = tile.get());
 
     // Check that the result tile is correctly modified.
-    BOOST_CHECK_EQUAL(eval_tile.range(), dist_eval2.trange().tile(index));
+    BOOST_CHECK_EQUAL(eval_tile.range(), dist_eval2.trange().make_tile_range(index));
     BOOST_CHECK_EQUAL(eval_tile.range(), perm * array_tile.range());
     for(std::size_t i = 0ul; i < eval_tile.size(); ++i) {
       BOOST_CHECK_EQUAL(eval_tile[perm * array_tile.range().idx(i)], 5 * 3 * array_tile[i]);

--- a/tests/distributed_storage.cpp
+++ b/tests/distributed_storage.cpp
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE( get_world )
 
 BOOST_AUTO_TEST_CASE( get_pmap )
 {
-  BOOST_CHECK_EQUAL(t.get_pmap(), pmap);
+  BOOST_CHECK_EQUAL(t.pmap(), pmap);
 }
 
 BOOST_AUTO_TEST_CASE( set_value )

--- a/tests/eigen.cpp
+++ b/tests/eigen.cpp
@@ -28,7 +28,7 @@ struct EigenFixture : public TiledRangeFixture {
   EigenFixture() :
     trange(dims.begin(), dims.begin() + 2), trange1(dims.begin(), dims.begin() + 1),
     array(*GlobalFixture::world, trange), array1(*GlobalFixture::world, trange1),
-    matrix(dims[0].element_range().second, dims[1].element_range().second), vector(dims[0].element_range().second)
+    matrix(dims[0].elements_range().second, dims[1].elements_range().second), vector(dims[0].elements_range().second)
   { }
 
 
@@ -44,7 +44,7 @@ BOOST_FIXTURE_TEST_SUITE( eigen_suite , EigenFixture )
 
 BOOST_AUTO_TEST_CASE( tile_map ) {
   // Make a tile with random data
-  Tensor<int> tensor(trange.tile(0));
+  Tensor<int> tensor(trange.make_tile_range(0));
   const Tensor<int>& ctensor = tensor;
   GlobalFixture::world->srand(27);
   for(Tensor<int>::iterator it = tensor.begin(); it != tensor.end(); ++it)
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE( tile_map ) {
 
 BOOST_AUTO_TEST_CASE( auto_tile_map ) {
   // Make a tile with random data
-  Tensor<int> tensor(trange.tile(0));
+  Tensor<int> tensor(trange.make_tile_range(0));
   const Tensor<int>& ctensor = tensor;
   GlobalFixture::world->srand(27);
   for(Tensor<int>::iterator it = tensor.begin(); it != tensor.end(); ++it)
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE( submatrix_to_tensor ) {
   // Fill the matrix with random data
   matrix = Eigen::MatrixXi::Random(matrix.rows(), matrix.cols());
   // Make a target tensor
-  Tensor<int> tensor(trange.tile(0));
+  Tensor<int> tensor(trange.make_tile_range(0));
 
   // Copy the sub matrix to the tensor objects
   BOOST_CHECK_NO_THROW(eigen_submatrix_to_tensor(matrix, tensor));
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE( submatrix_to_tensor ) {
 
 BOOST_AUTO_TEST_CASE( tensor_to_submatrix ) {
   // Fill a tensor with data
-  Tensor<int> tensor(trange.tile(0));
+  Tensor<int> tensor(trange.make_tile_range(0));
   GlobalFixture::world->srand(27);
   for(Tensor<int>::iterator it = tensor.begin(); it != tensor.end(); ++it)
     *it = GlobalFixture::world->rand();
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE( array_to_matrix ) {
     // Fill the array with random data
     GlobalFixture::world->srand(27);
     for(Range::const_iterator it = array.range().begin(); it != array.range().end(); ++it) {
-      TArrayI::value_type tile(array.trange().tile(*it));
+      TArrayI::value_type tile(array.trange().make_tile_range(*it));
       for(TArrayI::value_type::iterator tile_it = tile.begin(); tile_it != tile.end(); ++tile_it) {
         *tile_it = GlobalFixture::world->rand();
       }
@@ -214,8 +214,8 @@ BOOST_AUTO_TEST_CASE( array_to_matrix ) {
     BOOST_CHECK_NO_THROW(matrix = array_to_eigen(array));
 
     // Check that the matrix dimensions are the same as the array
-    BOOST_CHECK_EQUAL(matrix.rows(), array.trange().element_range().extent_data()[0]);
-    BOOST_CHECK_EQUAL(matrix.cols(), array.trange().element_range().extent_data()[1]);
+    BOOST_CHECK_EQUAL(matrix.rows(), array.trange().elements_range().extent_data()[0]);
+    BOOST_CHECK_EQUAL(matrix.cols(), array.trange().elements_range().extent_data()[1]);
 
 
     // Check that the data in matrix matches the data in array
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE( array_to_matrix ) {
     TArrayI::pmap_interface::const_iterator it = array.pmap()->begin();
     TArrayI::pmap_interface::const_iterator end = array.pmap()->end();
     for(; it != end; ++it) {
-      TArrayI::value_type tile(array.trange().tile(*it));
+      TArrayI::value_type tile(array.trange().make_tile_range(*it));
       for(TArrayI::value_type::iterator tile_it = tile.begin(); tile_it != tile.end(); ++tile_it) {
         *tile_it = GlobalFixture::world->rand();
       }
@@ -251,8 +251,8 @@ BOOST_AUTO_TEST_CASE( array_to_matrix ) {
 
 
     // Check that the matrix dimensions are the same as the array
-    BOOST_CHECK_EQUAL(matrix.rows(), array.trange().element_range().extent_data()[0]);
-    BOOST_CHECK_EQUAL(matrix.cols(), array.trange().element_range().extent_data()[1]);
+    BOOST_CHECK_EQUAL(matrix.rows(), array.trange().elements_range().extent_data()[0]);
+    BOOST_CHECK_EQUAL(matrix.cols(), array.trange().elements_range().extent_data()[1]);
 
     // Check that the data in vector matches the data in array
     for(Range::const_iterator it = array.range().begin(); it != array.range().end(); ++it) {
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE( array_to_vector ) {
     // Fill the array with random data
     GlobalFixture::world->srand(27);
     for(Range::const_iterator it = array1.range().begin(); it != array1.range().end(); ++it) {
-      TArrayI::value_type tile(array1.trange().tile(*it));
+      TArrayI::value_type tile(array1.trange().make_tile_range(*it));
       for(TArrayI::value_type::iterator tile_it = tile.begin(); tile_it != tile.end(); ++tile_it) {
         *tile_it = GlobalFixture::world->rand();
       }
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_CASE( array_to_vector ) {
 
 
     // Check that the matrix dimensions are the same as the array
-    BOOST_CHECK_EQUAL(vector.rows(), array1.trange().element_range().extent_data()[0]);
+    BOOST_CHECK_EQUAL(vector.rows(), array1.trange().elements_range().extent_data()[0]);
     BOOST_CHECK_EQUAL(vector.cols(), 1);
 
     // Check that the data in vector matches the data in array
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE( array_to_vector ) {
     TArrayI::pmap_interface::const_iterator it = array1.pmap()->begin();
     TArrayI::pmap_interface::const_iterator end = array1.pmap()->end();
     for(; it != end; ++it) {
-      TArrayI::value_type tile(array1.trange().tile(*it));
+      TArrayI::value_type tile(array1.trange().make_tile_range(*it));
       for(TArrayI::value_type::iterator tile_it = tile.begin(); tile_it != tile.end(); ++tile_it) {
         *tile_it = GlobalFixture::world->rand();
       }
@@ -319,7 +319,7 @@ BOOST_AUTO_TEST_CASE( array_to_vector ) {
 
 
     // Check that the matrix dimensions are the same as the array
-    BOOST_CHECK_EQUAL(vector.rows(), array1.trange().element_range().extent_data()[0]);
+    BOOST_CHECK_EQUAL(vector.rows(), array1.trange().elements_range().extent_data()[0]);
     BOOST_CHECK_EQUAL(vector.cols(), 1);
 
     // Check that the data in vector matches the data in array

--- a/tests/elemental.cpp
+++ b/tests/elemental.cpp
@@ -72,8 +72,8 @@ BOOST_AUTO_TEST_CASE(array_to_elem_test) {
   elem::DistMatrix<int> matrix(grid);
   BOOST_CHECK_NO_THROW(matrix = array_to_elem(array, grid));
   // Check dims
-  BOOST_CHECK_EQUAL(matrix.Width(), array.trange().element_range().extent_data()[0]);
-  BOOST_CHECK_EQUAL(matrix.Height(), array.trange().element_range().extent_data()[1]);
+  BOOST_CHECK_EQUAL(matrix.Width(), array.trange().elements_range().extent_data()[0]);
+  BOOST_CHECK_EQUAL(matrix.Height(), array.trange().elements_range().extent_data()[1]);
 
   check_equal(array, matrix);
   GlobalFixture::world->gop.fence();
@@ -95,8 +95,8 @@ BOOST_AUTO_TEST_CASE(elem_to_array_test) {
   elem::DistMatrix<int> matrix(grid);
   BOOST_CHECK_NO_THROW(matrix = array_to_elem(array, grid));
   // Check dims
-  BOOST_CHECK_EQUAL(matrix.Width(), array.trange().element_range().extent_data()[0]);
-  BOOST_CHECK_EQUAL(matrix.Height(), array.trange().element_range().extent_data()[1]);
+  BOOST_CHECK_EQUAL(matrix.Width(), array.trange().elements_range().extent_data()[0]);
+  BOOST_CHECK_EQUAL(matrix.Height(), array.trange().elements_range().extent_data()[1]);
 
   // Re-fill elemental matrix with other random values
   for(int i = 0; i < matrix.Width(); ++i){

--- a/tests/elemental.cpp
+++ b/tests/elemental.cpp
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(array_to_elem_test) {
   // Fill array with random data
   GlobalFixture::world->srand(27);
   for(Array<int,2>::iterator it = array.begin(); it != array.end(); ++it) {
-    Array<int, 2>::value_type tile(it.range());
+    Array<int, 2>::value_type tile(it.make_range());
     for(auto& v : tile) {
       v = GlobalFixture::world->rand();
     }
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(elem_to_array_test) {
   // Fill array with random data
   GlobalFixture::world->srand(27);
   for(Array<int,2>::iterator it = array.begin(); it != array.end(); ++it) {
-    Array<int, 2>::value_type tile(it.range());
+    Array<int, 2>::value_type tile(it.make_range());
     for(Array<int, 2>::value_type::iterator tile_it = tile.begin(); tile_it != tile.end(); ++tile_it) {
       *tile_it = GlobalFixture::world->rand();
     }

--- a/tests/elemental.cpp
+++ b/tests/elemental.cpp
@@ -72,8 +72,8 @@ BOOST_AUTO_TEST_CASE(array_to_elem_test) {
   elem::DistMatrix<int> matrix(grid);
   BOOST_CHECK_NO_THROW(matrix = array_to_elem(array, grid));
   // Check dims
-  BOOST_CHECK_EQUAL(matrix.Width(), array.trange().elements().extent_data()[0]);
-  BOOST_CHECK_EQUAL(matrix.Height(), array.trange().elements().extent_data()[1]);
+  BOOST_CHECK_EQUAL(matrix.Width(), array.trange().element_range().extent_data()[0]);
+  BOOST_CHECK_EQUAL(matrix.Height(), array.trange().element_range().extent_data()[1]);
 
   check_equal(array, matrix);
   GlobalFixture::world->gop.fence();
@@ -95,8 +95,8 @@ BOOST_AUTO_TEST_CASE(elem_to_array_test) {
   elem::DistMatrix<int> matrix(grid);
   BOOST_CHECK_NO_THROW(matrix = array_to_elem(array, grid));
   // Check dims
-  BOOST_CHECK_EQUAL(matrix.Width(), array.trange().elements().extent_data()[0]);
-  BOOST_CHECK_EQUAL(matrix.Height(), array.trange().elements().extent_data()[1]);
+  BOOST_CHECK_EQUAL(matrix.Width(), array.trange().element_range().extent_data()[0]);
+  BOOST_CHECK_EQUAL(matrix.Height(), array.trange().element_range().extent_data()[1]);
 
   // Re-fill elemental matrix with other random values
   for(int i = 0; i < matrix.Width(); ++i){
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(elem_to_array_test) {
 
   // Copy matrix to TiledArray Array
   elem_to_array(array, matrix);
-  array.get_world().gop.fence();
+  array.world().gop.fence();
 
   check_equal(array, matrix);
 }

--- a/tests/elemental.cpp
+++ b/tests/elemental.cpp
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(array_to_elem_test) {
   // Fill array with random data
   GlobalFixture::world->srand(27);
   for(Array<int,2>::iterator it = array.begin(); it != array.end(); ++it) {
-    Array<int, 2>::value_type tile(it.make_range());
+    Array<int, 2>::value_type tile(it.range());
     for(auto& v : tile) {
       v = GlobalFixture::world->rand();
     }
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(elem_to_array_test) {
   // Fill array with random data
   GlobalFixture::world->srand(27);
   for(Array<int,2>::iterator it = array.begin(); it != array.end(); ++it) {
-    Array<int, 2>::value_type tile(it.make_range());
+    Array<int, 2>::value_type tile(it.range());
     for(Array<int, 2>::value_type::iterator tile_it = tile.begin(); tile_it != tile.end(); ++tile_it) {
       *tile_it = GlobalFixture::world->rand();
     }

--- a/tests/expressions.cpp
+++ b/tests/expressions.cpp
@@ -52,7 +52,7 @@ struct ExpressionsFixture : public TiledRangeFixture {
     typename DistArray<Tile>::pmap_interface::const_iterator end = array.pmap()->end();
     for(; it != end; ++it)
       array.set(*it, array.world().taskq.add(& ExpressionsFixture::template make_rand_tile<DistArray<Tile> >,
-          array.trange().tile(*it)));
+          array.trange().make_tile_range(*it)));
   }
 
 
@@ -80,16 +80,16 @@ struct ExpressionsFixture : public TiledRangeFixture {
 
   template <typename M, typename A>
   static void rand_fill_matrix_and_array(M& matrix, A& array, int seed = 42) {
-    TA_ASSERT(std::size_t(matrix.size()) == array.trange().element_range().volume());
+    TA_ASSERT(std::size_t(matrix.size()) == array.trange().elements_range().volume());
     matrix.fill(0);
 
     GlobalFixture::world->srand(seed);
 
     // Iterate over local tiles
     for(typename A::iterator it = array.begin(); it != array.end(); ++it) {
-      typename A::value_type tile(array.trange().tile(it.index()));
+      typename A::value_type tile(array.trange().make_tile_range(it.index()));
       for(Range::const_iterator rit = tile.range().begin(); rit != tile.range().end(); ++rit) {
-        const std::size_t elem_index = array.element_range().ordinal(*rit);
+        const std::size_t elem_index = array.elements_range().ordinal(*rit);
         tile[*rit] = (matrix.array()(elem_index) = (GlobalFixture::world->rand() % 101));
       }
       *it = tile;
@@ -104,8 +104,8 @@ struct ExpressionsFixture : public TiledRangeFixture {
 
     // Construct the Eigen matrix
     Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic>
-        matrix(array.trange().element_range().extent_data()[0],
-            (array.trange().tile_range().rank() == 2 ? array.trange().element_range().extent_data()[1] : 1));
+        matrix(array.trange().elements_range().extent_data()[0],
+            (array.trange().tiles_range().rank() == 2 ? array.trange().elements_range().extent_data()[1] : 1));
 
     // Spawn tasks to copy array tiles to the Eigen matrix
     for(std::size_t i = 0; i < array.size(); ++i) {
@@ -496,7 +496,7 @@ BOOST_AUTO_TEST_CASE( block )
 {
   BOOST_REQUIRE_NO_THROW(c("a,b,c") = a("a,b,c").block({3,3,3}, {5,5,5}));
 
-  BlockRange block_range(a.trange().tile_range(), {3,3,3}, {5,5,5});
+  BlockRange block_range(a.trange().tiles_range(), {3,3,3}, {5,5,5});
 
   for(std::size_t index = 0ul; index < block_range.volume(); ++index) {
     Tensor<int> arg_tile = a.find(block_range.ordinal(index)).get();
@@ -529,7 +529,7 @@ BOOST_AUTO_TEST_CASE( const_block )
   const TArrayI& ca = a;
   BOOST_REQUIRE_NO_THROW(c("a,b,c") = ca("a,b,c").block({3,3,3}, {5,5,5}));
 
-  BlockRange block_range(a.trange().tile_range(), {3,3,3}, {5,5,5});
+  BlockRange block_range(a.trange().tiles_range(), {3,3,3}, {5,5,5});
 
   for(std::size_t index = 0ul; index < block_range.volume(); ++index) {
     Tensor<int> arg_tile = a.find(block_range.ordinal(index)).get();
@@ -561,7 +561,7 @@ BOOST_AUTO_TEST_CASE( scal_block )
 {
   BOOST_REQUIRE_NO_THROW(c("a,b,c") = 2 * a("a,b,c").block({3,3,3}, {5,5,5}));
 
-  BlockRange block_range(a.trange().tile_range(), {3,3,3}, {5,5,5});
+  BlockRange block_range(a.trange().tiles_range(), {3,3,3}, {5,5,5});
 
   for(std::size_t index = 0ul; index < block_range.volume(); ++index) {
     Tensor<int> arg_tile = a.find(block_range.ordinal(index)).get();
@@ -594,7 +594,7 @@ BOOST_AUTO_TEST_CASE( assign_sub_block )
 
   BOOST_REQUIRE_NO_THROW(c("a,b,c").block({3,3,3}, {5,5,5}) = 2 * a("a,b,c").block({3,3,3}, {5,5,5}));
 
-  BlockRange block_range(a.trange().tile_range(), {3,3,3}, {5,5,5});
+  BlockRange block_range(a.trange().tiles_range(), {3,3,3}, {5,5,5});
 
   for(std::size_t index = 0ul; index < block_range.volume(); ++index) {
     Tensor<int> arg_tile = a.find(block_range.ordinal(index)).get();
@@ -990,9 +990,9 @@ BOOST_AUTO_TEST_CASE( scale_mult )
 
 BOOST_AUTO_TEST_CASE( cont )
 {
-  const std::size_t m = a.trange().element_range().extent_data()[0];
-  const std::size_t k = a.trange().element_range().extent_data()[1] * a.trange().element_range().extent_data()[2];
-  const std::size_t n = b.trange().element_range().extent_data()[2];
+  const std::size_t m = a.trange().elements_range().extent_data()[0];
+  const std::size_t k = a.trange().elements_range().extent_data()[1] * a.trange().elements_range().extent_data()[2];
+  const std::size_t n = b.trange().elements_range().extent_data()[2];
 
   TiledArray::EigenMatrixXi left(m, k);
   left.fill(0);
@@ -1006,8 +1006,8 @@ BOOST_AUTO_TEST_CASE( cont )
       const std::size_t r = i[0];
       for(i[1] = tile.range().lobound_data()[1]; i[1] < tile.range().upbound_data()[1]; ++i[1]) {
         for(i[2] = tile.range().lobound_data()[2]; i[2] < tile.range().upbound_data()[2]; ++i[2]) {
-          const std::size_t c = i[1] * a.trange().element_range().stride_data()[1]
-                              + i[2] * a.trange().element_range().stride_data()[2];
+          const std::size_t c = i[1] * a.trange().elements_range().stride_data()[1]
+                              + i[2] * a.trange().elements_range().stride_data()[2];
 
           left(r, c) = tile[i];
         }
@@ -1029,8 +1029,8 @@ BOOST_AUTO_TEST_CASE( cont )
       const std::size_t r = i[0];
       for(i[1] = tile.range().lobound_data()[1]; i[1] < tile.range().upbound_data()[1]; ++i[1]) {
         for(i[2] = tile.range().lobound_data()[2]; i[2] < tile.range().upbound_data()[2]; ++i[2]) {
-          const std::size_t c = i[1] * a.trange().element_range().stride_data()[1]
-                              + i[2] * a.trange().element_range().stride_data()[2];
+          const std::size_t c = i[1] * a.trange().elements_range().stride_data()[1]
+                              + i[2] * a.trange().elements_range().stride_data()[2];
 
           right(r, c) = tile[i];
         }
@@ -1101,9 +1101,9 @@ BOOST_AUTO_TEST_CASE( cont )
 
 BOOST_AUTO_TEST_CASE( scale_cont )
 {
-  const std::size_t m = a.trange().element_range().extent_data()[0];
-  const std::size_t k = a.trange().element_range().extent_data()[1] * a.trange().element_range().extent_data()[2];
-  const std::size_t n = b.trange().element_range().extent_data()[2];
+  const std::size_t m = a.trange().elements_range().extent_data()[0];
+  const std::size_t k = a.trange().elements_range().extent_data()[1] * a.trange().elements_range().extent_data()[2];
+  const std::size_t n = b.trange().elements_range().extent_data()[2];
 
   TiledArray::EigenMatrixXi left(m, k);
   left.fill(0);
@@ -1117,8 +1117,8 @@ BOOST_AUTO_TEST_CASE( scale_cont )
       const std::size_t r = i[0];
       for(i[1] = tile.range().lobound_data()[1]; i[1] < tile.range().upbound_data()[1]; ++i[1]) {
         for(i[2] = tile.range().lobound_data()[2]; i[2] < tile.range().upbound_data()[2]; ++i[2]) {
-          const std::size_t c = i[1] * a.trange().element_range().stride_data()[1]
-                              + i[2] * a.trange().element_range().stride_data()[2];
+          const std::size_t c = i[1] * a.trange().elements_range().stride_data()[1]
+                              + i[2] * a.trange().elements_range().stride_data()[2];
 
           left(r, c) = tile[i];
         }
@@ -1140,8 +1140,8 @@ BOOST_AUTO_TEST_CASE( scale_cont )
       const std::size_t r = i[0];
       for(i[1] = tile.range().lobound_data()[1]; i[1] < tile.range().upbound_data()[1]; ++i[1]) {
         for(i[2] = tile.range().lobound_data()[2]; i[2] < tile.range().upbound_data()[2]; ++i[2]) {
-          const std::size_t c = i[1] * a.trange().element_range().stride_data()[1]
-                              + i[2] * a.trange().element_range().stride_data()[2];
+          const std::size_t c = i[1] * a.trange().elements_range().stride_data()[1]
+                              + i[2] * a.trange().elements_range().stride_data()[2];
 
           right(r, c) = tile[i];
         }
@@ -1250,7 +1250,7 @@ BOOST_AUTO_TEST_CASE( cont_non_uniform1 )
   for(TArrayI::iterator it = result.begin(); it != result.end(); ++it) {
     const TArrayI::value_type tile = *it;
     for(Range::const_iterator rit = tile.range().begin(); rit != tile.range().end(); ++rit) {
-      const std::size_t elem_index = result.element_range().ordinal(*rit);
+      const std::size_t elem_index = result.elements_range().ordinal(*rit);
       BOOST_CHECK_EQUAL(result_ref.array()(elem_index), tile[*rit]);
     }
   }
@@ -1294,7 +1294,7 @@ BOOST_AUTO_TEST_CASE( cont_non_uniform2 )
   for(TArrayI::iterator it = result.begin(); it != result.end(); ++it) {
     const TArrayI::value_type tile = *it;
     for(Range::const_iterator rit = tile.range().begin(); rit != tile.range().end(); ++rit) {
-      const std::size_t elem_index = result.element_range().ordinal(*rit);
+      const std::size_t elem_index = result.elements_range().ordinal(*rit);
       BOOST_CHECK_EQUAL(result_ref.array()(elem_index), tile[*rit]);
     }
   }
@@ -1353,7 +1353,7 @@ BOOST_AUTO_TEST_CASE( cont_plus_reduce )
   for(TArrayI::iterator it = result.begin(); it != result.end(); ++it) {
     const TArrayI::value_type tile = *it;
     for(Range::const_iterator rit = tile.range().begin(); rit != tile.range().end(); ++rit) {
-      const std::size_t elem_index = result.element_range().ordinal(*rit);
+      const std::size_t elem_index = result.elements_range().ordinal(*rit);
       BOOST_CHECK_EQUAL(result_ref.array()(elem_index), tile[*rit]);
     }
   }
@@ -1412,7 +1412,7 @@ BOOST_AUTO_TEST_CASE( no_alias_plus_reduce )
   for(TArrayI::iterator it = result.begin(); it != result.end(); ++it) {
     const TArrayI::value_type tile = *it;
     for(Range::const_iterator rit = tile.range().begin(); rit != tile.range().end(); ++rit) {
-      const std::size_t elem_index = result.element_range().ordinal(*rit);
+      const std::size_t elem_index = result.elements_range().ordinal(*rit);
       BOOST_CHECK_EQUAL(result_ref.array()(elem_index), tile[*rit]);
     }
   }

--- a/tests/range_fixture.h
+++ b/tests/range_fixture.h
@@ -100,23 +100,23 @@ struct TiledRangeFixtureBase : public Range1Fixture {
 
 struct TiledRangeFixture : public RangeFixture, public TiledRangeFixtureBase {
   typedef TiledRange TRangeN;
-  typedef TRangeN::tile_range_type::index tile_index;
+  typedef TRangeN::tiles_range_type::index tile_index;
 
 
   TiledRangeFixture() :
-    tile_range(TiledRangeFixture::index(GlobalFixture::dim, 0),
+    tiles_range(TiledRangeFixture::index(GlobalFixture::dim, 0),
         TiledRangeFixture::index(GlobalFixture::dim, 5)),
-    element_range(TiledRangeFixture::tile_index(GlobalFixture::dim, 0),
+    elements_range(TiledRangeFixture::tile_index(GlobalFixture::dim, 0),
         TiledRangeFixture::tile_index(GlobalFixture::dim, a[5])),
     tr(dims.begin(), dims.end())
   { }
 
   ~TiledRangeFixture() { }
 
-  static tile_index fill_tile_index(TRangeN::tile_range_type::index::value_type);
+  static tile_index fill_tile_index(TRangeN::tiles_range_type::index::value_type);
 
-  const TRangeN::range_type tile_range;
-  const TRangeN::tile_range_type element_range;
+  const TRangeN::range_type tiles_range;
+  const TRangeN::tiles_range_type elements_range;
   TRangeN tr;
 };
 

--- a/tests/sparse_shape.cpp
+++ b/tests/sparse_shape.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE( default_constructor )
 
   BOOST_CHECK(x.empty());
   BOOST_CHECK(! x.is_dense());
-  BOOST_CHECK(! x.validate(tr.tiles()));
+  BOOST_CHECK(! x.validate(tr.tile_range()));
 
 #ifdef TA_EXCEPTION_ERROR
   BOOST_CHECK_THROW(x[0], Exception);
@@ -88,13 +88,13 @@ BOOST_AUTO_TEST_CASE( non_comm_constructor )
   // Check that the shape has been initialized
   BOOST_CHECK(! x.empty());
   BOOST_CHECK(! x.is_dense());
-  BOOST_CHECK(x.validate(tr.tiles()));
+  BOOST_CHECK(x.validate(tr.tile_range()));
 
   size_type zero_tile_count = 0ul;
 
   for(Tensor<float>::size_type i = 0ul; i < tile_norms.size(); ++i) {
     // Compute the expected value
-    const TiledRange::range_type range = tr.make_tile_range(i);
+    const TiledRange::range_type range = tr.tile(i);
     float expected = tile_norms[i] / float(range.volume());
     if(expected < SparseShape<float>::threshold())
       expected = 0.0f;
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE( non_comm_constructor )
     }
   }
 
-  BOOST_CHECK_CLOSE(x.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(x.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE( comm_constructor )
   Tensor<float> tile_norms_ref = tile_norms.clone();
 
   // Zero non-local tiles
-  TiledArray::detail::BlockedPmap pmap(*GlobalFixture::world, tr.tiles().volume());
+  TiledArray::detail::BlockedPmap pmap(*GlobalFixture::world, tr.tile_range().volume());
   for(Tensor<float>::size_type i = 0ul; i < tile_norms.size(); ++i)
     if(! pmap.is_local(i))
       tile_norms[i] = 0.0f;
@@ -134,13 +134,13 @@ BOOST_AUTO_TEST_CASE( comm_constructor )
   // Check that the shape has been initialized
   BOOST_CHECK(! x.empty());
   BOOST_CHECK(! x.is_dense());
-  BOOST_CHECK(x.validate(tr.tiles()));
+  BOOST_CHECK(x.validate(tr.tile_range()));
 
   size_type zero_tile_count = 0ul;
 
   for(Tensor<float>::size_type i = 0ul; i < tile_norms.size(); ++i) {
     // Compute the expected value
-    const TiledRange::range_type range = tr.make_tile_range(i);
+    const TiledRange::range_type range = tr.tile(i);
     float expected = tile_norms_ref[i] / float(range.volume());
     if(expected < SparseShape<float>::threshold())
       expected = 0.0f;
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE( comm_constructor )
     }
   }
 
-  BOOST_CHECK_CLOSE(x.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(x.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 
@@ -170,10 +170,10 @@ BOOST_AUTO_TEST_CASE( copy_constructor )
   // Check that the shape has been initialized
   BOOST_CHECK(! y.empty());
   BOOST_CHECK(! y.is_dense());
-  BOOST_CHECK(y.validate(tr.tiles()));
+  BOOST_CHECK(y.validate(tr.tile_range()));
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Check that the tile data has been copied correctly
     BOOST_CHECK_CLOSE(y[i], sparse_shape[i], tolerance);
   }
@@ -187,8 +187,8 @@ BOOST_AUTO_TEST_CASE( permute )
   BOOST_REQUIRE_NO_THROW(result = sparse_shape.perm(perm));
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
-    BOOST_CHECK_CLOSE(result[perm * tr.tiles().idx(i)], sparse_shape[i], tolerance);
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
+    BOOST_CHECK_CLOSE(result[perm * tr.tile_range().idx(i)], sparse_shape[i], tolerance);
   }
 
   BOOST_CHECK_EQUAL(result.sparsity(), sparse_shape.sparsity());
@@ -198,10 +198,10 @@ BOOST_AUTO_TEST_CASE( block )
 {
   auto less = std::less<std::size_t>();
 
-  for(auto lower_it = tr.tiles().begin(); lower_it != tr.tiles().end(); ++lower_it) {
+  for(auto lower_it = tr.tile_range().begin(); lower_it != tr.tile_range().end(); ++lower_it) {
     const auto& lower = *lower_it;
 
-    for(auto upper_it = tr.tiles().begin(); upper_it != tr.tiles().end(); ++upper_it) {
+    for(auto upper_it = tr.tile_range().begin(); upper_it != tr.tile_range().end(); ++upper_it) {
       std::vector<std::size_t> upper = *upper_it;
       for(auto it = upper.begin(); it != upper.end(); ++it)
         *it += 1;
@@ -213,7 +213,7 @@ BOOST_AUTO_TEST_CASE( block )
 
         // Check that the block range data is correct
         std::size_t volume = 1ul;
-        for(int i = int(tr.tiles().rank()) - 1u; i >= 0; --i) {
+        for(int i = int(tr.tile_range().rank()) - 1u; i >= 0; --i) {
           auto size_i = upper[i] - lower[i];
           BOOST_CHECK_EQUAL(result.data().range().lobound_data()[i], 0);
           BOOST_CHECK_EQUAL(result.data().range().upbound_data()[i], size_i);
@@ -256,10 +256,10 @@ BOOST_AUTO_TEST_CASE( block_scale )
   auto less = std::less<std::size_t>();
   const float factor = 3.3;
 
-  for(auto lower_it = tr.tiles().begin(); lower_it != tr.tiles().end(); ++lower_it) {
+  for(auto lower_it = tr.tile_range().begin(); lower_it != tr.tile_range().end(); ++lower_it) {
     const auto& lower = *lower_it;
 
-    for(auto upper_it = tr.tiles().begin(); upper_it != tr.tiles().end(); ++upper_it) {
+    for(auto upper_it = tr.tile_range().begin(); upper_it != tr.tile_range().end(); ++upper_it) {
       std::vector<std::size_t> upper = *upper_it;
       for(auto it = upper.begin(); it != upper.end(); ++it)
         *it += 1;
@@ -272,7 +272,7 @@ BOOST_AUTO_TEST_CASE( block_scale )
 
         // Check that the block range data is correct
         std::size_t volume = 1ul;
-        for(int i = int(tr.tiles().rank()) - 1u; i >= 0; --i) {
+        for(int i = int(tr.tile_range().rank()) - 1u; i >= 0; --i) {
           auto size_i = upper[i] - lower[i];
           BOOST_CHECK_EQUAL(result.data().range().lobound_data()[i], 0);
           BOOST_CHECK_EQUAL(result.data().range().upbound_data()[i], size_i);
@@ -317,10 +317,10 @@ BOOST_AUTO_TEST_CASE( block_perm )
   auto less = std::less<std::size_t>();
   const auto inv_perm = perm.inv();
 
-  for(auto lower_it = tr.tiles().begin(); lower_it != tr.tiles().end(); ++lower_it) {
+  for(auto lower_it = tr.tile_range().begin(); lower_it != tr.tile_range().end(); ++lower_it) {
     const auto& lower = *lower_it;
 
-    for(auto upper_it = tr.tiles().begin(); upper_it != tr.tiles().end(); ++upper_it) {
+    for(auto upper_it = tr.tile_range().begin(); upper_it != tr.tile_range().end(); ++upper_it) {
       std::vector<std::size_t> upper = *upper_it;
       for(auto it = upper.begin(); it != upper.end(); ++it)
         *it += 1;
@@ -333,7 +333,7 @@ BOOST_AUTO_TEST_CASE( block_perm )
 
         // Check that the block range data is correct
         std::size_t volume = 1ul;
-        for(int i = int(tr.tiles().rank()) - 1u; i >= 0; --i) {
+        for(int i = int(tr.tile_range().rank()) - 1u; i >= 0; --i) {
           const auto inv_perm_i = inv_perm[i];
           const auto size_i = upper[inv_perm_i] - lower[inv_perm_i];
           BOOST_CHECK_EQUAL(result.data().range().lobound_data()[i], 0);
@@ -380,10 +380,10 @@ BOOST_AUTO_TEST_CASE( block_scale_perm )
   const float factor = 3.3;
   const auto inv_perm = perm.inv();
 
-  for(auto lower_it = tr.tiles().begin(); lower_it != tr.tiles().end(); ++lower_it) {
+  for(auto lower_it = tr.tile_range().begin(); lower_it != tr.tile_range().end(); ++lower_it) {
     const auto& lower = *lower_it;
 
-    for(auto upper_it = tr.tiles().begin(); upper_it != tr.tiles().end(); ++upper_it) {
+    for(auto upper_it = tr.tile_range().begin(); upper_it != tr.tile_range().end(); ++upper_it) {
       std::vector<std::size_t> upper = *upper_it;
       for(auto it = upper.begin(); it != upper.end(); ++it)
         *it += 1;
@@ -396,7 +396,7 @@ BOOST_AUTO_TEST_CASE( block_scale_perm )
 
         // Check that the block range data is correct
         std::size_t volume = 1ul;
-        for(int i = int(tr.tiles().rank()) - 1u; i >= 0; --i) {
+        for(int i = int(tr.tile_range().rank()) - 1u; i >= 0; --i) {
           const auto inv_perm_i = inv_perm[i];
           const auto size_i = upper[inv_perm_i] - lower[inv_perm_i];
           BOOST_CHECK_EQUAL(result.data().range().lobound_data()[i], 0);
@@ -461,7 +461,7 @@ BOOST_AUTO_TEST_CASE( transform )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
     
     float expected;
@@ -487,7 +487,7 @@ BOOST_AUTO_TEST_CASE( transform )
   }
 
   BOOST_CHECK_CLOSE(result.sparsity(), 
-          float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+          float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( mask )
@@ -496,14 +496,14 @@ BOOST_AUTO_TEST_CASE( mask )
   BOOST_REQUIRE_NO_THROW(result = left.mask(right));
 
   size_type zero_tile_count = 0ul;
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
       if(left.is_zero(i)){
           ++zero_tile_count;
       }
   }
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     auto threshold = SparseShape<float>::threshold();
     float expected = left[i];
     if(left[i] >= threshold && right[i] < threshold){
@@ -521,7 +521,7 @@ BOOST_AUTO_TEST_CASE( mask )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( scale )
@@ -532,7 +532,7 @@ BOOST_AUTO_TEST_CASE( scale )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
     float expected = sparse_shape[i] * 4.1;
     if(expected < SparseShape<float>::threshold())
@@ -551,7 +551,7 @@ BOOST_AUTO_TEST_CASE( scale )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( scale_perm )
@@ -562,7 +562,7 @@ BOOST_AUTO_TEST_CASE( scale_perm )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
     float expected = sparse_shape[i] * 5.4;
     if(expected < SparseShape<float>::threshold())
@@ -581,7 +581,7 @@ BOOST_AUTO_TEST_CASE( scale_perm )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( add )
@@ -592,7 +592,7 @@ BOOST_AUTO_TEST_CASE( add )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
     float expected = left[i] + right[i];
     if(expected < SparseShape<float>::threshold())
@@ -611,7 +611,7 @@ BOOST_AUTO_TEST_CASE( add )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( add_scale )
@@ -622,7 +622,7 @@ BOOST_AUTO_TEST_CASE( add_scale )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
     float expected = (left[i] + right[i]) * 2.2f;
     if(expected < SparseShape<float>::threshold())
@@ -641,7 +641,7 @@ BOOST_AUTO_TEST_CASE( add_scale )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( add_perm )
@@ -652,7 +652,7 @@ BOOST_AUTO_TEST_CASE( add_perm )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
     float expected = left[i] + right[i];
     if(expected < SparseShape<float>::threshold())
@@ -672,7 +672,7 @@ BOOST_AUTO_TEST_CASE( add_perm )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( add_scale_perm )
@@ -683,7 +683,7 @@ BOOST_AUTO_TEST_CASE( add_scale_perm )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
     float expected = (left[i] + right[i]) * 2.3f;
     if(expected < SparseShape<float>::threshold())
@@ -703,7 +703,7 @@ BOOST_AUTO_TEST_CASE( add_scale_perm )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( add_const )
@@ -714,9 +714,9 @@ BOOST_AUTO_TEST_CASE( add_const )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
-    const TiledRange::range_type range = tr.make_tile_range(i);
+    const TiledRange::range_type range = tr.tile(i);
     float expected = sparse_shape[i] + std::sqrt((8.8f * 8.8f) *
         float(range.volume())) / float(range.volume());
     if(expected < SparseShape<float>::threshold())
@@ -735,7 +735,7 @@ BOOST_AUTO_TEST_CASE( add_const )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( add_const_perm )
@@ -746,9 +746,9 @@ BOOST_AUTO_TEST_CASE( add_const_perm )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
-    const TiledRange::range_type range = tr.make_tile_range(i);
+    const TiledRange::range_type range = tr.tile(i);
     float expected = sparse_shape[i] + std::sqrt((1.7f * 1.7f) *
         range.volume()) / range.volume();
     if(expected < SparseShape<float>::threshold())
@@ -768,7 +768,7 @@ BOOST_AUTO_TEST_CASE( add_const_perm )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( subt )
@@ -779,7 +779,7 @@ BOOST_AUTO_TEST_CASE( subt )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
     float expected = left[i] + right[i];
     if(expected < SparseShape<float>::threshold())
@@ -798,7 +798,7 @@ BOOST_AUTO_TEST_CASE( subt )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( subt_scale )
@@ -809,7 +809,7 @@ BOOST_AUTO_TEST_CASE( subt_scale )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
     float expected = (left[i] + right[i]) * 2.2f;
     if(expected < SparseShape<float>::threshold())
@@ -828,7 +828,7 @@ BOOST_AUTO_TEST_CASE( subt_scale )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( subt_perm )
@@ -839,7 +839,7 @@ BOOST_AUTO_TEST_CASE( subt_perm )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
     float expected = left[i] + right[i];
     if(expected < SparseShape<float>::threshold())
@@ -859,7 +859,7 @@ BOOST_AUTO_TEST_CASE( subt_perm )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( subt_scale_perm )
@@ -870,7 +870,7 @@ BOOST_AUTO_TEST_CASE( subt_scale_perm )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
     float expected = (left[i] + right[i]) * 2.3f;
     if(expected < SparseShape<float>::threshold())
@@ -890,7 +890,7 @@ BOOST_AUTO_TEST_CASE( subt_scale_perm )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( subt_const )
@@ -901,9 +901,9 @@ BOOST_AUTO_TEST_CASE( subt_const )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
-    const TiledRange::range_type range = tr.make_tile_range(i);
+    const TiledRange::range_type range = tr.tile(i);
     float expected = sparse_shape[i] + std::sqrt((8.8f * 8.8f) *
         float(range.volume())) / float(range.volume());
     if(expected < SparseShape<float>::threshold())
@@ -920,7 +920,7 @@ BOOST_AUTO_TEST_CASE( subt_const )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( subt_const_perm )
@@ -931,9 +931,9 @@ BOOST_AUTO_TEST_CASE( subt_const_perm )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
-    const TiledRange::range_type range = tr.make_tile_range(i);
+    const TiledRange::range_type range = tr.tile(i);
     float expected = sparse_shape[i] + std::sqrt((1.7f * 1.7f) *
         float(range.volume())) / float(range.volume());
     if(expected < SparseShape<float>::threshold())
@@ -953,7 +953,7 @@ BOOST_AUTO_TEST_CASE( subt_const_perm )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( mult )
@@ -964,9 +964,9 @@ BOOST_AUTO_TEST_CASE( mult )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
-    const TiledRange::range_type range = tr.make_tile_range(i);
+    const TiledRange::range_type range = tr.tile(i);
     float expected = left[i] * right[i] * float(range.volume());
     if(expected < SparseShape<float>::threshold())
       expected = 0.0f;
@@ -982,7 +982,7 @@ BOOST_AUTO_TEST_CASE( mult )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( mult_scale )
@@ -993,9 +993,9 @@ BOOST_AUTO_TEST_CASE( mult_scale )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
-    const TiledRange::range_type range = tr.make_tile_range(i);
+    const TiledRange::range_type range = tr.tile(i);
     float expected = (left[i] * right[i]) * 2.2f * float(range.volume());
     if(expected < SparseShape<float>::threshold())
       expected = 0.0f;
@@ -1011,7 +1011,7 @@ BOOST_AUTO_TEST_CASE( mult_scale )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( mult_perm )
@@ -1022,9 +1022,9 @@ BOOST_AUTO_TEST_CASE( mult_perm )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
-    const TiledRange::range_type range = tr.make_tile_range(i);
+    const TiledRange::range_type range = tr.tile(i);
     float expected = left[i] * right[i] * float(range.volume());
     if(expected < SparseShape<float>::threshold())
       expected = 0.0f;
@@ -1043,7 +1043,7 @@ BOOST_AUTO_TEST_CASE( mult_perm )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( mult_scale_perm )
@@ -1054,9 +1054,9 @@ BOOST_AUTO_TEST_CASE( mult_scale_perm )
   size_type zero_tile_count = 0ul;
 
   // Check that all the tiles have been normalized correctly
-  for(Tensor<float>::size_type i = 0ul; i < tr.tiles().volume(); ++i) {
+  for(Tensor<float>::size_type i = 0ul; i < tr.tile_range().volume(); ++i) {
     // Compute expected value
-    const TiledRange::range_type range = tr.make_tile_range(i);
+    const TiledRange::range_type range = tr.tile(i);
     float expected = (left[i] * right[i]) * 2.3f * float(range.volume());
     if(expected < SparseShape<float>::threshold())
       expected = 0.0f;
@@ -1075,7 +1075,7 @@ BOOST_AUTO_TEST_CASE( mult_scale_perm )
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tiles().volume()), tolerance);
+  BOOST_CHECK_CLOSE(result.sparsity(), float(zero_tile_count) / float(tr.tile_range().volume()), tolerance);
 }
 
 BOOST_AUTO_TEST_CASE( gemm )
@@ -1094,9 +1094,9 @@ BOOST_AUTO_TEST_CASE( gemm )
   BOOST_REQUIRE_NO_THROW(result = left.gemm(right, -7.2, gemm_helper));
 
   // Create volumes tensors for the arguments
-  Tensor<float> volumes(tr.tiles(), 0.0f);
-  for(std::size_t i = 0ul; i < tr.tiles().volume(); ++i) {
-    const float volume = tr.make_tile_range(i).volume();
+  Tensor<float> volumes(tr.tile_range(), 0.0f);
+  for(std::size_t i = 0ul; i < tr.tile_range().volume(); ++i) {
+    const float volume = tr.tile(i).volume();
     volumes[i] = volume;
   }
 
@@ -1153,9 +1153,9 @@ BOOST_AUTO_TEST_CASE( gemm_perm )
   BOOST_REQUIRE_NO_THROW(result = left.gemm(right, -7.2, gemm_helper, perm));
 
   // Create volumes tensors for the arguments
-  Tensor<float> volumes(tr.tiles(), 0.0f);
-  for(std::size_t i = 0ul; i < tr.tiles().volume(); ++i) {
-    const float volume = tr.make_tile_range(i).volume();
+  Tensor<float> volumes(tr.tile_range(), 0.0f);
+  for(std::size_t i = 0ul; i < tr.tile_range().volume(); ++i) {
+    const float volume = tr.tile(i).volume();
     volumes[i] = volume;
   }
 

--- a/tests/sparse_shape_fixture.h
+++ b/tests/sparse_shape_fixture.h
@@ -40,7 +40,7 @@ namespace TiledArray {
       left(make_shape(tr, 0.1, 23)),
       right(make_shape(tr, 0.1, 82)),
       perm(make_perm()),
-      perm_index(tr.tile_range(), perm),
+      perm_index(tr.tiles_range(), perm),
       tolerance(0.0001)
 
     {
@@ -52,9 +52,9 @@ namespace TiledArray {
 
     static Tensor<float> make_norm_tensor(const TiledRange& trange, const float fill_percent, const int seed) {
       GlobalFixture::world->srand(seed);
-      Tensor<float> norms(trange.tile_range());
+      Tensor<float> norms(trange.tiles_range());
       for(Tensor<float>::size_type i = 0ul; i < norms.size(); ++i) {
-        const Range range = trange.tile(i);
+        const Range range = trange.make_tile_range(i);
         norms[i] = (GlobalFixture::world->rand() % 101);
         norms[i] = std::sqrt(norms[i] * norms[i] * range.volume());
       }

--- a/tests/sparse_shape_fixture.h
+++ b/tests/sparse_shape_fixture.h
@@ -40,7 +40,7 @@ namespace TiledArray {
       left(make_shape(tr, 0.1, 23)),
       right(make_shape(tr, 0.1, 82)),
       perm(make_perm()),
-      perm_index(tr.tiles(), perm),
+      perm_index(tr.tile_range(), perm),
       tolerance(0.0001)
 
     {
@@ -52,9 +52,9 @@ namespace TiledArray {
 
     static Tensor<float> make_norm_tensor(const TiledRange& trange, const float fill_percent, const int seed) {
       GlobalFixture::world->srand(seed);
-      Tensor<float> norms(trange.tiles());
+      Tensor<float> norms(trange.tile_range());
       for(Tensor<float>::size_type i = 0ul; i < norms.size(); ++i) {
-        const Range range = trange.make_tile_range(i);
+        const Range range = trange.tile(i);
         norms[i] = (GlobalFixture::world->rand() % 101);
         norms[i] = std::sqrt(norms[i] * norms[i] * range.volume());
       }

--- a/tests/tensor_impl.cpp
+++ b/tests/tensor_impl.cpp
@@ -27,7 +27,7 @@ using namespace TiledArray;
 struct TensorImplBaseFixture : public SparseShapeFixture {
   typedef detail::TensorImpl<DensePolicy> tensor_impl_base;
   TensorImplBaseFixture() :
-    pmap(new detail::HashPmap(* GlobalFixture::world, tr.tile_range().volume()))
+    pmap(new detail::HashPmap(* GlobalFixture::world, tr.tiles_range().volume()))
   { }
 
   std::shared_ptr<tensor_impl_base::pmap_interface> pmap;
@@ -64,11 +64,11 @@ BOOST_AUTO_TEST_CASE( constructor_dense_policy )
   // Check that the initial conditions are correct after construction.
   BOOST_CHECK_EQUAL(& x.world(), GlobalFixture::world);
   BOOST_CHECK(x.pmap() == pmap);
-  BOOST_CHECK_EQUAL(x.range(), tr.tile_range());
+  BOOST_CHECK_EQUAL(x.range(), tr.tiles_range());
   BOOST_CHECK_EQUAL(x.trange(), tr);
-  BOOST_CHECK_EQUAL(x.size(), tr.tile_range().volume());
+  BOOST_CHECK_EQUAL(x.size(), tr.tiles_range().volume());
   BOOST_CHECK(x.is_dense());
-  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i)
+  for(std::size_t i = 0; i < tr.tiles_range().volume(); ++i)
     BOOST_CHECK(! x.is_zero(i));
 }
 
@@ -80,11 +80,11 @@ BOOST_AUTO_TEST_CASE( constructor_shape_policy )
   // Check that the initial conditions are correct after construction.
   BOOST_CHECK_EQUAL(& x.world(), GlobalFixture::world);
   BOOST_CHECK(x.pmap() == pmap);
-  BOOST_CHECK_EQUAL(x.range(), tr.tile_range());
+  BOOST_CHECK_EQUAL(x.range(), tr.tiles_range());
   BOOST_CHECK_EQUAL(x.trange(), tr);
-  BOOST_CHECK_EQUAL(x.size(), tr.tile_range().volume());
+  BOOST_CHECK_EQUAL(x.size(), tr.tiles_range().volume());
   BOOST_CHECK(! x.is_dense());
-  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tiles_range().volume(); ++i) {
     if(x.shape()[i] < SparseShape<float>::threshold()) {
       BOOST_CHECK(x.is_zero(i));
     } else {
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE( process_map )
   BOOST_CHECK(impl.pmap() == pmap);
 
   // Check that the impl ownership and locality are correct
-  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tiles_range().volume(); ++i) {
     BOOST_CHECK_EQUAL(impl.owner(i), pmap->owner(i));
     if(impl.owner(i) == GlobalFixture::world->rank())
       BOOST_CHECK(impl.is_local(i));
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE( shape_access )
   BOOST_CHECK(impl.shape().is_dense());
 
   // Check that the tensor shape and s are the same
-  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tiles_range().volume(); ++i) {
     BOOST_CHECK(! impl.shape().is_zero(i));
   }
 }
@@ -122,12 +122,12 @@ BOOST_AUTO_TEST_CASE( zero )
   BOOST_CHECK(impl.is_dense());
 
   // Check that all tiles are non-zero when shape is dense
-  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tiles_range().volume(); ++i) {
     BOOST_CHECK(! impl.is_zero(i));
   }
 
   // Check that every third tile is non-zero
-  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tiles_range().volume(); ++i) {
     if(sp_impl.shape()[i] < SparseShape<float>::threshold()) {
       BOOST_CHECK(sp_impl.is_zero(i));
     } else {

--- a/tests/tensor_impl.cpp
+++ b/tests/tensor_impl.cpp
@@ -27,7 +27,7 @@ using namespace TiledArray;
 struct TensorImplBaseFixture : public SparseShapeFixture {
   typedef detail::TensorImpl<DensePolicy> tensor_impl_base;
   TensorImplBaseFixture() :
-    pmap(new detail::HashPmap(* GlobalFixture::world, tr.tiles().volume()))
+    pmap(new detail::HashPmap(* GlobalFixture::world, tr.tile_range().volume()))
   { }
 
   std::shared_ptr<tensor_impl_base::pmap_interface> pmap;
@@ -62,13 +62,13 @@ BOOST_AUTO_TEST_CASE( constructor_dense_policy )
   tensor_impl_base x(* GlobalFixture::world, tr, dense_shape_type(), pmap);
 
   // Check that the initial conditions are correct after construction.
-  BOOST_CHECK_EQUAL(& x.get_world(), GlobalFixture::world);
+  BOOST_CHECK_EQUAL(& x.world(), GlobalFixture::world);
   BOOST_CHECK(x.pmap() == pmap);
-  BOOST_CHECK_EQUAL(x.range(), tr.tiles());
+  BOOST_CHECK_EQUAL(x.range(), tr.tile_range());
   BOOST_CHECK_EQUAL(x.trange(), tr);
-  BOOST_CHECK_EQUAL(x.size(), tr.tiles().volume());
+  BOOST_CHECK_EQUAL(x.size(), tr.tile_range().volume());
   BOOST_CHECK(x.is_dense());
-  for(std::size_t i = 0; i < tr.tiles().volume(); ++i)
+  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i)
     BOOST_CHECK(! x.is_zero(i));
 }
 
@@ -78,13 +78,13 @@ BOOST_AUTO_TEST_CASE( constructor_shape_policy )
   sp_tensor_impl_base x(* GlobalFixture::world, tr, make_shape(tr, 0.5, 23), pmap);
 
   // Check that the initial conditions are correct after construction.
-  BOOST_CHECK_EQUAL(& x.get_world(), GlobalFixture::world);
+  BOOST_CHECK_EQUAL(& x.world(), GlobalFixture::world);
   BOOST_CHECK(x.pmap() == pmap);
-  BOOST_CHECK_EQUAL(x.range(), tr.tiles());
+  BOOST_CHECK_EQUAL(x.range(), tr.tile_range());
   BOOST_CHECK_EQUAL(x.trange(), tr);
-  BOOST_CHECK_EQUAL(x.size(), tr.tiles().volume());
+  BOOST_CHECK_EQUAL(x.size(), tr.tile_range().volume());
   BOOST_CHECK(! x.is_dense());
-  for(std::size_t i = 0; i < tr.tiles().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
     if(x.shape()[i] < SparseShape<float>::threshold()) {
       BOOST_CHECK(x.is_zero(i));
     } else {
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE( process_map )
   BOOST_CHECK(impl.pmap() == pmap);
 
   // Check that the impl ownership and locality are correct
-  for(std::size_t i = 0; i < tr.tiles().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
     BOOST_CHECK_EQUAL(impl.owner(i), pmap->owner(i));
     if(impl.owner(i) == GlobalFixture::world->rank())
       BOOST_CHECK(impl.is_local(i));
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE( shape_access )
   BOOST_CHECK(impl.shape().is_dense());
 
   // Check that the tensor shape and s are the same
-  for(std::size_t i = 0; i < tr.tiles().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
     BOOST_CHECK(! impl.shape().is_zero(i));
   }
 }
@@ -122,12 +122,12 @@ BOOST_AUTO_TEST_CASE( zero )
   BOOST_CHECK(impl.is_dense());
 
   // Check that all tiles are non-zero when shape is dense
-  for(std::size_t i = 0; i < tr.tiles().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
     BOOST_CHECK(! impl.is_zero(i));
   }
 
   // Check that every third tile is non-zero
-  for(std::size_t i = 0; i < tr.tiles().volume(); ++i) {
+  for(std::size_t i = 0; i < tr.tile_range().volume(); ++i) {
     if(sp_impl.shape()[i] < SparseShape<float>::threshold()) {
       BOOST_CHECK(sp_impl.is_zero(i));
     } else {

--- a/tests/tiled_range.cpp
+++ b/tests/tiled_range.cpp
@@ -28,8 +28,8 @@ BOOST_FIXTURE_TEST_SUITE( tiled_range_suite, TiledRangeFixture )
 
 BOOST_AUTO_TEST_CASE( accessor )
 {
-  BOOST_CHECK_EQUAL(tr.tile_range(), tile_range);
-  BOOST_CHECK_EQUAL(tr.element_range(), element_range);
+  BOOST_CHECK_EQUAL(tr.tiles_range(), tiles_range);
+  BOOST_CHECK_EQUAL(tr.elements_range(), elements_range);
 }
 
 BOOST_AUTO_TEST_CASE( constructor )
@@ -39,8 +39,8 @@ BOOST_AUTO_TEST_CASE( constructor )
     BOOST_REQUIRE_NO_THROW(TiledRange r0);
     TiledRange r0;
     std::vector<std::size_t> s0(3,0);
-    BOOST_CHECK(r0.tile_range().extent_data() == nullptr);
-    BOOST_CHECK(r0.element_range().extent_data() == nullptr);
+    BOOST_CHECK(r0.tiles_range().extent_data() == nullptr);
+    BOOST_CHECK(r0.elements_range().extent_data() == nullptr);
   }
 
 
@@ -48,8 +48,8 @@ BOOST_AUTO_TEST_CASE( constructor )
   {
     BOOST_REQUIRE_NO_THROW(TiledRange r1(dims.begin(), dims.end()));
     TiledRange r1(dims.begin(), dims.end());
-    BOOST_CHECK_EQUAL(r1.tile_range(), tile_range);
-    BOOST_CHECK_EQUAL(r1.element_range(), element_range);
+    BOOST_CHECK_EQUAL(r1.tiles_range(), tiles_range);
+    BOOST_CHECK_EQUAL(r1.elements_range(), elements_range);
   }
 
   // check initializer list of initializer list constructor
@@ -57,16 +57,16 @@ BOOST_AUTO_TEST_CASE( constructor )
     TiledRange r1 { {0,2,5,10,17,28},
                     {0,2,5,10,17,28},
                     {0,2,5,10,17,28} };
-    BOOST_CHECK_EQUAL(r1.tile_range(), tile_range);
-    BOOST_CHECK_EQUAL(r1.element_range(), element_range);
+    BOOST_CHECK_EQUAL(r1.tiles_range(), tiles_range);
+    BOOST_CHECK_EQUAL(r1.elements_range(), elements_range);
   }
 
   // check copy constructor
   {
     BOOST_REQUIRE_NO_THROW(TiledRange r4(tr));
     TiledRange r4(tr);
-    BOOST_CHECK_EQUAL(r4.tile_range(), tr.tile_range());
-    BOOST_CHECK_EQUAL(r4.element_range(), tr.element_range());
+    BOOST_CHECK_EQUAL(r4.tiles_range(), tr.tiles_range());
+    BOOST_CHECK_EQUAL(r4.elements_range(), tr.elements_range());
   }
 }
 
@@ -74,8 +74,8 @@ BOOST_AUTO_TEST_CASE( ostream )
 {
 
   std::stringstream stm;
-  stm << "( tiles = " << tr.tile_range() <<
-      ", elements = " << tr.element_range() << " )";
+  stm << "( tiles = " << tr.tiles_range() <<
+      ", elements = " << tr.elements_range() << " )";
 
   boost::test_tools::output_test_stream output;
   output << tr;
@@ -115,22 +115,22 @@ BOOST_AUTO_TEST_CASE( permutation )
 {
   Permutation p({2,0,1});
   TiledRange r1 = p * tr;
-  BOOST_CHECK_EQUAL(r1.tile_range(), p * tr.tile_range()); // check that tile data was permuted properly.
-  BOOST_CHECK_EQUAL(r1.element_range(), p * tr.element_range()); // check that element data was permuted properly.
+  BOOST_CHECK_EQUAL(r1.tiles_range(), p * tr.tiles_range()); // check that tile data was permuted properly.
+  BOOST_CHECK_EQUAL(r1.elements_range(), p * tr.elements_range()); // check that element data was permuted properly.
 
   TiledRange r2(tr);
   BOOST_CHECK_EQUAL((r2 *= p), r1); // check that permutation returns itself.
   BOOST_CHECK_EQUAL(r2, r1);// check that the permutation was assigned correctly.
 }
 
-BOOST_AUTO_TEST_CASE( make_tile_range )
+BOOST_AUTO_TEST_CASE( make_tiles_range )
 {
   tile_index start(GlobalFixture::dim);
   tile_index finish(GlobalFixture::dim);
 
   // iterate over all the tile indexes in the tiled range.
   TiledRange::size_type i = 0;
-  for(Range::const_iterator it = tr.tile_range().begin(); it != tr.tile_range().end(); ++it, ++i) {
+  for(Range::const_iterator it = tr.tiles_range().begin(); it != tr.tiles_range().end(); ++it, ++i) {
     // get the start and finish indexes of the current range.
     for(unsigned int d = 0; d < GlobalFixture::dim; ++d) {
       start[d] = a[ (*it)[d] ];
@@ -138,11 +138,11 @@ BOOST_AUTO_TEST_CASE( make_tile_range )
     }
 
     // construct a range object that should match the range constructed by TiledRange.
-    TiledRange::tile_range_type range(start, finish);
+    TiledRange::tiles_range_type range(start, finish);
 
     // Get the two ranges to be tested.
-    TiledRange::tile_range_type range_index = tr.tile(*it);
-    TiledRange::tile_range_type range_ordinal = tr.tile(i);
+    TiledRange::tiles_range_type range_index = tr.make_tile_range(*it);
+    TiledRange::tiles_range_type range_ordinal = tr.make_tile_range(i);
 
     BOOST_CHECK_EQUAL(range_index, range);
     BOOST_CHECK_EQUAL(range_ordinal, range);

--- a/tests/tiled_range.cpp
+++ b/tests/tiled_range.cpp
@@ -28,8 +28,8 @@ BOOST_FIXTURE_TEST_SUITE( tiled_range_suite, TiledRangeFixture )
 
 BOOST_AUTO_TEST_CASE( accessor )
 {
-  BOOST_CHECK_EQUAL(tr.tiles(), tile_range);
-  BOOST_CHECK_EQUAL(tr.elements(), element_range);
+  BOOST_CHECK_EQUAL(tr.tile_range(), tile_range);
+  BOOST_CHECK_EQUAL(tr.element_range(), element_range);
 }
 
 BOOST_AUTO_TEST_CASE( constructor )
@@ -39,8 +39,8 @@ BOOST_AUTO_TEST_CASE( constructor )
     BOOST_REQUIRE_NO_THROW(TiledRange r0);
     TiledRange r0;
     std::vector<std::size_t> s0(3,0);
-    BOOST_CHECK(r0.tiles().extent_data() == nullptr);
-    BOOST_CHECK(r0.elements().extent_data() == nullptr);
+    BOOST_CHECK(r0.tile_range().extent_data() == nullptr);
+    BOOST_CHECK(r0.element_range().extent_data() == nullptr);
   }
 
 
@@ -48,8 +48,8 @@ BOOST_AUTO_TEST_CASE( constructor )
   {
     BOOST_REQUIRE_NO_THROW(TiledRange r1(dims.begin(), dims.end()));
     TiledRange r1(dims.begin(), dims.end());
-    BOOST_CHECK_EQUAL(r1.tiles(), tile_range);
-    BOOST_CHECK_EQUAL(r1.elements(), element_range);
+    BOOST_CHECK_EQUAL(r1.tile_range(), tile_range);
+    BOOST_CHECK_EQUAL(r1.element_range(), element_range);
   }
 
   // check initializer list of initializer list constructor
@@ -57,16 +57,16 @@ BOOST_AUTO_TEST_CASE( constructor )
     TiledRange r1 { {0,2,5,10,17,28},
                     {0,2,5,10,17,28},
                     {0,2,5,10,17,28} };
-    BOOST_CHECK_EQUAL(r1.tiles(), tile_range);
-    BOOST_CHECK_EQUAL(r1.elements(), element_range);
+    BOOST_CHECK_EQUAL(r1.tile_range(), tile_range);
+    BOOST_CHECK_EQUAL(r1.element_range(), element_range);
   }
 
   // check copy constructor
   {
     BOOST_REQUIRE_NO_THROW(TiledRange r4(tr));
     TiledRange r4(tr);
-    BOOST_CHECK_EQUAL(r4.tiles(), tr.tiles());
-    BOOST_CHECK_EQUAL(r4.elements(), tr.elements());
+    BOOST_CHECK_EQUAL(r4.tile_range(), tr.tile_range());
+    BOOST_CHECK_EQUAL(r4.element_range(), tr.element_range());
   }
 }
 
@@ -74,8 +74,8 @@ BOOST_AUTO_TEST_CASE( ostream )
 {
 
   std::stringstream stm;
-  stm << "( tiles = " << tr.tiles() <<
-      ", elements = " << tr.elements() << " )";
+  stm << "( tiles = " << tr.tile_range() <<
+      ", elements = " << tr.element_range() << " )";
 
   boost::test_tools::output_test_stream output;
   output << tr;
@@ -115,8 +115,8 @@ BOOST_AUTO_TEST_CASE( permutation )
 {
   Permutation p({2,0,1});
   TiledRange r1 = p * tr;
-  BOOST_CHECK_EQUAL(r1.tiles(), p * tr.tiles()); // check that tile data was permuted properly.
-  BOOST_CHECK_EQUAL(r1.elements(), p * tr.elements()); // check that element data was permuted properly.
+  BOOST_CHECK_EQUAL(r1.tile_range(), p * tr.tile_range()); // check that tile data was permuted properly.
+  BOOST_CHECK_EQUAL(r1.element_range(), p * tr.element_range()); // check that element data was permuted properly.
 
   TiledRange r2(tr);
   BOOST_CHECK_EQUAL((r2 *= p), r1); // check that permutation returns itself.
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE( make_tile_range )
 
   // iterate over all the tile indexes in the tiled range.
   TiledRange::size_type i = 0;
-  for(Range::const_iterator it = tr.tiles().begin(); it != tr.tiles().end(); ++it, ++i) {
+  for(Range::const_iterator it = tr.tile_range().begin(); it != tr.tile_range().end(); ++it, ++i) {
     // get the start and finish indexes of the current range.
     for(unsigned int d = 0; d < GlobalFixture::dim; ++d) {
       start[d] = a[ (*it)[d] ];
@@ -141,8 +141,8 @@ BOOST_AUTO_TEST_CASE( make_tile_range )
     TiledRange::tile_range_type range(start, finish);
 
     // Get the two ranges to be tested.
-    TiledRange::tile_range_type range_index = tr.make_tile_range(*it);
-    TiledRange::tile_range_type range_ordinal = tr.make_tile_range(i);
+    TiledRange::tile_range_type range_index = tr.tile(*it);
+    TiledRange::tile_range_type range_ordinal = tr.tile(i);
 
     BOOST_CHECK_EQUAL(range_index, range);
     BOOST_CHECK_EQUAL(range_ordinal, range);

--- a/tests/tiled_range1.cpp
+++ b/tests/tiled_range1.cpp
@@ -28,10 +28,10 @@ BOOST_FIXTURE_TEST_SUITE( range1_suite, Range1Fixture )
 
 BOOST_AUTO_TEST_CASE( range_accessor )
 {
-  BOOST_CHECK_EQUAL(tr1.tiles().first, tiles.first);
-  BOOST_CHECK_EQUAL(tr1.tiles().second, tiles.second);
-  BOOST_CHECK_EQUAL(tr1.elements().first, elements.first);
-  BOOST_CHECK_EQUAL(tr1.elements().second, elements.second);
+  BOOST_CHECK_EQUAL(tr1.tile_range().first, tiles.first);
+  BOOST_CHECK_EQUAL(tr1.tile_range().second, tiles.second);
+  BOOST_CHECK_EQUAL(tr1.element_range().first, elements.first);
+  BOOST_CHECK_EQUAL(tr1.element_range().second, elements.second);
 
   // Check individual tiles
   for(std::size_t i = 0; i < a.size() - 1; ++i) {
@@ -42,10 +42,10 @@ BOOST_AUTO_TEST_CASE( range_accessor )
 
 BOOST_AUTO_TEST_CASE( range_info )
 {
-  BOOST_CHECK_EQUAL(tr1.tiles().first, 0ul);
-  BOOST_CHECK_EQUAL(tr1.tiles().second, a.size() - 1);
-  BOOST_CHECK_EQUAL(tr1.elements().first, 0ul);
-  BOOST_CHECK_EQUAL(tr1.elements().second, a.back());
+  BOOST_CHECK_EQUAL(tr1.tile_range().first, 0ul);
+  BOOST_CHECK_EQUAL(tr1.tile_range().second, a.size() - 1);
+  BOOST_CHECK_EQUAL(tr1.element_range().first, 0ul);
+  BOOST_CHECK_EQUAL(tr1.element_range().second, a.back());
   for(std::size_t i = 0; i < a.size() - 1; ++i) {
     BOOST_CHECK_EQUAL(tr1.tile(i).first, a[i]);
     BOOST_CHECK_EQUAL(tr1.tile(i).second, a[i + 1]);
@@ -58,10 +58,10 @@ BOOST_AUTO_TEST_CASE( constructor )
   {
     BOOST_REQUIRE_NO_THROW(TiledRange1 r);
     TiledRange1 r;
-    BOOST_CHECK_EQUAL(r.tiles().first, 0ul);
-    BOOST_CHECK_EQUAL(r.tiles().second, 0ul);
-    BOOST_CHECK_EQUAL(r.elements().first, 0ul);
-    BOOST_CHECK_EQUAL(r.elements().second, 0ul);
+    BOOST_CHECK_EQUAL(r.tile_range().first, 0ul);
+    BOOST_CHECK_EQUAL(r.tile_range().second, 0ul);
+    BOOST_CHECK_EQUAL(r.element_range().first, 0ul);
+    BOOST_CHECK_EQUAL(r.element_range().second, 0ul);
 #ifdef TA_EXCEPTION_ERROR
     BOOST_CHECK_THROW(r.tile(0), Exception);
 #endif // TA_EXCEPTION_ERROR
@@ -71,10 +71,10 @@ BOOST_AUTO_TEST_CASE( constructor )
   {
     BOOST_REQUIRE_NO_THROW(TiledRange1 r(a.begin(), a.end()));
     TiledRange1 r(a.begin(), a.end());
-    BOOST_CHECK_EQUAL(r.tiles().first, tiles.first);
-    BOOST_CHECK_EQUAL(r.tiles().second, tiles.second);
-    BOOST_CHECK_EQUAL(r.elements().first, elements.first);
-    BOOST_CHECK_EQUAL(r.elements().second, elements.second);
+    BOOST_CHECK_EQUAL(r.tile_range().first, tiles.first);
+    BOOST_CHECK_EQUAL(r.tile_range().second, tiles.second);
+    BOOST_CHECK_EQUAL(r.element_range().first, elements.first);
+    BOOST_CHECK_EQUAL(r.element_range().second, elements.second);
     for(std::size_t i = 0; i < a.size() - 1; ++i) {
       BOOST_CHECK_EQUAL(r.tile(i).first, a[i]);
       BOOST_CHECK_EQUAL(r.tile(i).second, a[i + 1]);
@@ -86,10 +86,10 @@ BOOST_AUTO_TEST_CASE( constructor )
     BOOST_REQUIRE_NO_THROW(TiledRange1 r(0,1,2,3,4,5));
     if (Range1Fixture::ntiles == 5) {
       TiledRange1 r(0,2,5,10,17,28);
-      BOOST_CHECK_EQUAL(r.tiles().first, tiles.first);
-      BOOST_CHECK_EQUAL(r.tiles().second, tiles.second);
-      BOOST_CHECK_EQUAL(r.elements().first, elements.first);
-      BOOST_CHECK_EQUAL(r.elements().second, elements.second);
+      BOOST_CHECK_EQUAL(r.tile_range().first, tiles.first);
+      BOOST_CHECK_EQUAL(r.tile_range().second, tiles.second);
+      BOOST_CHECK_EQUAL(r.element_range().first, elements.first);
+      BOOST_CHECK_EQUAL(r.element_range().second, elements.second);
       for(std::size_t i = 0; i < a.size() - 1; ++i) {
         BOOST_CHECK_EQUAL(r.tile(i).first, a[i]);
         BOOST_CHECK_EQUAL(r.tile(i).second, a[i + 1]);
@@ -101,10 +101,10 @@ BOOST_AUTO_TEST_CASE( constructor )
   {
     if (Range1Fixture::ntiles == 5) {
       TiledRange1 r {0,2,5,10,17,28};
-      BOOST_CHECK_EQUAL(r.tiles().first, tiles.first);
-      BOOST_CHECK_EQUAL(r.tiles().second, tiles.second);
-      BOOST_CHECK_EQUAL(r.elements().first, elements.first);
-      BOOST_CHECK_EQUAL(r.elements().second, elements.second);
+      BOOST_CHECK_EQUAL(r.tile_range().first, tiles.first);
+      BOOST_CHECK_EQUAL(r.tile_range().second, tiles.second);
+      BOOST_CHECK_EQUAL(r.element_range().first, elements.first);
+      BOOST_CHECK_EQUAL(r.element_range().second, elements.second);
       for(std::size_t i = 0; i < a.size() - 1; ++i) {
         BOOST_CHECK_EQUAL(r.tile(i).first, a[i]);
         BOOST_CHECK_EQUAL(r.tile(i).second, a[i + 1]);
@@ -116,10 +116,10 @@ BOOST_AUTO_TEST_CASE( constructor )
   {
     BOOST_REQUIRE_NO_THROW(TiledRange1 r(tr1));
     TiledRange1 r(tr1);
-    BOOST_CHECK_EQUAL(r.tiles().first, tiles.first);
-    BOOST_CHECK_EQUAL(r.tiles().second, tiles.second);
-    BOOST_CHECK_EQUAL(r.elements().first, elements.first);
-    BOOST_CHECK_EQUAL(r.elements().second, elements.second);
+    BOOST_CHECK_EQUAL(r.tile_range().first, tiles.first);
+    BOOST_CHECK_EQUAL(r.tile_range().second, tiles.second);
+    BOOST_CHECK_EQUAL(r.element_range().first, elements.first);
+    BOOST_CHECK_EQUAL(r.element_range().second, elements.second);
     for(std::size_t i = 0; i < a.size() - 1; ++i) {
       BOOST_CHECK_EQUAL(r.tile(i).first, a[i]);
       BOOST_CHECK_EQUAL(r.tile(i).second, a[i + 1]);
@@ -130,10 +130,10 @@ BOOST_AUTO_TEST_CASE( constructor )
   {
     BOOST_REQUIRE_NO_THROW(TiledRange1 r(a.begin() + 1, a.end()));
     TiledRange1 r(a.begin() + 1, a.end());
-    BOOST_CHECK_EQUAL(r.tiles().first, 0ul);
-    BOOST_CHECK_EQUAL(r.tiles().second, a.size() - 2);
-    BOOST_CHECK_EQUAL(r.elements().first, a[1]);
-    BOOST_CHECK_EQUAL(r.elements().second, a.back());
+    BOOST_CHECK_EQUAL(r.tile_range().first, 0ul);
+    BOOST_CHECK_EQUAL(r.tile_range().second, a.size() - 2);
+    BOOST_CHECK_EQUAL(r.element_range().first, a[1]);
+    BOOST_CHECK_EQUAL(r.element_range().second, a.back());
     for(std::size_t i = 1; i < a.size() - 1; ++i) {
       BOOST_CHECK_EQUAL(r.tile(i - 1).first, a[i]);
       BOOST_CHECK_EQUAL(r.tile(i - 1).second, a[i + 1]);
@@ -171,13 +171,13 @@ BOOST_AUTO_TEST_CASE( element2tile )
 {
   // construct a map that should match the element to tile map for tr1.
   std::vector<std::size_t> e;
-  for(std::size_t t = tr1.tiles().first; t < tr1.tiles().second; ++t)
+  for(std::size_t t = tr1.tile_range().first; t < tr1.tile_range().second; ++t)
     for(std::size_t i = tr1.tile(t).first; i < tr1.tile(t).second; ++i)
       e.push_back(t);
 
   // Construct a map that matches the internal element to tile map for tr1.
   std::vector<std::size_t> c;
-  for(std::size_t i = tr1.elements().first; i < tr1.elements().second; ++i)
+  for(std::size_t i = tr1.element_range().first; i < tr1.element_range().second; ++i)
     c.push_back(tr1.element2tile(i));
 
   // Check that the expected and internal element to tile maps match.
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE( iteration )
     BOOST_CHECK_EQUAL(it->first, a[count]);
     BOOST_CHECK_EQUAL(it->second, a[count + 1]);
   }
-  BOOST_CHECK_EQUAL(count, tr1.tiles().second - tr1.tiles().first);
+  BOOST_CHECK_EQUAL(count, tr1.tile_range().second - tr1.tile_range().first);
 }
 
 BOOST_AUTO_TEST_CASE( find )

--- a/tests/tiled_range1.cpp
+++ b/tests/tiled_range1.cpp
@@ -28,10 +28,10 @@ BOOST_FIXTURE_TEST_SUITE( range1_suite, Range1Fixture )
 
 BOOST_AUTO_TEST_CASE( range_accessor )
 {
-  BOOST_CHECK_EQUAL(tr1.tile_range().first, tiles.first);
-  BOOST_CHECK_EQUAL(tr1.tile_range().second, tiles.second);
-  BOOST_CHECK_EQUAL(tr1.element_range().first, elements.first);
-  BOOST_CHECK_EQUAL(tr1.element_range().second, elements.second);
+  BOOST_CHECK_EQUAL(tr1.tiles_range().first, tiles.first);
+  BOOST_CHECK_EQUAL(tr1.tiles_range().second, tiles.second);
+  BOOST_CHECK_EQUAL(tr1.elements_range().first, elements.first);
+  BOOST_CHECK_EQUAL(tr1.elements_range().second, elements.second);
 
   // Check individual tiles
   for(std::size_t i = 0; i < a.size() - 1; ++i) {
@@ -42,10 +42,10 @@ BOOST_AUTO_TEST_CASE( range_accessor )
 
 BOOST_AUTO_TEST_CASE( range_info )
 {
-  BOOST_CHECK_EQUAL(tr1.tile_range().first, 0ul);
-  BOOST_CHECK_EQUAL(tr1.tile_range().second, a.size() - 1);
-  BOOST_CHECK_EQUAL(tr1.element_range().first, 0ul);
-  BOOST_CHECK_EQUAL(tr1.element_range().second, a.back());
+  BOOST_CHECK_EQUAL(tr1.tiles_range().first, 0ul);
+  BOOST_CHECK_EQUAL(tr1.tiles_range().second, a.size() - 1);
+  BOOST_CHECK_EQUAL(tr1.elements_range().first, 0ul);
+  BOOST_CHECK_EQUAL(tr1.elements_range().second, a.back());
   for(std::size_t i = 0; i < a.size() - 1; ++i) {
     BOOST_CHECK_EQUAL(tr1.tile(i).first, a[i]);
     BOOST_CHECK_EQUAL(tr1.tile(i).second, a[i + 1]);
@@ -58,10 +58,10 @@ BOOST_AUTO_TEST_CASE( constructor )
   {
     BOOST_REQUIRE_NO_THROW(TiledRange1 r);
     TiledRange1 r;
-    BOOST_CHECK_EQUAL(r.tile_range().first, 0ul);
-    BOOST_CHECK_EQUAL(r.tile_range().second, 0ul);
-    BOOST_CHECK_EQUAL(r.element_range().first, 0ul);
-    BOOST_CHECK_EQUAL(r.element_range().second, 0ul);
+    BOOST_CHECK_EQUAL(r.tiles_range().first, 0ul);
+    BOOST_CHECK_EQUAL(r.tiles_range().second, 0ul);
+    BOOST_CHECK_EQUAL(r.elements_range().first, 0ul);
+    BOOST_CHECK_EQUAL(r.elements_range().second, 0ul);
 #ifdef TA_EXCEPTION_ERROR
     BOOST_CHECK_THROW(r.tile(0), Exception);
 #endif // TA_EXCEPTION_ERROR
@@ -71,10 +71,10 @@ BOOST_AUTO_TEST_CASE( constructor )
   {
     BOOST_REQUIRE_NO_THROW(TiledRange1 r(a.begin(), a.end()));
     TiledRange1 r(a.begin(), a.end());
-    BOOST_CHECK_EQUAL(r.tile_range().first, tiles.first);
-    BOOST_CHECK_EQUAL(r.tile_range().second, tiles.second);
-    BOOST_CHECK_EQUAL(r.element_range().first, elements.first);
-    BOOST_CHECK_EQUAL(r.element_range().second, elements.second);
+    BOOST_CHECK_EQUAL(r.tiles_range().first, tiles.first);
+    BOOST_CHECK_EQUAL(r.tiles_range().second, tiles.second);
+    BOOST_CHECK_EQUAL(r.elements_range().first, elements.first);
+    BOOST_CHECK_EQUAL(r.elements_range().second, elements.second);
     for(std::size_t i = 0; i < a.size() - 1; ++i) {
       BOOST_CHECK_EQUAL(r.tile(i).first, a[i]);
       BOOST_CHECK_EQUAL(r.tile(i).second, a[i + 1]);
@@ -86,10 +86,10 @@ BOOST_AUTO_TEST_CASE( constructor )
     BOOST_REQUIRE_NO_THROW(TiledRange1 r(0,1,2,3,4,5));
     if (Range1Fixture::ntiles == 5) {
       TiledRange1 r(0,2,5,10,17,28);
-      BOOST_CHECK_EQUAL(r.tile_range().first, tiles.first);
-      BOOST_CHECK_EQUAL(r.tile_range().second, tiles.second);
-      BOOST_CHECK_EQUAL(r.element_range().first, elements.first);
-      BOOST_CHECK_EQUAL(r.element_range().second, elements.second);
+      BOOST_CHECK_EQUAL(r.tiles_range().first, tiles.first);
+      BOOST_CHECK_EQUAL(r.tiles_range().second, tiles.second);
+      BOOST_CHECK_EQUAL(r.elements_range().first, elements.first);
+      BOOST_CHECK_EQUAL(r.elements_range().second, elements.second);
       for(std::size_t i = 0; i < a.size() - 1; ++i) {
         BOOST_CHECK_EQUAL(r.tile(i).first, a[i]);
         BOOST_CHECK_EQUAL(r.tile(i).second, a[i + 1]);
@@ -101,10 +101,10 @@ BOOST_AUTO_TEST_CASE( constructor )
   {
     if (Range1Fixture::ntiles == 5) {
       TiledRange1 r {0,2,5,10,17,28};
-      BOOST_CHECK_EQUAL(r.tile_range().first, tiles.first);
-      BOOST_CHECK_EQUAL(r.tile_range().second, tiles.second);
-      BOOST_CHECK_EQUAL(r.element_range().first, elements.first);
-      BOOST_CHECK_EQUAL(r.element_range().second, elements.second);
+      BOOST_CHECK_EQUAL(r.tiles_range().first, tiles.first);
+      BOOST_CHECK_EQUAL(r.tiles_range().second, tiles.second);
+      BOOST_CHECK_EQUAL(r.elements_range().first, elements.first);
+      BOOST_CHECK_EQUAL(r.elements_range().second, elements.second);
       for(std::size_t i = 0; i < a.size() - 1; ++i) {
         BOOST_CHECK_EQUAL(r.tile(i).first, a[i]);
         BOOST_CHECK_EQUAL(r.tile(i).second, a[i + 1]);
@@ -116,10 +116,10 @@ BOOST_AUTO_TEST_CASE( constructor )
   {
     BOOST_REQUIRE_NO_THROW(TiledRange1 r(tr1));
     TiledRange1 r(tr1);
-    BOOST_CHECK_EQUAL(r.tile_range().first, tiles.first);
-    BOOST_CHECK_EQUAL(r.tile_range().second, tiles.second);
-    BOOST_CHECK_EQUAL(r.element_range().first, elements.first);
-    BOOST_CHECK_EQUAL(r.element_range().second, elements.second);
+    BOOST_CHECK_EQUAL(r.tiles_range().first, tiles.first);
+    BOOST_CHECK_EQUAL(r.tiles_range().second, tiles.second);
+    BOOST_CHECK_EQUAL(r.elements_range().first, elements.first);
+    BOOST_CHECK_EQUAL(r.elements_range().second, elements.second);
     for(std::size_t i = 0; i < a.size() - 1; ++i) {
       BOOST_CHECK_EQUAL(r.tile(i).first, a[i]);
       BOOST_CHECK_EQUAL(r.tile(i).second, a[i + 1]);
@@ -130,10 +130,10 @@ BOOST_AUTO_TEST_CASE( constructor )
   {
     BOOST_REQUIRE_NO_THROW(TiledRange1 r(a.begin() + 1, a.end()));
     TiledRange1 r(a.begin() + 1, a.end());
-    BOOST_CHECK_EQUAL(r.tile_range().first, 0ul);
-    BOOST_CHECK_EQUAL(r.tile_range().second, a.size() - 2);
-    BOOST_CHECK_EQUAL(r.element_range().first, a[1]);
-    BOOST_CHECK_EQUAL(r.element_range().second, a.back());
+    BOOST_CHECK_EQUAL(r.tiles_range().first, 0ul);
+    BOOST_CHECK_EQUAL(r.tiles_range().second, a.size() - 2);
+    BOOST_CHECK_EQUAL(r.elements_range().first, a[1]);
+    BOOST_CHECK_EQUAL(r.elements_range().second, a.back());
     for(std::size_t i = 1; i < a.size() - 1; ++i) {
       BOOST_CHECK_EQUAL(r.tile(i - 1).first, a[i]);
       BOOST_CHECK_EQUAL(r.tile(i - 1).second, a[i + 1]);
@@ -171,13 +171,13 @@ BOOST_AUTO_TEST_CASE( element2tile )
 {
   // construct a map that should match the element to tile map for tr1.
   std::vector<std::size_t> e;
-  for(std::size_t t = tr1.tile_range().first; t < tr1.tile_range().second; ++t)
+  for(std::size_t t = tr1.tiles_range().first; t < tr1.tiles_range().second; ++t)
     for(std::size_t i = tr1.tile(t).first; i < tr1.tile(t).second; ++i)
       e.push_back(t);
 
   // Construct a map that matches the internal element to tile map for tr1.
   std::vector<std::size_t> c;
-  for(std::size_t i = tr1.element_range().first; i < tr1.element_range().second; ++i)
+  for(std::size_t i = tr1.elements_range().first; i < tr1.elements_range().second; ++i)
     c.push_back(tr1.element2tile(i));
 
   // Check that the expected and internal element to tile maps match.
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE( iteration )
     BOOST_CHECK_EQUAL(it->first, a[count]);
     BOOST_CHECK_EQUAL(it->second, a[count + 1]);
   }
-  BOOST_CHECK_EQUAL(count, tr1.tile_range().second - tr1.tile_range().first);
+  BOOST_CHECK_EQUAL(count, tr1.tiles_range().second - tr1.tiles_range().first);
 }
 
 BOOST_AUTO_TEST_CASE( find )


### PR DESCRIPTION
 (intended to make method names consistent across the class hierarchy):

- get_world() -> world()
- get_shape() -> shape()
- get_pmap() -> pmap()
- tiles() -> tile_range()
- elements() -> element_range()
- make_tile_range(i) -> tile(i)