### PR TITLE
Fix inconsistencies in rank-local SVD wrapper

### DIFF
--- a/src/TiledArray/math/linalg/rank-local.cpp
+++ b/src/TiledArray/math/linalg/rank-local.cpp
@@ -150,27 +150,6 @@ void svd(Job jobu, Job jobvt, Matrix<T>& A, std::vector<T>& S, Matrix<T>* U, Mat
   S.resize(k);
   T* s = S.data();
 
-#if 0
-  auto jobu = lapack::Job::NoVec;
-  T* u = nullptr;
-  integer ldu = m;
-  if (U) {
-    jobu = lapack::Job::SomeVec;
-    U->resize(m, k);
-    u = U->data();
-    ldu = U->rows();
-  }
-
-  auto jobvt = lapack::Job::NoVec;
-  T* vt = nullptr;
-  integer ldvt = n;
-  if (VT) {
-    jobvt = lapack::Job::SomeVec;
-    VT->resize(k, n);
-    vt = VT->data();
-    ldvt = VT->rows();
-  }
-#else
   T* u  = nullptr;
   T* vt = nullptr;
   integer ldu = 1, ldvt = 1;
@@ -203,8 +182,6 @@ void svd(Job jobu, Job jobvt, Matrix<T>& A, std::vector<T>& S, Matrix<T>* U, Mat
     ldvt = n;
   }
     
-#endif
-
   TA_LAPACK(gesvd, jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt);
 }
 

--- a/src/TiledArray/math/linalg/rank-local.cpp
+++ b/src/TiledArray/math/linalg/rank-local.cpp
@@ -143,18 +143,19 @@ template <typename T>
 void svd(Matrix<T>& A, std::vector<T>& S, Matrix<T>* U, Matrix<T>* VT) {
   integer m = A.rows();
   integer n = A.cols();
+  integer k = std::min(m, n);
   T* a = A.data();
   integer lda = A.rows();
 
-  S.resize(std::min(m, n));
+  S.resize(k);
   T* s = S.data();
 
   auto jobu = lapack::Job::NoVec;
   T* u = nullptr;
   integer ldu = m;
   if (U) {
-    jobu = lapack::Job::AllVec;
-    U->resize(m, n);
+    jobu = lapack::Job::SomeVec;
+    U->resize(m, k);
     u = U->data();
     ldu = U->rows();
   }
@@ -163,8 +164,8 @@ void svd(Matrix<T>& A, std::vector<T>& S, Matrix<T>* U, Matrix<T>* VT) {
   T* vt = nullptr;
   integer ldvt = n;
   if (VT) {
-    jobvt = lapack::Job::AllVec;
-    VT->resize(n, m);
+    jobvt = lapack::Job::SomeVec;
+    VT->resize(k, n);
     vt = VT->data();
     ldvt = VT->rows();
   }

--- a/src/TiledArray/math/linalg/rank-local.h
+++ b/src/TiledArray/math/linalg/rank-local.h
@@ -10,6 +10,8 @@
 
 namespace TiledArray::math::linalg::rank_local {
 
+using Job = ::lapack::Job;
+
 template <typename T, int Options = ::Eigen::ColMajor>
 using Matrix = ::Eigen::Matrix<T, ::Eigen::Dynamic, ::Eigen::Dynamic, Options>;
 
@@ -35,7 +37,14 @@ template <typename T>
 void heig(Matrix<T> &A, Matrix<T> &B, std::vector<T> &W);
 
 template <typename T>
-void svd(Matrix<T> &A, std::vector<T> &S, Matrix<T> *U, Matrix<T> *VT);
+void svd(Job jobu, Job jobvt, Matrix<T> &A, std::vector<T> &S, Matrix<T> *U, Matrix<T> *VT);
+
+template <typename T>
+void svd(Matrix<T> &A, std::vector<T> &S, Matrix<T> *U, Matrix<T> *VT) {
+  svd( U  ? Job::SomeVec : Job::NoVec, 
+       VT ? Job::SomeVec : Job::NoVec,
+       A, S, U, VT );
+}
 
 template <typename T>
 void lu_solve(Matrix<T> &A, Matrix<T> &B);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,11 +88,11 @@ set(ta_test_src_files  ta_test.cpp
     reduce_task.cpp
     proc_grid.cpp
     dist_eval_contraction_eval.cpp
-    #expressions.cpp
-    #expressions_sparse.cpp
-    #expressions_complex.cpp
-    #expressions_btas.cpp
-    #expressions_mixed.cpp
+    expressions.cpp
+    expressions_sparse.cpp
+    expressions_complex.cpp
+    expressions_btas.cpp
+    expressions_mixed.cpp
     foreach.cpp
     solvers.cpp
     initializer_list.cpp
@@ -102,7 +102,7 @@ set(ta_test_src_files  ta_test.cpp
     tot_dist_array_part2.cpp
     random.cpp
     trace.cpp
-    #tot_expressions.cpp
+    tot_expressions.cpp
     annotation.cpp
     diagonal_array.cpp
     contraction_helpers.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,11 +88,11 @@ set(ta_test_src_files  ta_test.cpp
     reduce_task.cpp
     proc_grid.cpp
     dist_eval_contraction_eval.cpp
-    expressions.cpp
-    expressions_sparse.cpp
-    expressions_complex.cpp
-    expressions_btas.cpp
-    expressions_mixed.cpp
+    #expressions.cpp
+    #expressions_sparse.cpp
+    #expressions_complex.cpp
+    #expressions_btas.cpp
+    #expressions_mixed.cpp
     foreach.cpp
     solvers.cpp
     initializer_list.cpp
@@ -102,7 +102,7 @@ set(ta_test_src_files  ta_test.cpp
     tot_dist_array_part2.cpp
     random.cpp
     trace.cpp
-    tot_expressions.cpp
+    #tot_expressions.cpp
     annotation.cpp
     diagonal_array.cpp
     contraction_helpers.cpp


### PR DESCRIPTION
Addresses https://github.com/ValeevGroup/tiledarray/issues/262

This PR implements the following changes:
1. The rank-local SVD wrapper now does the "right" thing viz reallocating U/VT to the right dimensions based on the desired outputs.
2. Changes the default behaviour to be "SomeVec" as opposed to "AllVec" to coincide with ScaLAPACK APIs
3. Adds flexibility in the rank-local SVD wrapper to allow for all allowable "Job" types for XGESVD in LAPACK