### PR TITLE
added toolchain of gcc + impi

### DIFF
--- a/cmake/toolchains/gcc-impi-mkl-tbb.cmake
+++ b/cmake/toolchains/gcc-impi-mkl-tbb.cmake
@@ -1,0 +1,49 @@
+#
+# Generic Toolchain for GCC + Intel IMPI + MKL + TBB
+#
+# REQUIREMENTS:
+# - in PATH:
+#   gcc, g++, mpiicc, and mpiicpc
+# - environment variables:
+#   * INTEL_DIR: the Intel compiler directory (includes MKL and TBB), e.g. /opt/intel
+#   * GCC_DIR: ${GCC_DIR}/bin/gcc points to the gcc compiler to use
+#   * EIGEN3_DIR or (deprecated) EIGEN_DIR: the Eigen3 directory
+#   * BOOST_DIR: the Boost root directory
+#
+
+# Set paths (add a cache entry for the paths used by the configure script)
+set(GCC_ROOT_DIR "$ENV{GCC_DIR}")
+set(MKL_ROOT_DIR "$ENV{INTEL_DIR}/mkl")
+set(TBB_ROOT_DIR "$ENV{INTEL_DIR}/tbb" CACHE PATH "TBB root directory")
+# query EIGEN3_DIR and (deprecated) EIGEN_DIR envvars
+if ($ENV{EIGEN3_DIR})
+  set(ENV_EIGEN3_DIR "$ENV{EIGEN3_DIR}")
+else()
+  set(ENV_EIGEN3_DIR "$ENV{EIGEN_DIR}")
+endif()
+set(EIGEN3_INCLUDE_DIR "${ENV_EIGEN3_DIR}" CACHE PATH "Eigen3 library directory")
+set(BOOST_ROOT "$ENV{BOOST_DIR}" CACHE PATH "Boost root directory")
+
+# Set compilers (assumes the compilers are in the PATH)
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+set(MPI_C_COMPILER mpiicc)
+set(MPI_CXX_COMPILER mpiicpc)
+
+# Set compile flags
+set(CMAKE_C_FLAGS_INIT             "-std=c99" CACHE STRING "Inital C compile flags")
+set(CMAKE_C_FLAGS_DEBUG            "-g -Wall" CACHE STRING "Inital C debug compile flags")
+set(CMAKE_C_FLAGS_MINSIZEREL       "-Os -DNDEBUG" CACHE STRING "Inital C minimum size release compile flags")
+set(CMAKE_C_FLAGS_RELEASE          "-O3 -DNDEBUG" CACHE STRING "Inital C release compile flags")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO   "-O2 -g -Wall" CACHE STRING "Inital C release with debug info compile flags")
+set(CMAKE_CXX_FLAGS_INIT           "-std=c++11" CACHE STRING "Inital C++ compile flags")
+set(CMAKE_CXX_FLAGS_DEBUG          "-g -Wall" CACHE STRING "Inital C++ debug compile flags")
+set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG" CACHE STRING "Inital C++ minimum size release compile flags")
+set(CMAKE_CXX_FLAGS_RELEASE        "-O3 -DNDEBUG" CACHE STRING "Inital C++ release compile flags")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -Wall" CACHE STRING "Inital C++ release with debug info compile flags")
+
+set(LAPACK_LIBRARIES "-Wl,--start-group" "${MKL_ROOT_DIR}/lib/intel64/libmkl_intel_lp64.a" 
+    "${MKL_ROOT_DIR}/lib/intel64/libmkl_core.a" "${MKL_ROOT_DIR}/lib/intel64/libmkl_sequential.a" "-Wl,--end-group"
+    "-lm" "-ldl" CACHE STRING "BLAS linker flags")
+set(INTEGER4 TRUE CACHE BOOL "Set Fortran integer size to 4 bytes")
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")

--- a/cmake/toolchains/gcc-mvapich-mkl-tbb.cmake
+++ b/cmake/toolchains/gcc-mvapich-mkl-tbb.cmake
@@ -1,5 +1,5 @@
 #
-# Generic Toolchain for MVAPICH + MKL 
+# Generic Toolchain for GCC + MVAPICH + MKL + TBB
 #
 # REQUIREMENTS:
 # - in PATH:


### PR DESCRIPTION
Intel 15/16 has issue compiling MPQC4. Other than using gcc + mvapich, @calewis propose to use gcc + impi. I made a new toolchain file for this combination, which makes it easier. 

