### PR TITLE
Sparse summa forced shape

### DIFF
--- a/src/TiledArray/dist_eval/contraction_eval.h
+++ b/src/TiledArray/dist_eval/contraction_eval.h
@@ -633,7 +633,7 @@ namespace TiledArray {
           bool have_group = false;
           madness::Group row_group;
           ProcessID group_root;
-          bool do_broadcast = false;
+          bool do_broadcast;
 
           // Search column k of left for non-zero tiles
           for(; index < left_end_; index += left_stride_local_) {
@@ -675,10 +675,10 @@ namespace TiledArray {
           index += proc_grid_.rank_col();
 
           // will create broadcast group only if needed
-          bool have_group = true;
+          bool have_group = false;
           madness::Group col_group;
           ProcessID group_root;
-          bool do_broadcast = false;
+          bool do_broadcast;
 
           // Search for and broadcast non-zero row
           for(; index < row_end; index += right_stride_local_) {

--- a/src/TiledArray/dist_eval/contraction_eval.h
+++ b/src/TiledArray/dist_eval/contraction_eval.h
@@ -278,7 +278,7 @@ namespace TiledArray {
 
         // if result is dense, include all processors
         if (result_shape.is_dense())
-          return std::vector<bool>(nproc_cols, false);
+          return std::vector<bool>(nproc_cols, true);
 
         // initialize the mask
         std::vector<bool> mask(nproc_cols, false);
@@ -347,7 +347,7 @@ namespace TiledArray {
 
         // if result is dense, include all processors
         if (result_shape.is_dense())
-          return std::vector<bool>(nproc_rows, false);
+          return std::vector<bool>(nproc_rows, true);
 
         // initialize the mask
         std::vector<bool> mask(nproc_rows, false);

--- a/src/TiledArray/dist_eval/contraction_eval.h
+++ b/src/TiledArray/dist_eval/contraction_eval.h
@@ -283,16 +283,16 @@ namespace TiledArray {
         // initialize the mask
         std::vector<bool> mask(nproc_cols, false);
 
-        // number of tiles in col dim of the result
-        const auto nj = right_.range().extent_data()[1];
+        // number of tiles in the col dimension of the result
+        const auto nj = proc_grid_.cols();
         // number of tiles in contraction dim
-        const auto nk = right_.range().extent_data()[0];
+        const auto nk = k_;
 
-        // for each i assigned to my column of processes ...
+        // for each i assigned to my row of processes ...
         size_type i_start, i_fence, i_stride;
         std::tie(i_start, i_fence, i_stride) =
             result_row_range(my_proc_row);
-        const auto ik_stride = i_fence * nk;
+        const auto ik_stride = i_stride * nk;
         for (size_type i = i_start, ik = i_start * nk + k; i < i_fence;
              i += i_stride, ik += ik_stride) {
           // ... such that A[i][k] exists ...
@@ -353,7 +353,7 @@ namespace TiledArray {
         std::vector<bool> mask(nproc_rows, false);
 
         // number of tiles in col dim of the result
-        const auto nj = right_.range().extent_data()[1];
+        const auto nj = proc_grid_.cols();
 
         // for each j assigned to my column of processes ...
         size_type j_start, j_fence, j_stride;

--- a/src/TiledArray/dist_eval/contraction_eval.h
+++ b/src/TiledArray/dist_eval/contraction_eval.h
@@ -20,6 +20,8 @@
 #ifndef TILEDARRAY_DIST_EVAL_CONTRACTION_EVAL_H__INCLUDED
 #define TILEDARRAY_DIST_EVAL_CONTRACTION_EVAL_H__INCLUDED
 
+#include <vector>
+
 #include <TiledArray/dist_eval/dist_eval.h>
 #include <TiledArray/proc_grid.h>
 #include <TiledArray/reduce_task.h>
@@ -35,7 +37,7 @@
 namespace TiledArray {
   namespace detail {
 
-    /// Distributed contraction evaluator implementation
+    /// \brief Distributed contraction evaluator implementation
 
     /// \tparam Left The left-hand argument evaluator type
     /// \tparam Right The right-hand argument evaluator type
@@ -67,7 +69,7 @@ namespace TiledArray {
       typedef Op op_type; ///< Tile evaluation operator type
 
     private:
-      static size_type max_memory_; ///< Maximum overhead used per node
+      static size_type max_memory_; ///< Maximum memory used per node
       static size_type max_depth_; ///< Maximum number of concurrent SUMMA iterations
 
       // Arguments and operation
@@ -86,7 +88,7 @@ namespace TiledArray {
       // Contraction results
       ReducePairTask<op_type>* reduce_tasks_; ///< A pointer to the reduction tasks
 
-      // Constant used to iterate over columns and rows of left_ and right_, respectively.
+      // Constants used to iterate over columns and rows of left_ and right_, respectively.
       const size_type left_start_local_; ///< The starting point of left column iterator ranges (just add k for specific columns)
       const size_type left_end_; ///< The end of the left column iterator ranges
       const size_type left_stride_; ///< Stride for left column iterators
@@ -163,6 +165,10 @@ namespace TiledArray {
       /// \tparam ProcMap The process map operation type
       /// \param shape The shape that will be used to select processes that are
       /// included in the process group
+      /// \param process_mask the process mask, if
+      ///        \code process_mask[p] == true \endcode,
+      ///        process \c p will not be included in the result (p is row/col index
+      ///        in this process's row/column)
       /// \param index The first index of the row or column range
       /// \param end The end of the row or column range
       /// \param stride The row or column index stride
@@ -172,11 +178,11 @@ namespace TiledArray {
       /// column as defined by \c proc_grid_.
       /// \param key_offset The key that will be used to identify the process group
       /// \param proc_map The operator that will convert a process row/column
-      /// into a process
+      /// index into the absolute process index (ProcessID)
       /// \return A sparse process group that includes process in the row or
       /// column of this process as defined by \c proc_grid_.
       template <typename Shape, typename ProcMap>
-      madness::Group make_group(const Shape& shape, size_type index,
+      madness::Group make_group(const Shape& shape, const std::vector<bool>& process_mask, size_type index,
           const size_type end, const size_type stride, const size_type max_group_size,
           const size_type k, const size_type key_offset, const ProcMap& proc_map) const
       {
@@ -189,10 +195,15 @@ namespace TiledArray {
         proc_list[p] = proc_map(p);
         size_type count = 1ul;
 
-        // Flag all process that have non-zero tiles
+        // Flag all processes that have non-zero tiles
         for(p = 0ul; (index < end) && (count < max_group_size); index += stride,
             p = (p + 1u) % max_group_size)
         {
+          static bool masked_out_broadcast_proc_flag = false;
+          if (!shape.is_zero(index) && !process_mask[p] && masked_out_broadcast_proc_flag) {
+            masked_out_broadcast_proc_flag = true;
+            std::cout << "set masked_out_broadcast_proc_flag" << std::endl;
+          }
           if((proc_list[p] != -1) || (shape.is_zero(index))) continue;
 
           proc_list[p] = proc_map(p);
@@ -220,20 +231,180 @@ namespace TiledArray {
         // Construct the sparse broadcast group
         const size_type right_begin_k = k * proc_grid_.cols();
         const size_type right_end_k = right_begin_k + proc_grid_.cols();
-        return make_group(right_.shape(), right_begin_k, right_end_k,
+        // make the row mask; using the same mask for all tiles avoids having to compute mask
+        // for every tile and use of masked broadcasts
+        auto result_row_mask_k = make_row_mask(k);
+
+        return make_group(right_.shape(), result_row_mask_k, right_begin_k, right_end_k,
             right_stride_, proc_grid_.proc_cols(), k, k_,
             [&](const ProcGrid::size_type col) { return proc_grid_.map_col(col); });
       }
+
 
       /// Column process group factory function
 
       /// \param k The broadcast group index
       /// \return A column process group
       madness::Group make_col_group(const size_type k) const {
+
+        // make the column mask; using the same mask for all tiles avoids having to compute mask
+        // for every tile and use of masked broadcasts
+        auto result_col_mask_k = make_col_mask(k);
+
         // Construct the sparse broadcast group
-        return make_group(left_.shape(), k, left_end_, left_stride_,
+        return make_group(left_.shape(), result_col_mask_k, k, left_end_, left_stride_,
             proc_grid_.proc_rows(), k, 0ul,
             [&](const ProcGrid::size_type row) { return proc_grid_.map_row(row); });
+      }
+
+      /// Makes the row result mask
+
+      /// \param k The SUMMA iteration (i.e. contraction tile) index
+      /// \return a set object, if \code result[p] == true \endcode the process
+      ///         in column \c p of this row has at least 1 result tile for this \c k
+      std::vector<bool> make_row_mask(const size_type k) const {
+        // "local" A[i][k] (i.e. for all i assigned to my row of processes) will produce C[i][*]
+        // for each process in my row of the process grid determine whether there are any
+        // nonzero C[i][*] located on that node
+
+        const auto nproc_rows = proc_grid_.proc_rows();
+        const auto nproc_cols = proc_grid_.proc_cols();
+        const auto my_proc_row = proc_grid_.rank_row();
+        const auto my_proc_col = proc_grid_.rank_col();
+
+        // initialize the mask
+        std::vector<bool> mask(nproc_cols, false);
+
+        // number of tiles in col dim of the result
+        const auto nj = right_.range().extent_data()[1];
+        // number of tiles in contraction dim
+        const auto nk = right_.range().extent_data()[0];
+        // result shape
+        const auto& result_shape = TensorImpl_::shape();
+
+        // for each i assigned to my column of processes ...
+        size_type i_start, i_fence, i_stride;
+        std::tie(i_start, i_fence, i_stride) =
+            result_row_range(my_proc_row);
+        const auto ik_stride = i_fence * nk;
+        for (size_type i = i_start, ik = i_start * nk + k; i < i_fence;
+             i += i_stride, ik += ik_stride) {
+          // ... such that A[i][k] exists ...
+          if (!left_.shape().is_zero(ik)) {
+            // ... loop over processes in my row ...
+            for (size_type proc_col = 0; proc_col != nproc_cols; ++proc_col) {
+              // ... that are not me ...
+              if (proc_col != my_proc_col) {
+                // ... loop over all C[i][j] tiles that belong to this process ...
+                size_type j_start, j_fence, j_stride;
+                std::tie(j_start, j_fence, j_stride) =
+                    result_col_range(proc_col);
+                const auto ij_stride = j_stride;
+                for (size_type j = j_start, ij = i * nj + j_start; j < j_fence;
+                     j += j_stride, ij += ij_stride) {
+                  // ... if any such C[i][j] exists, update the mask, and move
+                  // on to next process
+                  if (!result_shape.is_zero(DistEvalImpl_::perm_index_to_target(ij))) {
+                    mask[proc_col] = true;
+                    break;
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        return mask;
+      }
+
+      /// Makes the column result mask
+
+      /// \param k The SUMMA iteration (i.e. contraction tile) index
+      /// \return a set object, if \code result[p] == true \endcode the process
+      ///         in row \c p of this column has at least 1 result tile for this
+      ///         \c k
+      std::vector<bool> make_col_mask(const size_type k) const {
+        // "local" B[k][j] (i.e. for all j assigned to my column of processes)
+        // will produce C[*][j]
+        // for each process in my column of the process grid determine whether
+        // there are any
+        // nonzero C[*][j] located on that node
+
+        const auto nproc_rows = proc_grid_.proc_rows();
+        const auto nproc_cols = proc_grid_.proc_cols();
+        const auto my_proc_row = proc_grid_.rank_row();
+        const auto my_proc_col = proc_grid_.rank_col();
+
+        // initialize the mask
+        std::vector<bool> mask(nproc_rows, false);
+
+        // number of tiles in col dim of the result
+        const auto nj = right_.range().extent_data()[1];
+        // result shape
+        const auto& result_shape = TensorImpl_::shape();
+
+        // for each j assigned to my column of processes ...
+        size_type j_start, j_fence, j_stride;
+        std::tie(j_start, j_fence, j_stride) =
+            result_col_range(my_proc_col);
+        const auto kj_stride = j_stride;
+        for (size_type j = j_start, kj = k * nj + j_start; j < j_fence;
+             j += j_stride, kj += kj_stride) {
+          // ... such that B[k][j] exists ...
+          if (!right_.shape().is_zero(kj)) {
+            // ... loop over processes in my col ...
+            for (size_type proc_row = 0; proc_row != nproc_rows; ++proc_row) {
+              // ... that are not me ...
+              if (proc_row != my_proc_row) {
+                // ... loop over all C[i][j] tiles that belong to this process
+                // ...
+                size_type i_start, i_fence, i_stride;
+                std::tie(i_start, i_fence, i_stride) =
+                    result_row_range(proc_row);
+                const auto ij_stride = i_stride*nj;
+                for (size_type i = i_start, ij = i_start * nj + j; i < i_fence;
+                     i += i_stride, ij += ij_stride) {
+                  // ... if any such C[i][j] exists, update the mask, and move
+                  // on to next process
+                  if (!result_shape.is_zero(DistEvalImpl_::perm_index_to_target(ij))) {
+                    mask[proc_row] = true;
+                    break;
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        return mask;
+      }
+
+      /// computes the result row iteration range for a particular processor
+
+      /// \param proc_row the process row in \c this->proc_grid_
+      /// \return the {start,fence,stride} tuple which defines the iteration
+      ///         range for the row indices of the result tiles residing on
+      ///         process in row \c proc_row
+      inline std::tuple<size_type, size_type, size_type> result_row_range(
+          size_type proc_row) const {
+        const size_type start = left_.range().lobound_data()[0] + proc_row;
+        const size_type fence = left_.range().upbound_data()[0];
+        const size_type stride = proc_grid_.proc_rows();
+        return std::make_tuple(start, fence, stride);
+      }
+
+      /// computes the result column iteration range for a particular processor
+
+      /// \param proc_col the process column in \c this->proc_grid_
+      /// \return the {start,fence,stride} tuple which defines the iteration
+      ///         range for the column indices of the result tiles residing on
+      ///         process in column \c proc_col
+      std::tuple<size_type, size_type, size_type> result_col_range(
+          size_type proc_col) const {
+        const size_type start = right_.range().lobound_data()[1] + proc_col;
+        const size_type fence = left_.range().upbound_data()[1];
+        const size_type stride = proc_grid_.proc_cols();
+        return std::make_tuple(start, fence, stride);
       }
 
       // Broadcast kernels -----------------------------------------------------
@@ -680,6 +851,8 @@ namespace TiledArray {
         // Iterate over all local tiles
         size_type tile_count = 0ul;
         ReducePairTask<op_type>* restrict reduce_task = reduce_tasks_;
+        // this loops over result tiles arranged in block-cyclic order
+        // index = tile index (row major)
         for(; row_start < end; row_start += col_stride, row_end += col_stride) {
           for(size_type index = row_start; index < row_end; index += row_stride, ++reduce_task) {
 

--- a/src/TiledArray/dist_eval/contraction_eval.h
+++ b/src/TiledArray/dist_eval/contraction_eval.h
@@ -270,10 +270,8 @@ namespace TiledArray {
         // for each process in my row of the process grid determine whether there are any
         // nonzero C[i][*] located on that node
 
-        const auto nproc_rows = proc_grid_.proc_rows();
         const auto nproc_cols = proc_grid_.proc_cols();
         const auto my_proc_row = proc_grid_.rank_row();
-        const auto my_proc_col = proc_grid_.rank_col();
 
         // result shape
         const auto& result_shape = TensorImpl_::shape();
@@ -342,8 +340,6 @@ namespace TiledArray {
         // nonzero C[*][j] located on that node
 
         const auto nproc_rows = proc_grid_.proc_rows();
-        const auto nproc_cols = proc_grid_.proc_cols();
-        const auto my_proc_row = proc_grid_.rank_row();
         const auto my_proc_col = proc_grid_.rank_col();
 
         // result shape

--- a/src/TiledArray/proc_grid.h
+++ b/src/TiledArray/proc_grid.h
@@ -365,7 +365,7 @@ namespace TiledArray {
 
       /// Element count accessor
 
-      /// \return The number of element
+      /// \return The total number of elements
       size_type size() const { return size_; }
 
       /// Local element row count accessor
@@ -380,7 +380,7 @@ namespace TiledArray {
 
       /// Local element count accessor
 
-      /// \return The number of element
+      /// \return The number of elements assigned to this process
       size_type local_size() const { return local_size_; }
 
       /// Rank row accessor


### PR DESCRIPTION
broadcast groups take into account the result shape ... this is not an exhaustive account of sparsity but a good first step (e.g., the same group is used to broadcast all tiles in same row/column of processor grid, e.g. all A[i][k] are broadcast along the row using same group even though some may not be needed everywhere in the group due to the lack of matching B[k][j]) ... ideally in the future should use tile-specific masks to construct broadcast trees.