### PR TITLE
Intel 19 auto deduction errors

### DIFF
--- a/src/TiledArray/tile_op/binary_wrapper.h
+++ b/src/TiledArray/tile_op/binary_wrapper.h
@@ -100,13 +100,13 @@ namespace TiledArray {
       static constexpr bool right_is_consumable = Op::right_is_consumable;
 
       template <typename T>
-      static constexpr auto is_lazy_tile_v = is_lazy_tile<std::decay_t<T> >::value;
+      static constexpr bool is_lazy_tile_v = is_lazy_tile<std::decay_t<T> >::value;
 
       template <typename T>
-      static constexpr auto is_array_tile_v = is_array_tile<std::decay_t<T> >::value;
+      static constexpr bool is_array_tile_v = is_array_tile<std::decay_t<T> >::value;
 
       template <typename T>
-      static constexpr auto is_nonarray_lazy_tile_v = is_lazy_tile_v<T> && !is_array_tile_v<T>;
+      static constexpr bool is_nonarray_lazy_tile_v = is_lazy_tile_v<T> && !is_array_tile_v<T>;
 
       template <typename T>
       using eval_t = typename eval_trait<std::decay_t<T> >::type;

--- a/src/TiledArray/tile_op/unary_wrapper.h
+++ b/src/TiledArray/tile_op/unary_wrapper.h
@@ -90,13 +90,13 @@ namespace TiledArray {
       static constexpr bool is_consumable = Op::is_consumable;
 
       template <typename T>
-      static constexpr auto is_lazy_tile_v = is_lazy_tile<std::decay_t<T>>::value;
+      static constexpr bool is_lazy_tile_v = is_lazy_tile<std::decay_t<T>>::value;
 
       template <typename T>
-      static constexpr auto is_array_tile_v = is_array_tile<std::decay_t<T>>::value;
+      static constexpr bool is_array_tile_v = is_array_tile<std::decay_t<T>>::value;
 
       template <typename T>
-      static constexpr auto is_nonarray_lazy_tile_v = is_lazy_tile_v<T> && !is_array_tile_v<T>;
+      static constexpr bool is_nonarray_lazy_tile_v = is_lazy_tile_v<T> && !is_array_tile_v<T>;
 
       template <typename T>
       using eval_t = typename eval_trait<std::decay_t<T> >::type;


### PR DESCRIPTION
Now it compiles fine.
The changes via [ac27dce](https://github.com/ValeevGroup/tiledarray/commit/ac27dce1e4b6e8b3f5b8ddba4f36f67d2494c99b) solved a lot of errors in the test, but we are still left with the following error:

/export/home/mambrois/TA/TAintel/tests/type_traits.cpp(257): error: in "type_traits_suite/convertibility": check lazy_tile_has_conversion_operator_to_tile has failed
