### PR TITLE
Bump Eigen requirement to 3.3 so that move semantics are supported

### DIFF
--- a/bin/build-eigen3-linux.sh
+++ b/bin/build-eigen3-linux.sh
@@ -1,0 +1,40 @@
+#! /bin/sh
+
+# Exit on error
+set -ev
+
+# Install packages
+
+# Environment variables
+if [ "$CXX" = "g++" ]; then
+  export CC=/usr/bin/gcc-$GCC_VERSION
+  export CXX=/usr/bin/g++-$GCC_VERSION
+  export EXTRACXXFLAGS="-mno-avx -fext-numeric-literals"
+else
+  export CC=/usr/bin/clang-5.0
+  export CXX=/usr/bin/clang++-5.0
+  export EXTRACXXFLAGS="-mno-avx"
+fi
+
+# Print compiler information
+$CC --version
+$CXX --version
+
+# log the CMake version (need 3+)
+cmake --version
+
+# Install Eigen3 unless previous install is cached ... must manually wipe cache on version bump or toolchain update
+export INSTALL_DIR=${INSTALL_PREFIX}/eigen3
+if [ ! -d "${INSTALL_DIR}" ]; then
+    cd ${BUILD_PREFIX}
+    wget -q http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2
+    tar -xjf 3.3.4.tar.bz2
+    cd eigen-*
+    cmake -DCMAKE_CXX_COMPILER=$CXX \
+      -DCMAKE_C_COMPILER=$CC \
+      -DCMAKE_CXX_FLAGS="${EXTRACXXFLAGS}" \
+      -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
+    make install
+else
+    echo "Eigen3 already installed ..."
+fi

--- a/bin/build-eigen3-linux.sh
+++ b/bin/build-eigen3-linux.sh
@@ -30,7 +30,9 @@ if [ ! -d "${INSTALL_DIR}" ]; then
     wget -q http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2
     tar -xjf 3.3.4.tar.bz2
     cd eigen-*
-    cmake -DCMAKE_CXX_COMPILER=$CXX \
+    mkdir build
+    cd build
+    cmake .. -DCMAKE_CXX_COMPILER=$CXX \
       -DCMAKE_C_COMPILER=$CC \
       -DCMAKE_CXX_FLAGS="${EXTRACXXFLAGS}" \
       -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}

--- a/bin/build-linux.sh
+++ b/bin/build-linux.sh
@@ -3,6 +3,11 @@
 ${TRAVIS_BUILD_DIR}/bin/build-mpich-linux.sh
 ${TRAVIS_BUILD_DIR}/bin/build-madness-linux.sh
 
+# to test both separate CMake install and during-build eigen download, pre-install only for Debug builds
+if [ "$BUILD_TYPE" = "Debug" ]; then
+  ${TRAVIS_BUILD_DIR}/bin/build-eigen3-linux.sh
+fi
+
 # Exit on error
 set -ev
 
@@ -51,6 +56,7 @@ if [ "$BUILD_TYPE" = "Debug" ]; then
     -DBUILD_SHARED_LIBS=OFF \
     -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
     -DCMAKE_CXX_FLAGS="-ftemplate-depth=1024 -Wno-unused-command-line-argument ${EXTRACXXFLAGS} ${CODECOVCXXFLAGS}" \
+    -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} \
     -DTA_BUILD_UNITTEST=ON \
     -DTA_ERROR="throw" \
     -DENABLE_ELEMENTAL=ON \
@@ -67,6 +73,7 @@ else
     -DBUILD_SHARED_LIBS=OFF \
     -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
     -DCMAKE_CXX_FLAGS="-ftemplate-depth=1024 -Wno-unused-command-line-argument ${EXTRACXXFLAGS}" \
+    -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} \
     -DTA_BUILD_UNITTEST=ON \
     -DTA_ERROR="throw" \
     -DENABLE_ELEMENTAL=ON -Wno-dev \

--- a/external/eigen.cmake
+++ b/external/eigen.cmake
@@ -6,7 +6,7 @@ include(AppendFlags)
 
 # Check for existing Eigen
 # prefer CMake-configured-and-installed instance
-find_package(Eigen3 3.1 NO_MODULE QUIET)
+find_package(Eigen3 3.3 NO_MODULE QUIET)
 if (TARGET Eigen3::Eigen)
   # import alias into TiledArray "namespace"
   # TODO bump CMake requirement to 3.11 when available, uncomment this and remove the rest of this clause
@@ -20,7 +20,7 @@ if (TARGET Eigen3::Eigen)
   install(TARGETS TiledArray_Eigen EXPORT tiledarray COMPONENT tiledarray)
 else (TARGET Eigen3::Eigen)
   # otherwise use bundled FindEigen3.cmake module controlled by EIGEN3_INCLUDE_DIR
-  find_package(Eigen3 3.1)
+  find_package(Eigen3 3.3)
 
   if (EIGEN3_FOUND)
     add_library(TiledArray_Eigen INTERFACE)
@@ -71,7 +71,7 @@ else()
   set(EXTERNAL_SOURCE_DIR   ${PROJECT_BINARY_DIR}/external/source/eigen)
   set(EXTERNAL_BUILD_DIR  ${PROJECT_BINARY_DIR}/external/build/eigen)
   set(EIGEN3_URL https://bitbucket.org/eigen/eigen)
-  set(EIGEN3_TAG 3.2.4)
+  set(EIGEN3_TAG 3.3.4)
 
   message("** Will build Eigen from ${EIGEN3_URL}")
 


### PR DESCRIPTION
Move semantics has been backported into 3.2.7, see http://eigen.tuxfamily.org/index.php?title=ChangeLog#Eigen_3.2.7. So 3.3 is a conservative bump.