### PR TITLE
Make common namespace alias 'TA' standard by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ The following application is a minimal example of a distributed-memory matrix mu
 ```c++
 #include <tiledarray.h>
 
-namespace TA = TiledArray;
-
 int main(int argc, char** argv) {
   // Initialize the parallel runtime
   TA::World& world = TA::initialize(argc, argv);

--- a/examples/demo/demo.cpp
+++ b/examples/demo/demo.cpp
@@ -24,7 +24,6 @@
 
 int main(int argc, char* argv[]) {
   using namespace std;
-  namespace TA = TiledArray;
 
   auto& world = madness::initialize(argc, argv);
 

--- a/examples/dgemm/ta_cc_abcd.cpp
+++ b/examples/dgemm/ta_cc_abcd.cpp
@@ -20,8 +20,6 @@
 #include <iostream>
 #include <tiledarray.h>
 
-namespace TA = TiledArray;
-
 bool to_bool(const char* str) {
   if (not strcmp(str,"0") ||
       not strcmp(str,"no") ||

--- a/examples/fock/ta_k_build.cpp
+++ b/examples/fock/ta_k_build.cpp
@@ -21,7 +21,6 @@
 #include <tiledarray.h>
 #include <madness/world/worldmem.h>
 
-namespace TA = TiledArray;
 using array_type = TA::TSpArrayD;
 
 int main(int argc, char** argv) {

--- a/src/tiledarray_fwd.h
+++ b/src/tiledarray_fwd.h
@@ -74,4 +74,8 @@ namespace TiledArray {
 
 } // namespace TiledArray
 
+#ifndef TILEDARRAY_DISABLE_NAMESPACE_TA
+namespace TA = TiledArray;
+#endif  // TILEDARRAY_DISABLE_NAMESPACE_TA
+
 #endif // TILEDARRAY_FWD_H__INCLUDED


### PR DESCRIPTION
(disable the alias by defining macro TILEDARRAY_DISABLE_NAMESPACE_TA )