### PR TITLE
Tensor fwddecl "moved" to fwd.h

### DIFF
--- a/src/TiledArray/array_impl.cpp
+++ b/src/TiledArray/array_impl.cpp
@@ -28,31 +28,23 @@
 namespace TiledArray {
 namespace detail {
 
-template class ArrayImpl<Tensor<double, Eigen::aligned_allocator<double> >,
-                         DensePolicy>;
-template class ArrayImpl<Tensor<float, Eigen::aligned_allocator<float> >,
-                         DensePolicy>;
-template class ArrayImpl<Tensor<int, Eigen::aligned_allocator<int> >,
-                         DensePolicy>;
-template class ArrayImpl<Tensor<long, Eigen::aligned_allocator<long> >,
-                         DensePolicy>;
-//    template class ArrayImpl<Tensor<std::complex<double>,
-//    Eigen::aligned_allocator<std::complex<double> > >, DensePolicy>; template
-//    class ArrayImpl<Tensor<std::complex<float>,
-//    Eigen::aligned_allocator<std::complex<float> > >, DensePolicy>
+template class ArrayImpl<Tensor<double>, DensePolicy>;
+template class ArrayImpl<Tensor<float>, DensePolicy>;
+// template class ArrayImpl<Tensor<int>,
+//                         DensePolicy>;
+// template class ArrayImpl<Tensor<long>,
+//                         DensePolicy>;
+template class ArrayImpl<Tensor<std::complex<double>>, DensePolicy>;
+template class ArrayImpl<Tensor<std::complex<float>>, DensePolicy>;
 
-template class ArrayImpl<Tensor<double, Eigen::aligned_allocator<double> >,
-                         SparsePolicy>;
-template class ArrayImpl<Tensor<float, Eigen::aligned_allocator<float> >,
-                         SparsePolicy>;
-template class ArrayImpl<Tensor<int, Eigen::aligned_allocator<int> >,
-                         SparsePolicy>;
-template class ArrayImpl<Tensor<long, Eigen::aligned_allocator<long> >,
-                         SparsePolicy>;
-//    template class ArrayImpl<Tensor<std::complex<double>,
-//    Eigen::aligned_allocator<std::complex<double> > >, SparsePolicy>; template
-//    class ArrayImpl<Tensor<std::complex<float>,
-//    Eigen::aligned_allocator<std::complex<float> > >, SparsePolicy>;
+template class ArrayImpl<Tensor<double>, SparsePolicy>;
+template class ArrayImpl<Tensor<float>, SparsePolicy>;
+// template class ArrayImpl<Tensor<int>,
+//                         SparsePolicy>;
+// template class ArrayImpl<Tensor<long>,
+//                         SparsePolicy>;
+template class ArrayImpl<Tensor<std::complex<double>>, SparsePolicy>;
+template class ArrayImpl<Tensor<std::complex<float>>, SparsePolicy>;
 
 }  // namespace detail
 }  // namespace TiledArray

--- a/src/TiledArray/array_impl.h
+++ b/src/TiledArray/array_impl.h
@@ -644,33 +644,23 @@ class ArrayImpl : public TensorImpl<Policy> {
 
 #ifndef TILEDARRAY_HEADER_ONLY
 
-extern template class ArrayImpl<
-    Tensor<double, Eigen::aligned_allocator<double>>, DensePolicy>;
-extern template class ArrayImpl<Tensor<float, Eigen::aligned_allocator<float>>,
-                                DensePolicy>;
-extern template class ArrayImpl<Tensor<int, Eigen::aligned_allocator<int>>,
-                                DensePolicy>;
-extern template class ArrayImpl<Tensor<long, Eigen::aligned_allocator<long>>,
-                                DensePolicy>;
-//    extern template
-//    class ArrayImpl<Tensor<std::complex<double>,
-//    Eigen::aligned_allocator<std::complex<double> > >, DensePolicy>; extern
-//    template class ArrayImpl<Tensor<std::complex<float>,
-//    Eigen::aligned_allocator<std::complex<float> > >, DensePolicy>;
+extern template class ArrayImpl<Tensor<double>, DensePolicy>;
+extern template class ArrayImpl<Tensor<float>, DensePolicy>;
+// extern template class ArrayImpl<Tensor<int>,
+//                                DensePolicy>;
+// extern template class ArrayImpl<Tensor<long>,
+//                                DensePolicy>;
+extern template class ArrayImpl<Tensor<std::complex<double>>, DensePolicy>;
+extern template class ArrayImpl<Tensor<std::complex<float>>, DensePolicy>;
 
-extern template class ArrayImpl<
-    Tensor<double, Eigen::aligned_allocator<double>>, SparsePolicy>;
-extern template class ArrayImpl<Tensor<float, Eigen::aligned_allocator<float>>,
-                                SparsePolicy>;
-extern template class ArrayImpl<Tensor<int, Eigen::aligned_allocator<int>>,
-                                SparsePolicy>;
-extern template class ArrayImpl<Tensor<long, Eigen::aligned_allocator<long>>,
-                                SparsePolicy>;
-//    extern template
-//    class ArrayImpl<Tensor<std::complex<double>,
-//    Eigen::aligned_allocator<std::complex<double> > >, SparsePolicy>; extern
-//    template class ArrayImpl<Tensor<std::complex<float>,
-//    Eigen::aligned_allocator<std::complex<float> > >, SparsePolicy>;
+extern template class ArrayImpl<Tensor<double>, SparsePolicy>;
+extern template class ArrayImpl<Tensor<float>, SparsePolicy>;
+// extern template class ArrayImpl<Tensor<int>,
+//                                SparsePolicy>;
+// extern template class ArrayImpl<Tensor<long>,
+//                                SparsePolicy>;
+extern template class ArrayImpl<Tensor<std::complex<double>>, SparsePolicy>;
+extern template class ArrayImpl<Tensor<std::complex<float>>, SparsePolicy>;
 
 #endif  // TILEDARRAY_HEADER_ONLY
 

--- a/src/TiledArray/conversions/foreach.h
+++ b/src/TiledArray/conversions/foreach.h
@@ -277,8 +277,7 @@ inline std::
   tiles.reserve(arg.pmap()->size());
 
   // Construct a tensor to hold updated tile norms for the result shape.
-  TiledArray::Tensor<typename shape_type::value_type,
-                     Eigen::aligned_allocator<typename shape_type::value_type>>
+  TiledArray::Tensor<typename shape_type::value_type>
       tile_norms(arg.trange().tiles_range(), 0);
 
   // Construct the task function used to construct the result tiles.

--- a/src/TiledArray/conversions/make_array.h
+++ b/src/TiledArray/conversions/make_array.h
@@ -146,9 +146,7 @@ inline Array make_array(World& world, const detail::trange_t<Array>& trange,
   tiles.reserve(pmap->size());
 
   // Construct a tensor to hold updated tile norms for the result shape.
-  TiledArray::Tensor<
-      typename detail::shape_t<Array>::value_type,
-      Eigen::aligned_allocator<typename detail::shape_t<Array>::value_type> >
+  TiledArray::Tensor<typename detail::shape_t<Array>::value_type>
       tile_norms(trange.tiles_range(), 0);
 
   // Construct the task function used to construct the result tiles.

--- a/src/TiledArray/dist_array.cpp
+++ b/src/TiledArray/dist_array.cpp
@@ -31,30 +31,22 @@
 
 namespace TiledArray {
 
-template class DistArray<Tensor<double, Eigen::aligned_allocator<double> >,
-                         DensePolicy>;
-template class DistArray<Tensor<float, Eigen::aligned_allocator<float> >,
-                         DensePolicy>;
-template class DistArray<Tensor<int, Eigen::aligned_allocator<int> >,
-                         DensePolicy>;
-template class DistArray<Tensor<long, Eigen::aligned_allocator<long> >,
-                         DensePolicy>;
-//  template class DistArray<Tensor<std::complex<double>,
-//  Eigen::aligned_allocator<std::complex<double> > >, DensePolicy>; template
-//  class DistArray<Tensor<std::complex<float>,
-//  Eigen::aligned_allocator<std::complex<float> > >, DensePolicy>;
+template class DistArray<Tensor<double>, DensePolicy>;
+template class DistArray<Tensor<float>, DensePolicy>;
+// template class DistArray<Tensor<int>,
+//                         DensePolicy>;
+// template class DistArray<Tensor<long>,
+//                         DensePolicy>;
+template class DistArray<Tensor<std::complex<double>>, DensePolicy>;
+template class DistArray<Tensor<std::complex<float>>, DensePolicy>;
 
-template class DistArray<Tensor<double, Eigen::aligned_allocator<double> >,
-                         SparsePolicy>;
-template class DistArray<Tensor<float, Eigen::aligned_allocator<float> >,
-                         SparsePolicy>;
-template class DistArray<Tensor<int, Eigen::aligned_allocator<int> >,
-                         SparsePolicy>;
-template class DistArray<Tensor<long, Eigen::aligned_allocator<long> >,
-                         SparsePolicy>;
-//  template class DistArray<Tensor<std::complex<double>,
-//  Eigen::aligned_allocator<std::complex<double> > >, SparsePolicy>; template
-//  class DistArray<Tensor<std::complex<float>,
-//  Eigen::aligned_allocator<std::complex<float> > >, SparsePolicy>;
+template class DistArray<Tensor<double>, SparsePolicy>;
+template class DistArray<Tensor<float>, SparsePolicy>;
+// template class DistArray<Tensor<int>,
+//                         SparsePolicy>;
+// template class DistArray<Tensor<long>,
+//                         SparsePolicy>;
+template class DistArray<Tensor<std::complex<double>>, SparsePolicy>;
+template class DistArray<Tensor<std::complex<float>>, SparsePolicy>;
 
 }  // namespace TiledArray

--- a/src/TiledArray/dist_array.h
+++ b/src/TiledArray/dist_array.h
@@ -49,7 +49,7 @@ class Tensor;
 /// used to construct distributed tensor algebraic operations.
 /// \tparam T The element type of for array tiles
 /// \tparam Tile The tile type [ Default = \c Tensor<T> ]
-template <typename Tile = Tensor<double, Eigen::aligned_allocator<double>>,
+template <typename Tile = Tensor<double>,
           typename Policy = DensePolicy>
 class DistArray : public madness::archive::ParallelSerializableObject {
  public:
@@ -1555,33 +1555,23 @@ madness::AtomicInt DistArray<Tile, Policy>::cleanup_counter_;
 
 #ifndef TILEDARRAY_HEADER_ONLY
 
-extern template class DistArray<
-    Tensor<double, Eigen::aligned_allocator<double>>, DensePolicy>;
-extern template class DistArray<Tensor<float, Eigen::aligned_allocator<float>>,
-                                DensePolicy>;
-extern template class DistArray<Tensor<int, Eigen::aligned_allocator<int>>,
-                                DensePolicy>;
-extern template class DistArray<Tensor<long, Eigen::aligned_allocator<long>>,
-                                DensePolicy>;
-//  extern template
-//  class DistArray<Tensor<std::complex<double>,
-//  Eigen::aligned_allocator<std::complex<double> > >, DensePolicy>; extern
-//  template class DistArray<Tensor<std::complex<float>,
-//  Eigen::aligned_allocator<std::complex<float> > >, DensePolicy>
+extern template class DistArray<Tensor<double>, DensePolicy>;
+extern template class DistArray<Tensor<float>, DensePolicy>;
+// extern template class DistArray<Tensor<int>,
+//                                DensePolicy>;
+// extern template class DistArray<Tensor<long>,
+//                                DensePolicy>;
+extern template class DistArray<Tensor<std::complex<double>>, DensePolicy>;
+extern template class DistArray<Tensor<std::complex<float>>, DensePolicy>;
 
-extern template class DistArray<
-    Tensor<double, Eigen::aligned_allocator<double>>, SparsePolicy>;
-extern template class DistArray<Tensor<float, Eigen::aligned_allocator<float>>,
-                                SparsePolicy>;
-extern template class DistArray<Tensor<int, Eigen::aligned_allocator<int>>,
-                                SparsePolicy>;
-extern template class DistArray<Tensor<long, Eigen::aligned_allocator<long>>,
-                                SparsePolicy>;
-//  extern template
-//  class DistArray<Tensor<std::complex<double>,
-//  Eigen::aligned_allocator<std::complex<double> > >, SparsePolicy>; extern
-//  template class DistArray<Tensor<std::complex<float>,
-//  Eigen::aligned_allocator<std::complex<float> > >, SparsePolicy>;
+extern template class DistArray<Tensor<double>, SparsePolicy>;
+extern template class DistArray<Tensor<float>, SparsePolicy>;
+// extern template class DistArray<Tensor<int>,
+//                                SparsePolicy>;
+// extern template class DistArray<Tensor<long>,
+//                                SparsePolicy>;
+extern template class DistArray<Tensor<std::complex<double>>, SparsePolicy>;
+extern template class DistArray<Tensor<std::complex<float>>, SparsePolicy>;
 
 #endif  // TILEDARRAY_HEADER_ONLY
 

--- a/src/TiledArray/fwd.h
+++ b/src/TiledArray/fwd.h
@@ -25,6 +25,8 @@
 #include <btas/fwd.h>
 #include <complex>
 
+// #include <boost/container/detail/std_fwd.hpp>  // fwddecl for std::allocator
+
 namespace Eigen {  // fwd define Eigen's aligned allocator for
                    // TiledArray::Tensor
 template <class>
@@ -32,7 +34,7 @@ class aligned_allocator;
 }  // namespace Eigen
 
 namespace madness {
-  class World;
+class World;
 }
 
 namespace TiledArray {
@@ -44,25 +46,23 @@ World& get_default_world();
 class Range;
 class TiledRange1;
 class TiledRange;
+class BlockRange;
 
 // TiledArray Policy
 class DensePolicy;
 class SparsePolicy;
 
 // TiledArray Tensors
-template <typename, typename>
+template <typename T,
+          typename A = Eigen::aligned_allocator<T> /* std::allocator<T> */>
 class Tensor;
 
-typedef Tensor<double, Eigen::aligned_allocator<double> > TensorD;
-typedef Tensor<int, Eigen::aligned_allocator<int> > TensorI;
-typedef Tensor<float, Eigen::aligned_allocator<float> > TensorF;
-typedef Tensor<long, Eigen::aligned_allocator<long> > TensorL;
-typedef Tensor<std::complex<double>,
-               Eigen::aligned_allocator<std::complex<double> > >
-    TensorZ;
-typedef Tensor<std::complex<float>,
-               Eigen::aligned_allocator<std::complex<float> > >
-    TensorC;
+typedef Tensor<double> TensorD;
+typedef Tensor<int> TensorI;
+typedef Tensor<float> TensorF;
+typedef Tensor<long> TensorL;
+typedef Tensor<std::complex<double>> TensorZ;
+typedef Tensor<std::complex<float>> TensorC;
 
 // CUDA tensor
 #ifdef TILEDARRAY_HAS_CUDA
@@ -90,35 +90,43 @@ using btasUMTensorVarray =
 
 #endif
 
+template <typename>
+class Tile;
+
+class Permutation;
+class BipartitePermutation;
+
+namespace symmetry {
+class Permutation;
+}
+
 // TiledArray Arrays
 template <typename, typename>
 class DistArray;
 
 // Dense Array Typedefs
 template <typename T>
-using TArray = DistArray<Tensor<T, Eigen::aligned_allocator<T> >, DensePolicy>;
+using TArray = DistArray<Tensor<T>, DensePolicy>;
 typedef TArray<double> TArrayD;
 typedef TArray<int> TArrayI;
 typedef TArray<float> TArrayF;
 typedef TArray<long> TArrayL;
-typedef TArray<std::complex<double> > TArrayZ;
-typedef TArray<std::complex<float> > TArrayC;
+typedef TArray<std::complex<double>> TArrayZ;
+typedef TArray<std::complex<float>> TArrayC;
 
 // Sparse Array Typedefs
 template <typename T>
-using TSpArray =
-    DistArray<Tensor<T, Eigen::aligned_allocator<T> >, SparsePolicy>;
+using TSpArray = DistArray<Tensor<T>, SparsePolicy>;
 typedef TSpArray<double> TSpArrayD;
 typedef TSpArray<int> TSpArrayI;
 typedef TSpArray<float> TSpArrayF;
 typedef TSpArray<long> TSpArrayL;
-typedef TSpArray<std::complex<double> > TSpArrayZ;
-typedef TSpArray<std::complex<float> > TSpArrayC;
+typedef TSpArray<std::complex<double>> TSpArrayZ;
+typedef TSpArray<std::complex<float>> TSpArrayC;
 
 // type alias for backward compatibility: the old Array has static type,
 // DistArray is rank-polymorphic
-template <typename T, unsigned int = 0,
-          typename Tile = Tensor<T, Eigen::aligned_allocator<T> >,
+template <typename T, unsigned int = 0, typename Tile = Tensor<T>,
           typename Policy = DensePolicy>
 using Array = DistArray<Tile, Policy>;
 

--- a/src/TiledArray/tensor/tensor.cpp
+++ b/src/TiledArray/tensor/tensor.cpp
@@ -28,13 +28,11 @@
 
 namespace TiledArray {
 
-template class Tensor<double, Eigen::aligned_allocator<double> >;
-template class Tensor<float, Eigen::aligned_allocator<float> >;
-template class Tensor<int, Eigen::aligned_allocator<int> >;
-template class Tensor<long, Eigen::aligned_allocator<long> >;
-//  template class Tensor<std::complex<double>,
-//  Eigen::aligned_allocator<std::complex<double> > >; template class
-//  Tensor<std::complex<float>, Eigen::aligned_allocator<std::complex<float> >
-//  >;
+template class Tensor<double>;
+template class Tensor<float>;
+// template class Tensor<int>;
+// template class Tensor<long>;
+template class Tensor<std::complex<double>>;
+template class Tensor<std::complex<float>>;
 
 }  // namespace TiledArray

--- a/src/TiledArray/tensor/tensor.h
+++ b/src/TiledArray/tensor/tensor.h
@@ -2250,15 +2250,12 @@ struct transform<Tensor<T, A>> {
 
 #ifndef TILEDARRAY_HEADER_ONLY
 
-extern template class Tensor<double, Eigen::aligned_allocator<double>>;
-extern template class Tensor<float, Eigen::aligned_allocator<float>>;
-extern template class Tensor<int, Eigen::aligned_allocator<int>>;
-extern template class Tensor<long, Eigen::aligned_allocator<long>>;
-//  extern template
-//  class Tensor<std::complex<double>,
-//  Eigen::aligned_allocator<std::complex<double> > >; extern template class
-//  Tensor<std::complex<float>, Eigen::aligned_allocator<std::complex<float> >
-//  >;
+extern template class Tensor<double>;
+extern template class Tensor<float>;
+// extern template class Tensor<int>;
+// extern template class Tensor<long>;
+extern template class Tensor<std::complex<double>>;
+extern template class Tensor<std::complex<float>>;
 
 #endif  // TILEDARRAY_HEADER_ONLY
 

--- a/src/TiledArray/tensor/type_traits.h
+++ b/src/TiledArray/tensor/type_traits.h
@@ -30,6 +30,7 @@
 
 #include <TiledArray/type_traits.h>
 #include <type_traits>
+#include <TiledArray/fwd.h>
 
 namespace Eigen {
 
@@ -42,20 +43,6 @@ class aligned_allocator;
 namespace TiledArray {
 
 // Forward declarations
-class Range;
-class BlockRange;
-template <typename T, typename A = Eigen::aligned_allocator<T>>
-class Tensor;
-template <typename>
-class Tile;
-
-class Permutation;
-class BipartitePermutation;
-
-namespace symmetry {
-class Permutation;
-}
-
 namespace detail {
 
 // Forward declarations


### PR DESCRIPTION
- appeared in type_traits.h (with default allocator value) and fwd.h (without); now there is a single fwddecl
- removed explicit specification of Tensor's default allocator where not needed
- disabled default instantiations for integer types, enabled default instatiations for complex types