### PR TITLE
update travis clang to 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,64 +83,36 @@ matrix:
             - g++-9
             - gfortran-9
     - compiler: clang
-      env: CLANG_VERSION=9 GCC_VERSION=8 BUILD_TYPE=Debug
+      env: CLANG_VERSION=11 GCC_VERSION=8 BUILD_TYPE=Debug
       addons:
         apt:
           sources:
-            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-9 main'
+            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
             - *base_packages
             - g++-8
             - gfortran-8
-            - clang-9
-            - libc++-9-dev
-            - libc++abi-9-dev
+            - clang-11
+            - libc++-11-dev
+            - libc++abi-11-dev
     - compiler: clang
-      env: CLANG_VERSION=9 GCC_VERSION=8 BUILD_TYPE=Release DEPLOY=1
+      env: CLANG_VERSION=11 GCC_VERSION=8 BUILD_TYPE=Release DEPLOY=1
       addons:
         apt:
           sources:
-            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-9 main'
+            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
             - *base_packages
             - g++-8
             - gfortran-8
-            - clang-9
-            - libc++-9-dev
-            - libc++abi-9-dev
+            - clang-11
+            - libc++-11-dev
+            - libc++abi-11-dev
             - libclang1-9 # libclang for doxygen
             - graphviz # provides dot for doxygen graphs
             - fonts-liberation # recommended by graphviz
-    - compiler: clang
-      env: CLANG_VERSION=10 GCC_VERSION=8 BUILD_TYPE=Debug
-      addons:
-        apt:
-          sources:
-            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
-              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
-          packages:
-            - *base_packages
-            - g++-8
-            - gfortran-8
-            - clang-10
-            - libc++-10-dev
-            - libc++abi-10-dev
-    - compiler: clang
-      env: CLANG_VERSION=10 GCC_VERSION=8 BUILD_TYPE=Release
-      addons:
-        apt:
-          sources:
-            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
-              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
-          packages:
-            - *base_packages
-            - g++-8
-            - gfortran-8
-            - clang-10
-            - libc++-10-dev
-            - libc++abi-10-dev
 
 before_install:
   - env

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,33 +83,11 @@ matrix:
             - g++-9
             - gfortran-9
     - compiler: clang
-      env: CLANG_VERSION=8 GCC_VERSION=8 BUILD_TYPE=Debug
-      addons:
-        apt:
-          packages:
-            - *base_packages
-            - g++-8
-            - gfortran-8
-            - clang-8
-            - libc++-8-dev
-            - libc++abi-8-dev
-    - compiler: clang
-      env: CLANG_VERSION=8 GCC_VERSION=8 BUILD_TYPE=Release
-      addons:
-        apt:
-          packages:
-            - *base_packages
-            - g++-8
-            - gfortran-8
-            - clang-8
-            - libc++-8-dev
-            - libc++abi-8-dev
-    - compiler: clang
       env: CLANG_VERSION=9 GCC_VERSION=8 BUILD_TYPE=Debug
       addons:
         apt:
           sources:
-            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal main'
+            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-9 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
             - *base_packages
@@ -123,7 +101,7 @@ matrix:
       addons:
         apt:
           sources:
-            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal main'
+            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-9 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
             - *base_packages
@@ -135,6 +113,34 @@ matrix:
             - libclang1-9 # libclang for doxygen
             - graphviz # provides dot for doxygen graphs
             - fonts-liberation # recommended by graphviz
+    - compiler: clang
+      env: CLANG_VERSION=10 GCC_VERSION=8 BUILD_TYPE=Debug
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+          packages:
+            - *base_packages
+            - g++-8
+            - gfortran-8
+            - clang-10
+            - libc++-10-dev
+            - libc++abi-10-dev
+    - compiler: clang
+      env: CLANG_VERSION=10 GCC_VERSION=8 BUILD_TYPE=Release
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+          packages:
+            - *base_packages
+            - g++-8
+            - gfortran-8
+            - clang-10
+            - libc++-10-dev
+            - libc++abi-10-dev
 
 before_install:
   - env

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ matrix:
             - *base_packages
             - g++-9
             - gfortran-9
+  allow_failures:   # travis focal images broken right now: https://travis-ci.community/t/clang-10-was-recently-broken-on-linux-unmet-dependencies-for-clang-10-clang-tidy-10-valgrind/11527
     - compiler: clang
       env: CLANG_VERSION=11 GCC_VERSION=8 BUILD_TYPE=Debug
       addons:

--- a/bin/docker-travis.md
+++ b/bin/docker-travis.md
@@ -14,7 +14,7 @@ These notes assume that Docker is installed on your machine and that you start a
     * `export CXX=g++`
   * If want to use Clang C++ compiler (clang++):
     * `export GCC_VERSION=8`
-    * `export CLANG_VERSION=VVV` where `VVV` should be the Clang version to be used. The currently valid values are `8` and `9`.
+    * `export CLANG_VERSION=VVV` where `VVV` should be the Clang version to be used. The currently valid values are `9` and `10`.
     * `export CXX=clang++`
     * `apt-get update && apt-get install libc++-${CLANG_VERSION}-dev libc++abi-${CLANG_VERSION}-dev`
 5. Build prerequisites (MPICH, MADNESS, ScaLAPACK), TiledArray, and run tests: `./build.sh`

--- a/bin/docker-travis.md
+++ b/bin/docker-travis.md
@@ -14,7 +14,7 @@ These notes assume that Docker is installed on your machine and that you start a
     * `export CXX=g++`
   * If want to use Clang C++ compiler (clang++):
     * `export GCC_VERSION=8`
-    * `export CLANG_VERSION=VVV` where `VVV` should be the Clang version to be used. The currently valid values are `9` and `10`.
+    * `export CLANG_VERSION=VVV` where `VVV` should be the Clang version to be used. The currently valid values is `11`.
     * `export CXX=clang++`
     * `apt-get update && apt-get install libc++-${CLANG_VERSION}-dev libc++abi-${CLANG_VERSION}-dev`
 5. Build prerequisites (MPICH, MADNESS, ScaLAPACK), TiledArray, and run tests: `./build.sh`


### PR DESCRIPTION
but disable due to still unfixed issue with travis ubuntu focal image https://travis-ci.community/t/clang-10-was-recently-broken-on-linux-unmet-dependencies-for-clang-10-clang-tidy-10-valgrind/11527