### PR TITLE
Add DistArray initializer_list ctor that supports tiling

### DIFF
--- a/src/TiledArray/dist_array.h
+++ b/src/TiledArray/dist_array.h
@@ -228,9 +228,11 @@ class DistArray : public madness::archive::ParallelSerializableObject {
                 std::shared_ptr<pmap_interface>())
       : pimpl_(init(world, trange, shape, pmap)) {}
 
+  /// \name Initializer list constructors
   /// \brief Creates a new tensor containing the elements in the provided
   ///         `std::initializer_list`.
-  ///
+  ///@{
+
   ///  This ctor will create an array comprised of a single tile. The array
   ///  will have a rank equal to the nesting of \p il and the elements will be
   ///  those in the provided `std::initializer_list`. This ctor can not be used
@@ -251,7 +253,6 @@ class DistArray : public madness::archive::ParallelSerializableObject {
   ///                              initialize a matrix with the value
   ///                              `{{1, 2}, {3, 4, 5}}`). If an exception is
   ///                              raised \p world and \p il are unchanged.
-  ///@{
   template <typename T>
   DistArray(World& world, detail::vector_il<T> il)
       : DistArray(array_from_il<DistArray_>(world, il)) {}
@@ -277,9 +278,11 @@ class DistArray : public madness::archive::ParallelSerializableObject {
       : DistArray(array_from_il<DistArray_>(world, il)) {}
   ///@}
 
-  /// \brief Creates a new tensor containing the elements in the provided
+  /// \name Tiling initializer list constructors
+  /// \brief Constructs a new tensor containing the elements in the provided
   ///         `std::initializer_list`.
-  ///
+  /// @{
+
   ///  This ctor will create an array using the provided TiledRange instance
   ///  whose values will be initialized from the provided
   ///  `std::initializer_list` \p il. This ctor can not be used to create an
@@ -301,7 +304,6 @@ class DistArray : public madness::archive::ParallelSerializableObject {
   ///                              initialize a matrix with the value
   ///                              `{{1, 2}, {3, 4, 5}}`). If an exception is
   ///                              raised \p world and \p il are unchanged.
-  ///@{
   template <typename T>
   DistArray(World& world, const trange_type& trange, detail::vector_il<T> il)
       : DistArray(array_from_il<DistArray_>(world, trange, il)) {}

--- a/src/TiledArray/dist_array.h
+++ b/src/TiledArray/dist_array.h
@@ -277,6 +277,54 @@ class DistArray : public madness::archive::ParallelSerializableObject {
       : DistArray(array_from_il<DistArray_>(world, il)) {}
   ///@}
 
+  /// \brief Creates a new tensor containing the elements in the provided
+  ///         `std::initializer_list`.
+  ///
+  ///  This ctor will create an array using the provided TiledRange instance
+  ///  whose values will be initialized from the provided
+  ///  `std::initializer_list` \p il. This ctor can not be used to create an
+  ///  empty tensor (attempts to do so will raise an error).
+  ///
+  /// \tparam T The types of the elements in the `std::initializer_list`. Must
+  ///           be implicitly convertible to element_type.
+  ///
+  /// \param[in] world The world where the resulting array will live.
+  /// \param[in] trange The tiling to use for the resulting array.
+  /// \param[in] il The initial values for the elements in the array. The
+  ///               elements are assumed to be listed in row-major order.
+  ///
+  /// \throw TiledArray::Exception if \p il contains no elements. If an
+  ///                              exception is raised \p world and \p il are
+  ///                              unchanged (strong throw guarantee).
+  /// \throw TiledArray::Exception If the provided `std::initializer_list` is
+  ///                              not rectangular (*e.g.*, attempting to
+  ///                              initialize a matrix with the value
+  ///                              `{{1, 2}, {3, 4, 5}}`). If an exception is
+  ///                              raised \p world and \p il are unchanged.
+  ///@{
+  template <typename T>
+  DistArray(World& world, const trange_type& trange, detail::vector_il<T> il)
+      : DistArray(array_from_il<DistArray_>(world, trange, il)) {}
+
+  template <typename T>
+  DistArray(World& world, const trange_type& trange, detail::matrix_il<T> il)
+      : DistArray(array_from_il<DistArray_>(world, trange, il)) {}
+
+  template <typename T>
+  DistArray(World& world, const trange_type& trange, detail::tensor3_il<T> il)
+      : DistArray(array_from_il<DistArray_>(world, trange, il)) {}
+
+  template <typename T>
+  DistArray(World& world, const trange_type& trange, detail::tensor4_il<T> il)
+      : DistArray(array_from_il<DistArray_>(world, trange, il)) {}
+
+  template <typename T>
+  DistArray(World& world, const trange_type& trange, detail::tensor5_il<T> il)
+      : DistArray(array_from_il<DistArray_>(world, trange, il)) {}
+
+  template <typename T>
+  DistArray(World& world, const trange_type& trange, detail::tensor6_il<T> il)
+      : DistArray(array_from_il<DistArray_>(world, trange, il)) {}
   /// @}
 
   /// converting copy constructor

--- a/src/TiledArray/tensor/tensor.h
+++ b/src/TiledArray/tensor/tensor.h
@@ -192,6 +192,9 @@ class Tensor {
     math::uninitialized_copy_vector(range.volume(), u, pimpl_->data_);
   }
 
+  Tensor(const Range& range, std::initializer_list<T> il)
+    : Tensor(range, il.begin()) {}
+
   /// Construct a copy of a tensor interface object
 
   /// \tparam T1 A tensor type

--- a/src/TiledArray/util/initializer_list.h
+++ b/src/TiledArray/util/initializer_list.h
@@ -250,17 +250,50 @@ auto flatten_il(T&& il, OutputItr out_itr) {
   return out_itr;
 }
 
+//------------------------------------------------------------------------------
+// get_elem_from_il free function
+//------------------------------------------------------------------------------
 
+/** @brief Retrieves the specified element from an initializer_list
+ *
+ *  Given an initializer_list with @f$N@f$ nestings, @p il, and an @f$N@f$
+ *  element index, @p idx, this function will return the element which is offset
+ *  `idx[i]` along the @f$i@f$-th mode of @p il.
+ *
+ * @tparam T The type of the container holding the index. Assumed to be a random
+ *           access container whose elements are of an integral type.
+ * @tparam U Assumed to be a scalar type (*e.g.* float, double, *etc.*) or a
+ *           (possibly nested) `std::initializer_list` of scalar types.
+ *
+ * @param[in] idx The desired element's offsets along each mode.
+ * @param[in] il The initializer list we are retrieving the value from.
+ * @param[in] depth Used internally to keep track of how many levels of
+ *                  recursion have occurred. Defaults to 0 and should not be
+ *                  modified.
+ * @return The requested element.
+ *
+ * @throws TiledArray::Exception if the number of elements in @p idx does not
+ *                               equal the nesting of @p il. Strong throw
+ *                               guarantee.
+ * @throws TiledArray::Exception if the offset along a mode is greater than the
+ *                               length of the mode. Strong throw guarantee.
+ */
 template<typename T, typename U>
 auto get_elem_from_il(T idx, U&&il, std::size_t depth = 0){
-  TA_ASSERT(il.size() > idx[depth]);
-
-  auto itr = std::advance(il.begin(), idx[depth]);
-  if constexpr(initializer_list_rank_v<std::decay_t<U>> == 1) {
-    return *itr;
+  constexpr auto nestings_left = initializer_list_rank_v<std::decay_t<U>>;
+  TA_ASSERT(idx.size() == nestings_left + depth);
+  if constexpr(nestings_left == 0){ // Handle scalars
+    return il;
   }
   else {
-    return get_elem_from_il(std::forward<T>(idx), *itr, depth + 1);
+    // Make sure the current nesting is long enough
+    TA_ASSERT(il.size() > idx[depth]);
+    auto itr = il.begin() + idx[depth];
+    if constexpr (nestings_left == 1) {
+      return *itr;
+    } else {
+      return get_elem_from_il(std::forward<T>(idx), *itr, depth + 1);
+    }
   }
 }
 
@@ -268,6 +301,39 @@ auto get_elem_from_il(T idx, U&&il, std::size_t depth = 0){
 // array_from_il free function
 //------------------------------------------------------------------------------
 
+/** @brief Converts an `std::initializer_list` into a tiled array.
+ *
+ *  This function encapsulates the process of turning an `std::initializer_list`
+ *  into a TiledArray array. The resulting tensor will have a tiling consistent
+ *  with the provided TiledRange, @p trange.
+ *
+ *  @note This function will raise a static assertion if you try to construct a
+ *        rank 0 tensor (*i.e.*, you pass in a single element and not an
+ *        `std::initializer_list`).
+ *
+ * @tparam ArrayType The type of the array we are creating. Expected to be
+ *                   have an API akin to that of DistArray
+ * @tparam T The type of the provided `std::initializer_list`.
+ *
+ * @param[in] world The context in which the resulting tensor will live.
+ * @param[in] trange The tiling for the resulting tensor.
+ * @param[in] il The initializer_list containing the initial state of the
+ *               tensor. @p il is assumed to be non-empty and in row-major form.
+ *               The nesting of @p il will be used to determine the rank of the
+ *               resulting tensor.
+ *
+ * @return A newly created instance of type @p ArrayType whose state is derived
+ *         from @p il and exists in the @p world context.
+ *
+ * @throw TiledArray::Exception if @p il contains no elements. If an exception
+ *                              is raised @p world, @p trange, and @p il are
+ *                              unchanged (strong throw guarantee).
+ * @throw TiledArray::Exception If the provided `std::initializer_list` is not
+ *                              rectangular (*e.g.*, attempting to initialize
+ *                              a matrix with the value `{{1, 2}, {3, 4, 5}}`).
+ *                              If an exception is raised @p world, @p trange,
+ *                              and @p il are unchanged.
+ */
 template<typename ArrayType, typename T>
 auto array_from_il(World& world, const TiledRange& trange, T&& il) {
   using element_type = typename ArrayType::element_type;
@@ -289,7 +355,7 @@ auto array_from_il(World& world, const TiledRange& trange, T&& il) {
   return rv;
 }
 
-/** @brief Converts an `std::initializer_list` into an array.
+/** @brief Converts an `std::initializer_list` into a single tile array.
  *
  *  This function encapsulates the process of turning an `std::initializer_list`
  *  into a TiledArray array. The resulting tensor will consistent of a single

--- a/tests/dist_array.cpp
+++ b/tests/dist_array.cpp
@@ -84,7 +84,9 @@ BOOST_AUTO_TEST_CASE(constructors) {
     auto op = [](auto& result, const auto& input) { result = input.clone(); };
     BOOST_REQUIRE_NO_THROW(SpArrayN as1(as, op));
   }
+}
 
+BOOST_AUTO_TEST_CASE(single_tile_initializer_list_ctors){
   // Create a vector with an initializer list
   {
     detail::vector_il<double> il{1, 2, 3};
@@ -99,7 +101,7 @@ BOOST_AUTO_TEST_CASE(constructors) {
   }
 
   // Create a matrix with an initializer list
-  {
+ {
     detail::matrix_il<double> il{{1, 2, 3}, {4, 5, 6}};
     TArray<double> a_matrix(world, il);
     for (typename TArray<double>::value_type tile : a_matrix) {
@@ -211,6 +213,80 @@ BOOST_AUTO_TEST_CASE(constructors) {
         }
       }
     }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(multi_tile_initializer_list_ctors) {
+  // Create a vector with an initializer list
+  {
+    detail::vector_il<double> il{1, 2, 3};
+    TiledRange tr{{0, 1, 3}};
+    TArray<double> a_vector(world, tr, il);
+    BOOST_CHECK_EQUAL(a_vector.size(), 2);
+  }
+
+  {
+    detail::matrix_il<double> il{{1, 2, 3}, {4, 5, 6}};
+    TiledRange tr{{0, 1, 2}, {0, 1, 3}};
+    TArray<double> a_matrix(world, tr, il);
+    BOOST_CHECK_EQUAL(a_matrix.size(), 4);
+  }
+
+  {
+    detail::tensor3_il<double> il{{{1, 2, 3}, {4, 5, 6}},
+                                  {{7, 8, 9}, {10, 11, 12}}};
+    TiledRange tr{{0, 1, 2}, {0, 1, 2}, {0, 1, 3}};
+    TArray<double> a_tensor(world, tr, il);
+    BOOST_CHECK_EQUAL(a_tensor.size(), 8);
+  }
+
+  {
+    detail::tensor4_il<double> il{{{{1, 2, 3}, {4, 5, 6}},
+                                   {{7, 8, 9}, {10, 11, 12}}},
+
+                                  {{{13, 14, 15} ,{16, 17, 18}},
+                                   {{19, 20, 21}, {22, 23, 24}}}};
+    TiledRange tr{{0, 1, 2},{0, 1, 2}, {0, 1, 2}, {0, 1, 3}};
+    TArray<double> a_tensor(world, tr, il);
+    BOOST_CHECK_EQUAL(a_tensor.size(), 16);
+  }
+
+  {
+    detail::tensor5_il<double> il{{{{{1, 2, 3}, {4, 5, 6}},
+                                    {{7, 8, 9}, {10, 11, 12}}},
+                                   {{{13, 14, 15} ,{16, 17, 18}},
+                                    {{19, 20, 21}, {22, 23, 24}}}},
+
+                                  {{{{1, 2, 3}, {4, 5, 6}},
+                                    {{7, 8, 9}, {10, 11, 12}}},
+                                   {{{13, 14, 15} ,{16, 17, 18}},
+                                    {{19, 20, 21}, {22, 23, 24}}}}};
+    TiledRange tr{{0, 1, 2}, {0, 1, 2}, {0, 1, 2}, {0, 1, 2}, {0, 1, 3}};
+    TArray<double> a_tensor(world, tr, il);
+    BOOST_CHECK_EQUAL(a_tensor.size(), 32);
+  }
+
+  {
+    detail::tensor6_il<double> il{{{{{{1, 2, 3}, {4, 5, 6}},
+                                     {{7, 8, 9}, {10, 11, 12}}},
+                                    {{{13, 14, 15} ,{16, 17, 18}},
+                                     {{19, 20, 21}, {22, 23, 24}}}},
+                                   {{{{1, 2, 3}, {4, 5, 6}},
+                                     {{7, 8, 9}, {10, 11, 12}}},
+                                    {{{13, 14, 15} ,{16, 17, 18}},
+                                     {{19, 20, 21}, {22, 23, 24}}}}},
+
+                                  {{{{{1, 2, 3}, {4, 5, 6}},
+                                     {{7, 8, 9}, {10, 11, 12}}},
+                                    {{{13, 14, 15} ,{16, 17, 18}},
+                                     {{19, 20, 21}, {22, 23, 24}}}},
+                                   {{{{1, 2, 3}, {4, 5, 6}},
+                                     {{7, 8, 9}, {10, 11, 12}}},
+                                    {{{13, 14, 15} ,{16, 17, 18}},
+                                     {{19, 20, 21}, {22, 23, 24}}}}}};
+    TiledRange tr{{0,1, 2}, {0, 1, 2}, {0, 1, 2}, {0, 1, 2}, {0, 1, 2}, {0, 1, 3}};
+    TArray<double> a_tensor(world, tr, il);
+    BOOST_CHECK_EQUAL(a_tensor.size(), 64);
   }
 }
 


### PR DESCRIPTION
This is basically just the generalization of #174 to multiple tiles.

To properly unit test some functions I really need there to be tiles in the tensors. This PR will add additional ctors of the form:

```.cpp
DistArray(World&, const trange_type&, T);
```
(where `T` is one of the `initializer_list` types). The provided `initializer_list` is expected to be the entire tensor, properly nested in row-major form. The ctor will then pluck the elements out of the provided `initializer_list` and put them into the correct tiles.

TODO:

- [x] unit test and document `get_elem_from_il`
- [x] unit test and document new `array_from_il` overload
- [x] add, document, and unit test new `DistArray` ctors