### PR TITLE
cuda/c++17 linking

### DIFF
--- a/cmake/tiledarray-config.cmake.in
+++ b/cmake/tiledarray-config.cmake.in
@@ -32,6 +32,7 @@ endif()
 set(TILEDARRAY_HAS_CUDA "@CUDA_FOUND@")
 if(TILEDARRAY_HAS_CUDA)
   set(CMAKE_CUDA_HOST_COMPILER "@CMAKE_CUDA_HOST_COMPILER@")
+  # workaround from https://gitlab.kitware.com/cmake/cmake/issues/18614#note_485631
   set(CUDA_LIBRARIES "@CUDA_LIBRARIES@")
   get_target_property(_ta_interface_libs tiledarray INTERFACE_LINK_LIBRARIES)
   if(_ta_interface_libs)

--- a/cmake/tiledarray-config.cmake.in
+++ b/cmake/tiledarray-config.cmake.in
@@ -39,8 +39,9 @@ if(TILEDARRAY_HAS_CUDA)
   else()
     set(_ta_interface_libs ${CUDA_LIBRARIES})
   endif()
+    string(TOUPPER ${CMAKE_BUILD_TYPE} TA_BUILD_TYPE)
   set_target_properties(tiledarray PROPERTIES
-    IMPORTED_LINK_INTERFACE_LANGUAGES_@CMAKE_BUILD_TYPE@ CXX
+    IMPORTED_LINK_INTERFACE_LANGUAGES_${TA_BUILD_TYPE} CXX
     INTERFACE_LINK_LIBRARIES "${_ta_interface_libs}")
 endif()
 

--- a/cmake/tiledarray-config.cmake.in
+++ b/cmake/tiledarray-config.cmake.in
@@ -40,6 +40,7 @@ if(TILEDARRAY_HAS_CUDA)
     set(_ta_interface_libs ${CUDA_LIBRARIES})
   endif()
   set_target_properties(tiledarray PROPERTIES
+    IMPORTED_LINK_INTERFACE_LANGUAGES_@CMAKE_BUILD_TYPE@ CXX
     INTERFACE_LINK_LIBRARIES "${_ta_interface_libs}")
 endif()
 

--- a/cmake/tiledarray-config.cmake.in
+++ b/cmake/tiledarray-config.cmake.in
@@ -12,21 +12,6 @@ set(TILEDARRAY_EXT_VERSION "@TILEDARRAY_EXT_VERSION@")
 
 @PACKAGE_INIT@
 
-set(TILEDARRAY_CMAKE_TOOLCHAIN_FILE "@CMAKE_TOOLCHAIN_FILE@")
-
-set(TILEDARRAY_HAS_CUDA "@CUDA_FOUND@")
-if(TILEDARRAY_HAS_CUDA)
-    set(CMAKE_CUDA_HOST_COMPILER "@CMAKE_CUDA_HOST_COMPILER@")
-# if TA is a CUDA-dependent library it needs CUDA to link properly ... unfortunately CMake is not able to do this correctly
-# see https://gitlab.kitware.com/cmake/cmake/issues/18614
-#    set(CMAKE_CUDA_STANDARD 17)
-#    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
-#    set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)
-#    enable_language(CUDA)
-#    include(SanitizeCUDAImplicitDirectories)
-#    sanitize_cuda_implicit_directories()
-endif()
-
 # Include library IMPORT targets
 if(NOT TARGET tiledarray)
   include("${CMAKE_CURRENT_LIST_DIR}/tiledarray-targets.cmake")
@@ -39,6 +24,23 @@ if(NOT TARGET MADworld)
     set(MADNESS_CONFIG_DIR "${CMAKE_CURRENT_LIST_DIR}/../madness")
   endif()
   find_package(MADNESS 0.10.1 CONFIG QUIET REQUIRED COMPONENTS world PATHS ${MADNESS_CONFIG_DIR} NO_DEFAULT_PATH)
+endif()
+
+# if TA is a CUDA-dependent library it needs CUDA to link properly ... unfortunately CMake is not able to do this correctly
+# see https://gitlab.kitware.com/cmake/cmake/issues/18614
+# so try workarounds
+set(TILEDARRAY_HAS_CUDA "@CUDA_FOUND@")
+if(TILEDARRAY_HAS_CUDA)
+  set(CMAKE_CUDA_HOST_COMPILER "@CMAKE_CUDA_HOST_COMPILER@")
+  set(CUDA_LIBRARIES "@CUDA_LIBRARIES@")
+  get_target_property(_ta_interface_libs tiledarray INTERFACE_LINK_LIBRARIES)
+  if(_ta_interface_libs)
+    list(APPEND _ta_interface_libs ${CUDA_LIBRARIES})
+  else()
+    set(_ta_interface_libs ${CUDA_LIBRARIES})
+  endif()
+  set_target_properties(tiledarray PROPERTIES
+    INTERFACE_LINK_LIBRARIES "${_ta_interface_libs}")
 endif()
 
 # Set the tiledarray compiled library target
@@ -58,5 +60,7 @@ if(CMAKE_CURRENT_LIST_DIR EQUAL TILEDARRAY_BINARY_DIR)
 else()
   set(TILEDARRAY_INCLUDE_DIRS "${TILEDARRAY_INSTALL_INCLUDE_DIRS}")
 endif()
+
+set(TILEDARRAY_CMAKE_TOOLCHAIN_FILE "@CMAKE_TOOLCHAIN_FILE@")
 
 set(TILEDARRAY_FOUND TRUE)

--- a/external/cuda.cmake
+++ b/external/cuda.cmake
@@ -22,10 +22,10 @@ set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)
 # despite enable_language(CUDA), this is still needed to find cuBLAS
 find_package(CUDA REQUIRED)
 
-message(STATUS "CUDA Host Compiler: " ${CMAKE_CUDA_HOST_COMPILER})
+message(STATUS "CUDA Host Compiler: ${CMAKE_CUDA_HOST_COMPILER}")
 message(STATUS "CUDA NVCC FLAGS: ${CUDA_NVCC_FLAGS}")
-message(STATUS "CUDA Include Dirs: " ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
-message(STATUS "CUDA Libraries: " ${CUDA_LIBRARIES})
+message(STATUS "CUDA Include Dirs: ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
+message(STATUS "CUDA Libraries: ${CUDA_LIBRARIES}")
 message(STATUS "cuBLAS Libraries: : ${CUDA_CUBLAS_LIBRARIES}")
 
 # CUDA_nvToolsExt_LIBRARY found by CMake 3.16 and later

--- a/external/cuda.cmake
+++ b/external/cuda.cmake
@@ -8,8 +8,12 @@ if(ENABLE_CUDA_ERROR_CHECK)
   set (TILEDARRAY_CHECK_CUDA_ERROR 1)
 endif(ENABLE_CUDA_ERROR_CHECK)
 
+# TODO uncomment, and remove workaround, when 3.17.0 is released
+#cmake_minimum_required(3.17.0) # decouples C++ and CUDA standards, see https://gitlab.kitware.com/cmake/cmake/issues/19123
+if (CMAKE_VERSION VERSION_LESS 3.17.0)
+  message(FATAL_ERROR "Need CMake 3.17 to support CUDA, but found version ${CMAKE_VERSION}")
+endif()
 enable_language(CUDA)
-cmake_minimum_required(3.17.0) # decouples C++ and CUDA standards, see https://gitlab.kitware.com/cmake/cmake/issues/19123
 set(CMAKE_CUDA_STANDARD 14)
 set(CMAKE_CUDA_EXTENSIONS OFF)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)

--- a/external/cuda.cmake
+++ b/external/cuda.cmake
@@ -18,9 +18,10 @@ set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)
 # despite enable_language(CUDA), this is still needed to find cuBLAS
 find_package(CUDA REQUIRED)
 
-message(STATUS "CUDA Include Dirs: " ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
 message(STATUS "CUDA Host Compiler: " ${CMAKE_CUDA_HOST_COMPILER})
 message(STATUS "CUDA NVCC FLAGS: ${CUDA_NVCC_FLAGS}")
+message(STATUS "CUDA Include Dirs: " ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+message(STATUS "CUDA Libraries: " ${CUDA_LIBRARIES})
 message(STATUS "cuBLAS Libraries: : ${CUDA_CUBLAS_LIBRARIES}")
 
 # CUDA_nvToolsExt_LIBRARY found by CMake 3.16 and later

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -243,7 +243,8 @@ target_include_directories(tiledarray PUBLIC ${Boost_INCLUDE_DIRS})
 
 if (CUDA_FOUND)
   target_include_directories(tiledarray PUBLIC ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
-  target_compile_features(tiledarray PUBLIC "cuda_std_${CMAKE_CUDA_STANDARD}")
+  # this will eventually work, but does not as of 3.17.0-rc2
+  #target_compile_features(tiledarray PUBLIC "cuda_std_${CMAKE_CUDA_STANDARD}")
 endif(CUDA_FOUND)
 
 if (LAPACK_INCLUDE_DIRS)


### PR DESCRIPTION
follow-up to #180, works around the inability of CMAKE to propagate CUDA dependency correctly (option or link libraries) to the downstream consumers