### PR TITLE
Additional ToT Kernels

### DIFF
--- a/src/TiledArray/expressions/detail/einsum_traits.h
+++ b/src/TiledArray/expressions/detail/einsum_traits.h
@@ -1,0 +1,91 @@
+/*
+ * This file is a part of TiledArray.
+ * Copyright (C) 2013  Virginia Tech
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef TILEDARRAY_EXPRESSIONS_DETAIL_EINSUM_TRAITS_H__INCLUDED
+#define TILEDARRAY_EXPRESSIONS_DETAIL_EINSUM_TRAITS_H__INCLUDED
+
+#include <type_traits>                      // For std::conditional_t
+#include "TiledArray/tensor/type_traits.h"  // For is_tensor_of_tensors_v
+
+namespace TiledArray::expressions::detail {
+
+/** @brief Struct used to analyze the types of the tensors input to `einsum`.
+ *
+ *  The EinsumTraits struct encapsulates some minor template meta-programming
+ *  which needs to occur in order for the main `einsum` API to dispatch
+ *  correctly.
+ *
+ *  @tparam LHSArray The type of the array in the first tensor provided to
+ *                   `einsum`. Expected to satisfy the concept of a tile.
+ *  @tparam RHSArray The type of the array in the second tensor provided to
+ *                   `einsum`. Expected to satisfy the concept of a tile.
+ */
+template <typename LHSArray, typename RHSArray>
+struct EinsumTraits {
+ private:
+  /// Alias to shorten typedefs so they fit on one line
+  template <typename T>
+  static constexpr bool tot = TiledArray::detail::is_tensor_of_tensor_v<T>;
+
+ public:
+  /// True if @p LHSArray is a tile in a tensor of tensors. False otherwise.
+  static constexpr bool lhs_is_tot = tot<LHSArray>;
+
+  /// True if @p RHSArray is a tile in a tensor of tensors. False otherwise
+  static constexpr bool rhs_is_tot = tot<RHSArray>;
+
+  /// True @p LHSArray and @p RHSArray are types of ToTs
+  static constexpr bool both_are_tots = lhs_is_tot && rhs_is_tot;
+
+  /// Type of the tensor returned by einsum
+  using return_type = std::conditional_t<lhs_is_tot, LHSArray, RHSArray>;
+};
+
+/** @brief Partial specialization of EinsumTraits so that it "does the right
+ *         thing" when the templater parameters are DistArray instances instead
+ *         of tiles.
+ *
+ *  Throughout TiledArray it is common to deal with DistArray instances, but it
+ *  is the tile types that determine whether a particular tensor is
+ *  non-hierarchical or a tensor-of-tensors. This partial specialization is
+ *  instantiated when the template parameters to EinsumTraits are DistArray
+ *  instances instead of tiles. This specialization unwraps the tile types and
+ *  forwards them to base class, which is also the primary template. The
+ *  result is instances of this partial specialization have the same TMP values
+ *  as the primary template, but are populated from DistArray instances instead
+ *  of tiles.
+ *
+ *  @tparam LHSArray The tile type in the first tensor passed to `einsum`.
+ *                   Expected to satisfy the concept of tile.
+ *  @tparam RHSArray The tile type in the second tensor passed to `einsum`.
+ *                   Expected to satisfy the concept of tile.
+ *  @tparam LHSPolicy The policy of the first tensor passed to `einsum`.
+ *                    Expected to satisfy the concept of policy.
+ *  @tparam RHSPolicy The policy of the second tensor passed to `einsum`.
+ *                    Expected to satisfy the concept of policy.
+ */
+template <typename LHSArray, typename RHSArray, typename LHSPolicy,
+          typename RHSPolicy>
+struct EinsumTraits<DistArray<LHSArray, LHSPolicy>,
+                    DistArray<RHSArray, RHSPolicy>>
+    : EinsumTraits<LHSArray, RHSArray> {};
+
+}  // namespace TiledArray::expressions::detail
+
+#endif

--- a/src/TiledArray/expressions/detail/tensor_tot_kernel.h
+++ b/src/TiledArray/expressions/detail/tensor_tot_kernel.h
@@ -1,0 +1,37 @@
+/*
+ * This file is a part of TiledArray.
+ * Copyright (C) 2013  Virginia Tech
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef TILEDARRAY_EXPRESSIONS_DETAIL_TENSOR_TOT_KERNEL_H__INCLUDED
+#define TILEDARRAY_EXPRESSIONS_DETAIL_TENSOR_TOT_KERNEL_H__INCLUDED
+
+#include <tuple>                         // std::tuple
+#include "TiledArray/expressions/fwd.h"  // TsrExpr<T>
+#include "TiledArray/util/index.h"       // Index
+
+namespace TiledArray::expressions::detail {
+
+template <typename ArrayA, typename ArrayB, typename... Indices>
+auto tensor_tot_kernel(TsrExpr<ArrayA> A, TsrExpr<ArrayB> B,
+                       std::tuple<Index, Indices...> cs, World &world) {
+  return B.array();
+}
+
+}  // namespace TiledArray::expressions::detail
+
+#endif

--- a/src/TiledArray/expressions/detail/tot_tot_kernel.h
+++ b/src/TiledArray/expressions/detail/tot_tot_kernel.h
@@ -1,0 +1,164 @@
+/*
+ * This file is a part of TiledArray.
+ * Copyright (C) 2013  Virginia Tech
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef TILEDARRAY_EXPRESSIONS_DETAIL_TOT_TOT_KERNEL_H__INCLUDED
+#define TILEDARRAY_EXPRESSIONS_DETAIL_TOT_TOT_KERNEL_H__INCLUDED
+
+#include "TiledArray/expressions/fwd.h"
+#include "TiledArray/fwd.h"
+#include "TiledArray/tiled_range.h"
+#include "TiledArray/tiled_range1.h"
+#include "TiledArray/util/index.h"
+#include "TiledArray/util/range.h"
+
+namespace TiledArray::expressions::detail {
+
+template <typename Array, typename... Indices>
+auto tot_tot_kernel(TsrExpr<Array> A, TsrExpr<Array> B,
+                    std::tuple<Index, Indices...> cs, World &world) {
+  // These are the outer indices
+  auto a = std::get<0>(idx(A));
+  auto b = std::get<0>(idx(B));
+  Index c = std::get<0>(cs);
+
+  struct {
+    std::string a, b, c;
+  } inner;
+  if constexpr (std::tuple_size<decltype(cs)>::value == 2) {
+    inner.a = ";" + (std::string)std::get<1>(idx(A));
+    inner.b = ";" + (std::string)std::get<1>(idx(B));
+    inner.c = ";" + (std::string)std::get<1>(cs);
+  }
+
+  // these are "Hadamard" (fused) indices
+  auto h = a & b & c;
+
+  // no Hadamard indices => standard contraction (or even outer product)
+  // same a, b, and c => pure Hadamard
+  if (!h || (!(a ^ b) && !(b ^ c))) {
+    Array C;
+    C(std::string(c) + inner.c) = A * B;
+    return C;
+  }
+
+  auto e = (a ^ b);
+  // contracted indices
+  auto i = (a & b) - h;
+
+  TA_ASSERT(e);
+  TA_ASSERT(h);
+
+  using range::Range;
+  using RangeProduct = range::RangeProduct<Range, index::small_vector<size_t> >;
+
+  using RangeMap = IndexMap<std::string, TiledRange1>;
+  auto range_map =
+      (RangeMap(a, A.array().trange()) | RangeMap(b, B.array().trange()));
+
+  using TiledArray::Permutation;
+  using TiledArray::index::permutation;
+
+  struct Term {
+    Array array;
+    Index idx;
+    Permutation permutation;
+    RangeProduct tiles;
+    Array local;
+    std::string expr;
+  };
+
+  Term AB[2] = {{A.array(), a}, {B.array(), b}};
+
+  for (auto &term : AB) {
+    auto ei = (e + i & term.idx);
+    term.local = Array(world, TiledRange(range_map[ei]));
+    for (auto idx : ei) {
+      term.tiles *= Range(range_map[idx].tiles_range());
+    }
+    if (term.idx != h + ei) {
+      term.permutation = permutation(term.idx, h + ei);
+    }
+    term.expr = ei;
+  }
+
+  Term C = {Array(world, TiledRange(range_map[c])), c};
+  for (auto idx : e) {
+    C.tiles *= Range(range_map[idx].tiles_range());
+  }
+  if (C.idx != h + e) {
+    C.permutation = permutation(h + e, C.idx);
+  }
+  C.expr = e;
+
+  AB[0].expr += inner.a;
+  AB[1].expr += inner.b;
+  C.expr += inner.c;
+
+  struct {
+    RangeProduct tiles;
+    std::vector<std::vector<size_t> > batch;
+  } H;
+
+  for (auto idx : h) {
+    H.tiles *= Range(range_map[idx].tiles_range());
+    H.batch.push_back({});
+    for (auto r : range_map[idx]) {
+      H.batch.back().push_back(Range{r}.size());
+    }
+  }
+
+  // iterates over tiles of hadamard indices
+  using Index = index::Index<size_t>;
+  for (Index h : H.tiles) {
+    size_t batch = 1;
+    for (size_t i = 0; i < h.size(); ++i) {
+      batch *= H.batch[i].at(h[i]);
+    }
+    for (auto &term : AB) {
+      term.local = Array(term.local.world(), term.local.trange());
+      const Permutation &P = term.permutation;
+      for (Index ei : term.tiles) {
+        auto tile = term.array.find(apply_inverse(P, h + ei)).get();
+        if (P) tile = tile.permute(P);
+        auto shape = term.local.trange().tile(ei);
+        tile = tile.reshape(shape, batch);
+        term.local.set(ei, tile);
+      }
+    }
+    auto &[A, B] = AB;
+    C.local(C.expr) = A.local(A.expr) * B.local(B.expr);
+    const Permutation &P = C.permutation;
+    for (Index e : C.tiles) {
+      auto c = apply(P, h + e);
+      auto shape = C.array.trange().tile(c);
+      shape = apply_inverse(P, shape);
+      auto tile = C.local.find(e).get();
+      assert(tile.batch_size() == batch);
+      tile = tile.reshape(shape);
+      if (P) tile = tile.permute(P);
+      C.array.set(c, tile);
+    }
+  }
+
+  return C.array;
+}
+
+}  // namespace TiledArray::expressions::detail
+
+#endif

--- a/src/TiledArray/expressions/einsum.h
+++ b/src/TiledArray/expressions/einsum.h
@@ -1,12 +1,15 @@
 #ifndef TILEDARRAY_EINSUM_H__INCLUDED
 #define TILEDARRAY_EINSUM_H__INCLUDED
 
-#include "TiledArray/fwd.h"
+#include "TiledArray/expressions/detail/einsum_traits.h"
+#include "TiledArray/expressions/detail/tensor_tot_kernel.h"
+#include "TiledArray/expressions/detail/tot_tot_kernel.h"
 #include "TiledArray/expressions/fwd.h"
+#include "TiledArray/fwd.h"
+#include "TiledArray/tiled_range.h"
+#include "TiledArray/tiled_range1.h"
 #include "TiledArray/util/index.h"
 #include "TiledArray/util/range.h"
-#include "TiledArray/tiled_range1.h"
-#include "TiledArray/tiled_range.h"
 //#include "TiledArray/util/string.h"
 
 namespace TiledArray::expressions {
@@ -28,153 +31,53 @@ auto einsum(TsrExpr<Array> A, TsrExpr<Array> B) {
   return R;
 }
 
-/// einsum function with result indices explicitly specified
-/// @param[in] A first argument to the product
-/// @param[in] B second argument to the product
-/// @param[in] r result indices
-/// @warning just as in the plain expression code, reductions are a special
-/// case; use Expr::reduce()
-template<typename Array, typename ... Indices>
-auto einsum(
-  TsrExpr<Array> A, TsrExpr<Array> B,
-  const std::string &cs,
-  World &world = get_default_world())
-{
-  return einsum(A, B, idx<Array>(cs), world);
+/** @brief einsum function with result indices explicitly specified
+ *
+ *  @tparam ArrayA The tensor type of @p A. Expected to be an instantiation of
+ *                 DistArray.
+ *  @tparam ArrayB The tensor type of @p B. Expected to be an instantiation of
+ *                 DistArray.
+ *
+ *  @param[in] A first argument to the product
+ *  @param[in] B second argument to the product
+ *  @param[in] r result indices
+ *
+ *  @result The tensor resulting from multiplying @p A with @p B so that the
+ *          result has indices consistent with @p r.
+ *
+ *  @warning just as in the plain expression code, reductions are a special
+ *           case; use Expr::reduce()
+ *
+ */
+template <typename ArrayA, typename ArrayB, typename... Indices>
+auto einsum(TsrExpr<ArrayA> A, TsrExpr<ArrayB> B, const std::string &cs,
+            World &world = get_default_world()) {
+  using traits_type = detail::EinsumTraits<ArrayA, ArrayB>;
+  using return_type = typename traits_type::return_type;
+  return einsum(A, B, idx<return_type>(cs), world);
 }
 
-template<typename Array, typename ... Indices>
-auto einsum(
-  TsrExpr<Array> A, TsrExpr<Array> B,
-  std::tuple<Index,Indices...> cs,
-  World &world)
-{
+template <typename ArrayA, typename ArrayB, typename... Indices>
+auto einsum(TsrExpr<ArrayA> A, TsrExpr<ArrayB> B,
+            std::tuple<Index, Indices...> cs, World &world) {
+  using traits_type = detail::EinsumTraits<ArrayA, ArrayB>;
 
-  auto a = std::get<0>(idx(A));
-  auto b = std::get<0>(idx(B));
-  Index c = std::get<0>(cs);
-
-  struct { std::string a, b, c; } inner;
-  if constexpr (std::tuple_size<decltype(cs)>::value == 2) {
-      inner.a = ";" + (std::string)std::get<1>(idx(A));
-      inner.b = ";" + (std::string)std::get<1>(idx(B));
-      inner.c = ";" + (std::string)std::get<1>(cs);
+  // Dispatch based on whether A and B are, or are not, ToTs
+  if constexpr (traits_type::both_are_tots) {
+    return detail::tot_tot_kernel(A, B, std::move(cs), world);
+  } else if constexpr (traits_type::rhs_is_tot) {
+    return detail::tensor_tot_kernel(A, B, std::move(cs), world);
+  } else if constexpr (traits_type::lhs_is_tot) {
+    // N.B. When indices are attached to the tensors, the tensors commute
+    return detail::tensor_tot_kernel(B, A, std::move(cs), world);
+  } else {
+    // Else is triggered when neither A or B are a ToT
+    //
+    // N.B. C++ won't let us just put false, but getting here we know
+    //     both_are_tots is false so it's just as good...
+    static_assert(traits_type::both_are_tots,
+                  "Einsum expects at least one ToT");
   }
-
-  // these are "Hadamard" (fused) indices
-  auto h = a & b & c;
-
-  // no Hadamard indices => standard contraction (or even outer product)
-  // same a, b, and c => pure Hadamard
-  if (!h || (!(a ^ b) && !(b ^ c))) {
-    Array C;
-    C(std::string(c) + inner.c) = A*B;
-    return C;
-  }
-
-  auto e = (a ^ b);
-  // contracted indices
-  auto i = (a & b) - h;
-
-  TA_ASSERT(e);
-  TA_ASSERT(h);
-
-  using range::Range;
-  using RangeProduct = range::RangeProduct<Range, index::small_vector<size_t> >;
-
-  using RangeMap = IndexMap<std::string,TiledRange1>;
-  auto range_map = (
-    RangeMap(a, A.array().trange()) |
-    RangeMap(b, B.array().trange())
-  );
-
-  using TiledArray::Permutation;
-  using TiledArray::index::permutation;
-
-  struct Term {
-    Array array;
-    Index idx;
-    Permutation permutation;
-    RangeProduct tiles;
-    Array local;
-    std::string expr;
-  };
-
-  Term AB[2] = { { A.array(), a }, { B.array(), b } };
-
-  for (auto &term : AB) {
-    auto ei = (e+i & term.idx);
-    term.local = Array(world, TiledRange(range_map[ei]));
-    for (auto idx : ei) {
-      term.tiles *= Range(range_map[idx].tiles_range());
-    }
-    if (term.idx != h+ei) {
-      term.permutation = permutation(term.idx, h+ei);
-    }
-    term.expr = ei;
-  }
-
-  Term C = { Array(world, TiledRange(range_map[c])), c };
-  for (auto idx : e) {
-    C.tiles *= Range(range_map[idx].tiles_range());
-  }
-  if (C.idx != h+e) {
-    C.permutation = permutation(h+e, C.idx);
-  }
-  C.expr = e;
-
-  AB[0].expr += inner.a;
-  AB[1].expr += inner.b;
-  C.expr += inner.c;
-
-  struct {
-    RangeProduct tiles;
-    std::vector< std::vector<size_t> > batch;
-  } H;
-
-  for (auto idx : h) {
-    H.tiles *= Range(range_map[idx].tiles_range());
-    H.batch.push_back({});
-    for (auto r : range_map[idx]) {
-      H.batch.back().push_back(Range{r}.size());
-    }
-  }
-
-  // iterates over tiles of hadamard indices
-  using Index = index::Index<size_t>;
-  for (Index h : H.tiles) {
-    size_t batch = 1;
-    for (size_t i = 0; i < h.size(); ++i) {
-      batch *= H.batch[i].at(h[i]);
-    }
-    for (auto &term : AB) {
-      term.local = Array(term.local.world(), term.local.trange());
-      const Permutation &P = term.permutation;
-      for (Index ei : term.tiles) {
-        auto tile = term.array.find(apply_inverse(P, h+ei)).get();
-        if (P) tile = tile.permute(P);
-        auto shape = term.local.trange().tile(ei);
-        tile = tile.reshape(shape, batch);
-        term.local.set(ei, tile);
-      }
-    }
-    auto& [A,B] = AB;
-    C.local(C.expr) = A.local(A.expr) * B.local(B.expr);
-    const Permutation &P = C.permutation;
-    for (Index e : C.tiles) {
-      auto c = apply(P, h+e);
-      auto shape = C.array.trange().tile(c);
-      shape = apply_inverse(P, shape);
-      auto tile = C.local.find(e).get();
-      assert(tile.batch_size() == batch);
-      tile = tile.reshape(shape);
-      if (P) tile = tile.permute(P);
-      C.array.set(c, tile);
-    }
-  }
-
-  return C.array;
-
 }
 
 }  // namespace TiledArray::expressions

--- a/src/TiledArray/util/index.h
+++ b/src/TiledArray/util/index.h
@@ -1,16 +1,19 @@
+#ifndef TILEDARRAY_UTIL_INDEX_H__INCLUDED
+#define TILEDARRAY_UTIL_INDEX_H__INCLUDED
+
 // Samuel R. Powell, 2021
 #include "TiledArray/expressions/fwd.h"
 
 #include <TiledArray/error.h>
-#include <TiledArray/util/vector.h>
 #include <TiledArray/permutation.h>
+#include <TiledArray/util/vector.h>
 
-#include <string>
 #include <iosfwd>
+#include <string>
 
 namespace TiledArray::index {
 
-template<typename T>
+template <typename T>
 using small_vector = container::svector<T>;
 
 small_vector<std::string> tokenize(const std::string &s);
@@ -19,30 +22,32 @@ small_vector<std::string> validate(const small_vector<std::string> &v);
 
 std::string join(const small_vector<std::string> &v);
 
-template<typename T, typename U>
-using enable_if_string = std::enable_if_t< std::is_same_v<T,std::string>, U>;
+template <typename T, typename U>
+using enable_if_string = std::enable_if_t<std::is_same_v<T, std::string>, U>;
 
 /// an n-index, with n a runtime parameter
-template<typename T>
+template <typename T>
 class Index {
-public:
+ public:
   using container_type = small_vector<T>;
   using value_type = typename container_type::value_type;
 
   Index() = default;
   Index(container_type &&s) : data_(std::move(s)) {}
 
-  template<typename S, typename U = void>
+  template <typename S, typename U = void>
   Index(const S &s) : data_(s.begin(), s.end()) {}
 
-  template<typename U = void>
+  template <typename U = void>
   Index(const std::string &s) : Index(index::tokenize(s)) {}
 
-  template<typename U = void>
+  template <typename U = void>
   Index(const char *s) : Index(std::string(s)) {}
 
-  template<typename U = void>
-  operator std::string() const { return index::join(data_); }
+  template <typename U = void>
+  operator std::string() const {
+    return index::join(data_);
+  }
 
   explicit operator bool() const { return !data_.empty(); }
 
@@ -50,22 +55,20 @@ public:
     return (this->data_ == other.data_);
   }
 
-  bool operator!=(const Index &other) const {
-    return !(*this == other);
-  }
+  bool operator!=(const Index &other) const { return !(*this == other); }
 
   size_t size() const { return data_.size(); }
 
   auto begin() const { return data_.begin(); }
   auto end() const { return data_.end(); }
 
-  auto find(const T& v) const {
+  auto find(const T &v) const {
     return std::find(this->begin(), this->end(), v);
   }
 
-  const auto& operator[](size_t idx) const { return data_.at(idx); }
+  const auto &operator[](size_t idx) const { return data_.at(idx); }
 
-  size_t indexof(const T& v) const {
+  size_t indexof(const T &v) const {
     for (size_t i = 0; i < this->size(); ++i) {
       if (this[i] == v) return i;
     }
@@ -73,16 +76,14 @@ public:
   }
 
   /// Returns true if argument exists in the Index object, else returns false
-  bool contains(const T& v) const {
-    return (this->find(v) != this->end());
-  }
+  bool contains(const T &v) const { return (this->find(v) != this->end()); }
 
  private:
   container_type data_;
 };
 
-template<typename T>
-std::ostream& operator<<(std::ostream& os, const Index<T> &idx) {
+template <typename T>
+std::ostream &operator<<(std::ostream &os, const Index<T> &idx) {
   os << std::string(idx);
   return os;
 }
@@ -91,7 +92,7 @@ std::ostream& operator<<(std::ostream& os, const Index<T> &idx) {
 /// @param[in] a an Index object
 /// @param[in] b an Index object
 /// @pre a and b do not have duplicates
-template<typename T>
+template <typename T>
 Index<T> operator&(const Index<T> &a, const Index<T> &b) {
   typename Index<T>::container_type r;
   for (const auto &s : a) {
@@ -104,7 +105,7 @@ Index<T> operator&(const Index<T> &a, const Index<T> &b) {
 /// @param[in] a an Index object
 /// @param[in] b an Index object
 /// @pre a and b do not have duplicates
-template<typename T>
+template <typename T>
 Index<T> operator|(const Index<T> &a, const Index<T> &b) {
   typename Index<T>::container_type r;
   r.assign(a.begin(), a.end());
@@ -119,7 +120,7 @@ Index<T> operator|(const Index<T> &a, const Index<T> &b) {
 /// @param[in] a an Index object
 /// @param[in] b an Index object
 /// @note unline operator| @p a and @p b can have have duplicates
-template<typename T>
+template <typename T>
 Index<T> operator+(const Index<T> &a, const Index<T> &b) {
   typename Index<T>::container_type r;
   r.assign(a.begin(), a.end());
@@ -131,7 +132,7 @@ Index<T> operator+(const Index<T> &a, const Index<T> &b) {
 /// @param[in] a an Index object
 /// @param[in] b an Index object
 /// @note unline operator& @p a and @p b can have have duplicates
-template<typename T>
+template <typename T>
 Index<T> operator-(const Index<T> &a, const Index<T> &b) {
   typename Index<T>::container_type r;
   for (const auto &s : a) {
@@ -145,22 +146,24 @@ Index<T> operator-(const Index<T> &a, const Index<T> &b) {
 /// @param[in] a an Index object
 /// @param[in] b an Index object
 /// @pre a and b do not have duplicates
-template<typename T>
+template <typename T>
 inline Index<T> operator^(const Index<T> &a, const Index<T> &b) {
   return (a | b) - (a & b);
 }
 
-template<typename T>
-size_t rank(const Index<T> &idx) { return idx.size(); }
+template <typename T>
+size_t rank(const Index<T> &idx) {
+  return idx.size();
+}
 
 template <typename T>
-Index<T> sorted(const Index<T>& a) {
+Index<T> sorted(const Index<T> &a) {
   typename Index<T>::container_type r(a.begin(), a.end());
   std::sort(r.begin(), r.end());
   return Index<T>(r);
 }
 
-template<typename T>
+template <typename T>
 Permutation permutation(const Index<T> &s, const Index<T> &p) {
   assert(sorted(s) == sorted(p));
   small_vector<size_t> m;
@@ -171,30 +174,30 @@ Permutation permutation(const Index<T> &s, const Index<T> &p) {
   return Permutation(m);
 }
 
-template<typename T, bool Inverse>
-auto permute(const Permutation &p, const Index<T> &s, std::bool_constant<Inverse>) {
+template <typename T, bool Inverse>
+auto permute(const Permutation &p, const Index<T> &s,
+             std::bool_constant<Inverse>) {
   if (!p) return s;
   using R = typename Index<T>::container_type;
   R r(p.size());
-  detail::permute_n(p.size(), p.begin(), s.begin(), r.begin(), std::bool_constant<Inverse>{});
+  detail::permute_n(p.size(), p.begin(), s.begin(), r.begin(),
+                    std::bool_constant<Inverse>{});
   return Index<T>{r};
 }
 
 /// @brief Index-annotated collection of objects
 /// @tparam Value
 /// This is a map using Index::element_type as key
-template<typename K, typename V>
+template <typename K, typename V>
 struct IndexMap {
-
   using key_type = K;
   using value_type = V;
 
   IndexMap(const Index<K> &keys, std::initializer_list<V> s)
-    : IndexMap(keys, s.begin(), s.end()) {}
+      : IndexMap(keys, s.begin(), s.end()) {}
 
   template <typename S>
-  IndexMap(const Index<K> &keys, S &&s)
-    : IndexMap(keys, s.begin(), s.end()) {}
+  IndexMap(const Index<K> &keys, S &&s) : IndexMap(keys, s.begin(), s.end()) {}
 
   template <typename It>
   IndexMap(const Index<K> &keys, It begin, It end) {
@@ -202,25 +205,23 @@ struct IndexMap {
     data_.reserve(keys.size());
     for (auto &&key : keys) {
       assert(it != end);
-      data_.emplace_back(std::pair<K,V>{key, *it});
+      data_.emplace_back(std::pair<K, V>{key, *it});
       ++it;
     }
     assert(it == end);
   }
 
-  IndexMap(const small_vector<std::pair<K, V> > &data) : data_(data) { }
+  IndexMap(const small_vector<std::pair<K, V> > &data) : data_(data) {}
 
   /// @return const iterator pointing to the element associated with @p key
   auto find(const key_type &key) const {
-    return std::find_if(
-      data_.begin(), data_.end(),
-      [&key](const auto &v) { return key == v.first; }
-    );
+    return std::find_if(data_.begin(), data_.end(),
+                        [&key](const auto &v) { return key == v.first; });
   }
 
   /// @return reference to the element associated with @p key
   /// @throw TA::Exception if @p key is not in this map
-  const auto& operator[](const key_type &key) const {
+  const auto &operator[](const key_type &key) const {
     auto it = find(key);
     if (it != data_.end()) return it->second;
     throw TiledArray::Exception("IndexMap::at(key): key not found");
@@ -242,16 +243,15 @@ struct IndexMap {
   auto end() const { return data_.end(); }
 
  private:
-  small_vector< std::pair<key_type, value_type> > data_;
-
+  small_vector<std::pair<key_type, value_type> > data_;
 };
 
-template<typename K, typename V>
-bool operator==(const IndexMap<K,V>& lhs, const IndexMap<K,V>& rhs) {
-  for (const auto& [k,v] : lhs) {
+template <typename K, typename V>
+bool operator==(const IndexMap<K, V> &lhs, const IndexMap<K, V> &rhs) {
+  for (const auto &[k, v] : lhs) {
     if (rhs.find(k) == rhs.end() || v != rhs[k]) return false;
   }
-  for (const auto& [k,v] : rhs) {
+  for (const auto &[k, v] : rhs) {
     if (lhs.find(k) == lhs.end()) return false;
   }
   return true;
@@ -259,9 +259,9 @@ bool operator==(const IndexMap<K,V>& lhs, const IndexMap<K,V>& rhs) {
 
 /// TODO to be filled by Sam
 template <typename K, typename V>
-IndexMap<K,V> operator|(const IndexMap<K,V> &a, const IndexMap<K,V> &b) {
-  small_vector< std::pair<K, V> > d(a.begin(), a.end());
-  for (const auto [k,v] : b) {
+IndexMap<K, V> operator|(const IndexMap<K, V> &a, const IndexMap<K, V> &b) {
+  small_vector<std::pair<K, V> > d(a.begin(), a.end());
+  for (const auto [k, v] : b) {
     if (a.find(k) != a.end()) {
       TA_ASSERT(a[k] == b[k]);
       continue;
@@ -279,24 +279,24 @@ using Index = TiledArray::index::Index<std::string>;
 using TiledArray::index::IndexMap;
 
 /// converts the annotation of an expression to an Index
-template<typename Array>
+template <typename Array>
 auto idx(const std::string &s) {
   if constexpr (detail::is_tensor_of_tensor_v<typename Array::value_type>) {
     auto semi = std::find(s.begin(), s.end(), ';');
     assert(semi != s.end());
     auto first = std::string(s.begin(), semi);
-    auto second = std::string(semi+1, s.end());
-    return std::tuple<Index,Index>{ first, second };
-  }
-  else {
-    return std::tuple<Index>{ s };
+    auto second = std::string(semi + 1, s.end());
+    return std::tuple<Index, Index>{first, second};
+  } else {
+    return std::tuple<Index>{s};
   }
 }
 
 /// converts the annotation of an expression to an Index
-template<typename A, bool Alias>
+template <typename A, bool Alias>
 auto idx(const expressions::TsrExpr<A, Alias> &e) {
   return idx<A>(e.annotation());
 }
 
 }  // namespace TiledArray
+#endif

--- a/src/TiledArray/util/range.h
+++ b/src/TiledArray/util/range.h
@@ -1,38 +1,39 @@
+#ifndef TILEDARRAY_UTIL_RANGE_H__INCLUDED
+#define TILEDARRAY_UTIL_RANGE_H__INCLUDED
+
 #include <TiledArray/util/vector.h>
 
-#include <vector>
 #include <boost/iterator/counting_iterator.hpp>
+#include <vector>
 
 namespace TiledArray::range {
 
-template<typename T>
+template <typename T>
 using small_vector = container::svector<T>;
 
 struct Range {
   using value_type = int64_t;
   using iterator = boost::counting_iterator<value_type>;
-  template<class Pair>
-  explicit Range(Pair &&pair) : Range(pair.first, pair.second) {}
+  template <class Pair>
+  explicit Range(Pair&& pair) : Range(pair.first, pair.second) {}
   Range(value_type begin, value_type end) : begin_(begin), end_(end) {}
   auto begin() const { return iterator(begin_); }
   auto end() const { return iterator(end_); }
   auto size() const { return end_ - begin_; }
-protected:
-  const value_type begin_, end_;
 
+ protected:
+  const value_type begin_, end_;
 };
 
-template<typename R, typename T = small_vector<typename R::value_type> >
+template <typename R, typename T = small_vector<typename R::value_type> >
 struct RangeProduct {
-
   using ranges_type = std::vector<R>;
 
-public:
-
+ public:
   RangeProduct() = default;
   RangeProduct(std::initializer_list<R> ranges) : ranges_(ranges) {}
 
-  RangeProduct& operator *= (R a) {
+  RangeProduct& operator*=(R a) {
     this->ranges_.push_back(a);
     return *this;
   }
@@ -43,15 +44,17 @@ public:
     using iterator1 = decltype(std::begin(ranges_type{}[0]));
     auto operator*() const {
       T r;
-      for (auto &it : its_) { r.push_back(*it); }
+      for (auto& it : its_) {
+        r.push_back(*it);
+      }
       return r;
     }
-    bool operator!=(const iterator &other) const {
+    bool operator!=(const iterator& other) const {
       return !(this->p_ == other.p_ && this->its_ == other.its_);
     }
     iterator& operator++() {
       size_t i = its_.size();
-      auto &ranges = p_->ranges();
+      auto& ranges = p_->ranges();
       while (i > 0) {
         --i;
         ++its_[i];
@@ -61,9 +64,10 @@ public:
       }
       return *this;
     }
-  private:
+
+   private:
     friend class RangeProduct;
-    explicit iterator(const RangeProduct *p, bool End = false) {
+    explicit iterator(const RangeProduct* p, bool End = false) {
       this->p_ = p;
       using std::begin;
       using std::end;
@@ -73,34 +77,30 @@ public:
         End = false;
       }
     }
-  private:
-    const RangeProduct *p_;
+
+   private:
+    const RangeProduct* p_;
     small_vector<iterator1> its_;
   };
 
-  auto begin() const {
-    return iterator(this);
-  }
+  auto begin() const { return iterator(this); }
 
-  auto end() const {
-    return iterator(this, true);
-  }
+  auto end() const { return iterator(this, true); }
 
-protected:
+ protected:
   ranges_type ranges_;
-
 };
 
-RangeProduct<Range> operator*(Range a, Range b){
+RangeProduct<Range> operator*(Range a, Range b) {
   return RangeProduct<Range>({a, b});
 };
 
-template<typename R, typename T>
-RangeProduct<R,T> operator*(const RangeProduct<R,T>& a, Range b) {
-  return RangeProduct<R,T>(a) *= b;
+template <typename R, typename T>
+RangeProduct<R, T> operator*(const RangeProduct<R, T>& a, Range b) {
+  return RangeProduct<R, T>(a) *= b;
 };
 
-template<typename R, typename F>
+template <typename R, typename F>
 void cartesian_foreach(const std::vector<R>& rs, F f) {
   using It = decltype(std::begin(rs[0]));
   using T = typename R::value_type;
@@ -127,4 +127,6 @@ void cartesian_foreach(const std::vector<R>& rs, F f) {
   }
 }
 
-}  // namespace TiledArray::expressions
+}  // namespace TiledArray::range
+
+#endif

--- a/tests/einsum.cpp
+++ b/tests/einsum.cpp
@@ -1,235 +1,598 @@
 /*
-* This file is a part of TiledArray.
-* Copyright (C) 2013  Virginia Tech
-*
-*  This program is free software: you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation, either version 3 of the License, or
-*   (at your option) any later version.
-*
-*  This program is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*  GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License
-*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*
-*/
+ * This file is a part of TiledArray.
+ * Copyright (C) 2013  Virginia Tech
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 #include "TiledArray/expressions/einsum.h"
 #include "tiledarray.h"
-#include "unit_test_config.h"
 #include "tot_array_fixture.h"
+#include "unit_test_config.h"
 
 #include "TiledArray/expressions/contraction_helpers.h"
 
 using namespace TiledArray;
 using namespace TiledArray::expressions;
 
+/* Unit tests:
+ *
+ * The first two tests are contractions on outer indices:
+ * - C("i,k;m,n") = A("i,j;m,n") * B("j,k;m,n")
+ * - C("i,k;m,n") = A("i,j;m,n") * B("k,j;m,n")
+ *
+ *
+ * The next three test the hadamard-like contractions:
+ * - C("i,j;m,n") = A("i,j;m,n") * B("i,j;m,n")
+ * - C("i,j;m,n") = A("i,j;m,n") * B("j,i;m,n")
+ * - Same contraction, but different einsum API
+ *
+ * The next four test contractions between a ToT and a non-ToT, first over the
+ * outer indices, then over the inner indices
+ * - C("i,k;m,n") = A("i,j") * B("j,k;m,n")
+ * - C("i,k;m,n") = A("i,j") * B("k,j;m,n")
+ * - C("i,k;m,n") = A("j,m") * B("i,k;j,n")
+ * - C("i,k;m,n") = A("j,m") * B("i,k;n,j")
+ *
+ */
+
 BOOST_AUTO_TEST_SUITE(einsumfxn)
 
-BOOST_AUTO_TEST_CASE(ik_mn_eq_ij_mn_times_jk_mn){
+BOOST_AUTO_TEST_CASE(ik_mn_eq_ij_mn_times_jk_mn) {
   using dist_array_t = DistArray<Tensor<Tensor<double>>, DensePolicy>;
   using matrix_il = TiledArray::detail::matrix_il<Tensor<double>>;
   auto& world = TiledArray::get_default_world();
-  Tensor<double> lhs_elem_0_0(Range{7, 2}, {49, 73, 28, 46, 12, 83, 29, 61, 61, 98, 57, 28, 96, 57});
-  Tensor<double> lhs_elem_0_1(Range{7, 2}, {78, 15, 69, 55, 87, 94, 28, 94, 79, 30, 26, 88, 48, 74});
-  Tensor<double> lhs_elem_1_0(Range{7, 2}, {70, 32, 25, 71, 6, 56, 4, 13, 72, 50, 15, 95, 52, 89});
-  Tensor<double> lhs_elem_1_1(Range{7, 2}, {12, 29, 17, 68, 37, 79, 5, 52, 13, 35, 53, 54, 78, 71});
-  Tensor<double> lhs_elem_2_0(Range{7, 2}, {77, 39, 34, 94, 16, 82, 63, 27, 75, 12, 14, 59, 3, 14});
-  Tensor<double> lhs_elem_2_1(Range{7, 2}, {65, 90, 37, 41, 65, 75, 59, 16, 44, 85, 86, 11, 40, 24});
-  Tensor<double> lhs_elem_3_0(Range{7, 2}, {77, 53, 11, 6, 99, 63, 46, 68, 83, 56, 76, 86, 91, 79});
-  Tensor<double> lhs_elem_3_1(Range{7, 2}, {56, 11, 33, 90, 36, 38, 33, 54, 60, 21, 16, 28, 6, 97});
-  matrix_il lhs_il {{lhs_elem_0_0, lhs_elem_0_1},{lhs_elem_1_0, lhs_elem_1_1},{lhs_elem_2_0, lhs_elem_2_1},{lhs_elem_3_0, lhs_elem_3_1}};
-  TiledRange lhs_trange{{0, 2, 4},{0, 2}};
+  Tensor<double> lhs_elem_0_0(
+      Range{7, 2}, {49, 73, 28, 46, 12, 83, 29, 61, 61, 98, 57, 28, 96, 57});
+  Tensor<double> lhs_elem_0_1(
+      Range{7, 2}, {78, 15, 69, 55, 87, 94, 28, 94, 79, 30, 26, 88, 48, 74});
+  Tensor<double> lhs_elem_1_0(
+      Range{7, 2}, {70, 32, 25, 71, 6, 56, 4, 13, 72, 50, 15, 95, 52, 89});
+  Tensor<double> lhs_elem_1_1(
+      Range{7, 2}, {12, 29, 17, 68, 37, 79, 5, 52, 13, 35, 53, 54, 78, 71});
+  Tensor<double> lhs_elem_2_0(
+      Range{7, 2}, {77, 39, 34, 94, 16, 82, 63, 27, 75, 12, 14, 59, 3, 14});
+  Tensor<double> lhs_elem_2_1(
+      Range{7, 2}, {65, 90, 37, 41, 65, 75, 59, 16, 44, 85, 86, 11, 40, 24});
+  Tensor<double> lhs_elem_3_0(
+      Range{7, 2}, {77, 53, 11, 6, 99, 63, 46, 68, 83, 56, 76, 86, 91, 79});
+  Tensor<double> lhs_elem_3_1(
+      Range{7, 2}, {56, 11, 33, 90, 36, 38, 33, 54, 60, 21, 16, 28, 6, 97});
+  matrix_il lhs_il{{lhs_elem_0_0, lhs_elem_0_1},
+                   {lhs_elem_1_0, lhs_elem_1_1},
+                   {lhs_elem_2_0, lhs_elem_2_1},
+                   {lhs_elem_3_0, lhs_elem_3_1}};
+  TiledRange lhs_trange{{0, 2, 4}, {0, 2}};
   dist_array_t lhs(world, lhs_trange, lhs_il);
-  Tensor<double> rhs_elem_0_0(Range{7, 2}, {53, 10, 70, 2, 14, 82, 81, 27, 22, 76, 51, 68, 77, 17});
-  Tensor<double> rhs_elem_0_1(Range{7, 2}, {5, 99, 15, 7, 98, 85, 33, 92, 32, 91, 21, 19, 40, 54});
-  Tensor<double> rhs_elem_0_2(Range{7, 2}, {4, 53, 38, 39, 8, 90, 43, 77, 57, 42, 92, 88, 76, 1});
-  Tensor<double> rhs_elem_0_3(Range{7, 2}, {44, 86, 81, 43, 9, 40, 13, 6, 24, 12, 10, 60, 62, 59});
-  Tensor<double> rhs_elem_0_4(Range{7, 2}, {35, 87, 52, 20, 55, 84, 66, 36, 41, 44, 3, 93, 91, 12});
-  Tensor<double> rhs_elem_0_5(Range{7, 2}, {21, 23, 37, 39, 3, 25, 93, 61, 86, 11, 45, 70, 47, 30});
-  Tensor<double> rhs_elem_1_0(Range{7, 2}, {63, 19, 60, 77, 10, 60, 68, 52, 5, 31, 44, 6, 90, 37});
-  Tensor<double> rhs_elem_1_1(Range{7, 2}, {79, 73, 42, 83, 71, 83, 73, 32, 66, 87, 14, 76, 14, 72});
-  Tensor<double> rhs_elem_1_2(Range{7, 2}, {80, 19, 59, 90, 73, 84, 22, 16, 1, 95, 90, 7, 97, 26});
-  Tensor<double> rhs_elem_1_3(Range{7, 2}, {32, 55, 64, 81, 63, 97, 76, 86, 69, 61, 76, 87, 19, 72});
-  Tensor<double> rhs_elem_1_4(Range{7, 2}, {63, 84, 5, 64, 43, 30, 78, 8, 65, 25, 99, 93, 23, 22});
-  Tensor<double> rhs_elem_1_5(Range{7, 2}, {6, 74, 86, 41, 43, 63, 5, 83, 78, 54, 5, 1, 43, 97});
-  matrix_il rhs_il {{rhs_elem_0_0, rhs_elem_0_1, rhs_elem_0_2, rhs_elem_0_3, rhs_elem_0_4, rhs_elem_0_5},{rhs_elem_1_0, rhs_elem_1_1, rhs_elem_1_2, rhs_elem_1_3, rhs_elem_1_4, rhs_elem_1_5}};
-  TiledRange rhs_trange{{0, 2},{0, 2, 4, 6}};
+  Tensor<double> rhs_elem_0_0(
+      Range{7, 2}, {53, 10, 70, 2, 14, 82, 81, 27, 22, 76, 51, 68, 77, 17});
+  Tensor<double> rhs_elem_0_1(
+      Range{7, 2}, {5, 99, 15, 7, 98, 85, 33, 92, 32, 91, 21, 19, 40, 54});
+  Tensor<double> rhs_elem_0_2(
+      Range{7, 2}, {4, 53, 38, 39, 8, 90, 43, 77, 57, 42, 92, 88, 76, 1});
+  Tensor<double> rhs_elem_0_3(
+      Range{7, 2}, {44, 86, 81, 43, 9, 40, 13, 6, 24, 12, 10, 60, 62, 59});
+  Tensor<double> rhs_elem_0_4(
+      Range{7, 2}, {35, 87, 52, 20, 55, 84, 66, 36, 41, 44, 3, 93, 91, 12});
+  Tensor<double> rhs_elem_0_5(
+      Range{7, 2}, {21, 23, 37, 39, 3, 25, 93, 61, 86, 11, 45, 70, 47, 30});
+  Tensor<double> rhs_elem_1_0(
+      Range{7, 2}, {63, 19, 60, 77, 10, 60, 68, 52, 5, 31, 44, 6, 90, 37});
+  Tensor<double> rhs_elem_1_1(
+      Range{7, 2}, {79, 73, 42, 83, 71, 83, 73, 32, 66, 87, 14, 76, 14, 72});
+  Tensor<double> rhs_elem_1_2(
+      Range{7, 2}, {80, 19, 59, 90, 73, 84, 22, 16, 1, 95, 90, 7, 97, 26});
+  Tensor<double> rhs_elem_1_3(
+      Range{7, 2}, {32, 55, 64, 81, 63, 97, 76, 86, 69, 61, 76, 87, 19, 72});
+  Tensor<double> rhs_elem_1_4(
+      Range{7, 2}, {63, 84, 5, 64, 43, 30, 78, 8, 65, 25, 99, 93, 23, 22});
+  Tensor<double> rhs_elem_1_5(
+      Range{7, 2}, {6, 74, 86, 41, 43, 63, 5, 83, 78, 54, 5, 1, 43, 97});
+  matrix_il rhs_il{{rhs_elem_0_0, rhs_elem_0_1, rhs_elem_0_2, rhs_elem_0_3,
+                    rhs_elem_0_4, rhs_elem_0_5},
+                   {rhs_elem_1_0, rhs_elem_1_1, rhs_elem_1_2, rhs_elem_1_3,
+                    rhs_elem_1_4, rhs_elem_1_5}};
+  TiledRange rhs_trange{{0, 2}, {0, 2, 4, 6}};
   dist_array_t rhs(world, rhs_trange, rhs_il);
-  Tensor<double> corr_elem_0_0(Range{7, 2}, {7511, 1015, 6100, 4327, 1038, 12446, 4253, 6535, 1737, 8378, 4051, 2432, 11712, 3707});
-  Tensor<double> corr_elem_0_1(Range{7, 2}, {6407, 8322, 3318, 4887, 7353, 14857, 3001, 8620, 7166, 11528, 1561, 7220, 4512, 8406});
-  Tensor<double> corr_elem_0_2(Range{7, 2}, {6436, 4154, 5135, 6744, 6447, 15366, 1863, 6201, 3556, 6966, 7584, 3080, 11952, 1981});
-  Tensor<double> corr_elem_0_3(Range{7, 2}, {4652, 7103, 6684, 6433, 5589, 12438, 2505, 8450, 6915, 3006, 2546, 9336, 6864, 8691});
-  Tensor<double> corr_elem_0_4(Range{7, 2}, {6629, 7611, 1801, 4440, 4401, 9792, 4098, 2948, 7636, 5062, 2745, 10788, 9840, 2312});
-  Tensor<double> corr_elem_0_5(Range{7, 2}, {1497, 2789, 6970, 4049, 3777, 7997, 2837, 11523, 11408, 2698, 2695, 2048, 6576, 8888});
-  Tensor<double> corr_elem_1_0(Range{7, 2}, {4466, 871, 2770, 5378, 454, 9332, 664, 3055, 1649, 4885, 3097, 6784, 11024, 4140});
-  Tensor<double> corr_elem_1_1(Range{7, 2}, {1298, 5285, 1089, 6141, 3215, 11317, 497, 2860, 3162, 7595, 1057, 5909, 3172, 9918});
-  Tensor<double> corr_elem_1_2(Range{7, 2}, {1240, 2247, 1953, 8889, 2749, 11676, 282, 1833, 4117, 5425, 6150, 8738, 11518, 1935});
-  Tensor<double> corr_elem_1_3(Range{7, 2}, {3464, 4347, 3113, 8561, 2385, 9903, 432, 4550, 2625, 2735, 4178, 10398, 4706, 10363});
-  Tensor<double> corr_elem_1_4(Range{7, 2}, {3206, 5220, 1385, 5772, 1921, 7074, 654, 884, 3797, 3075, 5292, 13857, 6526, 2630});
-  Tensor<double> corr_elem_1_5(Range{7, 2}, {1542, 2882, 2387, 5557, 1609, 6377, 397, 5109, 7206, 2440, 940, 6704, 5798, 9557});
-  Tensor<double> corr_elem_2_0(Range{7, 2}, {8176, 2100, 4600, 3345, 874, 11224, 9115, 1561, 1870, 3547, 4498, 4078, 3831, 1126});
-  Tensor<double> corr_elem_2_1(Range{7, 2}, {5520, 10431, 2064, 4061, 6183, 13195, 6386, 2996, 5304, 8487, 1498, 1957, 680, 2484});
-  Tensor<double> corr_elem_2_2(Range{7, 2}, {5508, 3777, 3475, 7356, 4873, 13680, 4007, 2335, 4319, 8579, 9028, 5269, 4108, 638});
-  Tensor<double> corr_elem_2_3(Range{7, 2}, {5468, 8304, 5122, 7363, 4239, 10555, 5303, 1538, 4836, 5329, 6676, 4497, 946, 2554});
-  Tensor<double> corr_elem_2_4(Range{7, 2}, {6790, 10953, 1953, 4504, 3675, 9138, 8760, 1100, 5935, 2653, 8556, 6510, 1193, 696});
-  Tensor<double> corr_elem_2_5(Range{7, 2}, {2007, 7557, 4440, 5347, 2843, 6775, 6154, 2975, 9882, 4722, 1060, 4141, 1861, 2748});
-  Tensor<double> corr_elem_3_0(Range{7, 2}, {7609, 739, 2750, 6942, 1746, 7446, 5970, 4644, 2126, 4907, 4580, 6016, 7547, 4932});
-  Tensor<double> corr_elem_3_1(Range{7, 2}, {4809, 6050, 1551, 7512, 12258, 8509, 3927, 7984, 6616, 6923, 1820, 3762, 3724, 11250});
-  Tensor<double> corr_elem_3_2(Range{7, 2}, {4788, 3018, 2365, 8334, 3420, 8862, 2704, 6100, 4791, 4347, 8432, 7764, 7498, 2601});
-  Tensor<double> corr_elem_3_3(Range{7, 2}, {5180, 5163, 3003, 7548, 3159, 6206, 3106, 5052, 6132, 1953, 1976, 7596, 5756, 11645});
-  Tensor<double> corr_elem_3_4(Range{7, 2}, {6223, 5535, 737, 5880, 6993, 6432, 5610, 2880, 7303, 2989, 1812, 10602, 8419, 3082});
-  Tensor<double> corr_elem_3_5(Range{7, 2}, {1953, 2033, 3245, 3924, 1845, 3969, 4443, 8630, 11818, 1750, 3500, 6048, 4535, 11779});
-  matrix_il corr_il {{corr_elem_0_0, corr_elem_0_1, corr_elem_0_2, corr_elem_0_3, corr_elem_0_4, corr_elem_0_5},{corr_elem_1_0, corr_elem_1_1, corr_elem_1_2, corr_elem_1_3, corr_elem_1_4, corr_elem_1_5},{corr_elem_2_0, corr_elem_2_1, corr_elem_2_2, corr_elem_2_3, corr_elem_2_4, corr_elem_2_5},{corr_elem_3_0, corr_elem_3_1, corr_elem_3_2, corr_elem_3_3, corr_elem_3_4, corr_elem_3_5}};
-  TiledRange corr_trange{{0, 2, 4},{0, 2, 4, 6}};
+  Tensor<double> corr_elem_0_0(
+      Range{7, 2}, {7511, 1015, 6100, 4327, 1038, 12446, 4253, 6535, 1737, 8378,
+                    4051, 2432, 11712, 3707});
+  Tensor<double> corr_elem_0_1(
+      Range{7, 2}, {6407, 8322, 3318, 4887, 7353, 14857, 3001, 8620, 7166,
+                    11528, 1561, 7220, 4512, 8406});
+  Tensor<double> corr_elem_0_2(
+      Range{7, 2}, {6436, 4154, 5135, 6744, 6447, 15366, 1863, 6201, 3556, 6966,
+                    7584, 3080, 11952, 1981});
+  Tensor<double> corr_elem_0_3(
+      Range{7, 2}, {4652, 7103, 6684, 6433, 5589, 12438, 2505, 8450, 6915, 3006,
+                    2546, 9336, 6864, 8691});
+  Tensor<double> corr_elem_0_4(
+      Range{7, 2}, {6629, 7611, 1801, 4440, 4401, 9792, 4098, 2948, 7636, 5062,
+                    2745, 10788, 9840, 2312});
+  Tensor<double> corr_elem_0_5(
+      Range{7, 2}, {1497, 2789, 6970, 4049, 3777, 7997, 2837, 11523, 11408,
+                    2698, 2695, 2048, 6576, 8888});
+  Tensor<double> corr_elem_1_0(
+      Range{7, 2}, {4466, 871, 2770, 5378, 454, 9332, 664, 3055, 1649, 4885,
+                    3097, 6784, 11024, 4140});
+  Tensor<double> corr_elem_1_1(
+      Range{7, 2}, {1298, 5285, 1089, 6141, 3215, 11317, 497, 2860, 3162, 7595,
+                    1057, 5909, 3172, 9918});
+  Tensor<double> corr_elem_1_2(
+      Range{7, 2}, {1240, 2247, 1953, 8889, 2749, 11676, 282, 1833, 4117, 5425,
+                    6150, 8738, 11518, 1935});
+  Tensor<double> corr_elem_1_3(
+      Range{7, 2}, {3464, 4347, 3113, 8561, 2385, 9903, 432, 4550, 2625, 2735,
+                    4178, 10398, 4706, 10363});
+  Tensor<double> corr_elem_1_4(
+      Range{7, 2}, {3206, 5220, 1385, 5772, 1921, 7074, 654, 884, 3797, 3075,
+                    5292, 13857, 6526, 2630});
+  Tensor<double> corr_elem_1_5(
+      Range{7, 2}, {1542, 2882, 2387, 5557, 1609, 6377, 397, 5109, 7206, 2440,
+                    940, 6704, 5798, 9557});
+  Tensor<double> corr_elem_2_0(
+      Range{7, 2}, {8176, 2100, 4600, 3345, 874, 11224, 9115, 1561, 1870, 3547,
+                    4498, 4078, 3831, 1126});
+  Tensor<double> corr_elem_2_1(
+      Range{7, 2}, {5520, 10431, 2064, 4061, 6183, 13195, 6386, 2996, 5304,
+                    8487, 1498, 1957, 680, 2484});
+  Tensor<double> corr_elem_2_2(
+      Range{7, 2}, {5508, 3777, 3475, 7356, 4873, 13680, 4007, 2335, 4319, 8579,
+                    9028, 5269, 4108, 638});
+  Tensor<double> corr_elem_2_3(
+      Range{7, 2}, {5468, 8304, 5122, 7363, 4239, 10555, 5303, 1538, 4836, 5329,
+                    6676, 4497, 946, 2554});
+  Tensor<double> corr_elem_2_4(
+      Range{7, 2}, {6790, 10953, 1953, 4504, 3675, 9138, 8760, 1100, 5935, 2653,
+                    8556, 6510, 1193, 696});
+  Tensor<double> corr_elem_2_5(
+      Range{7, 2}, {2007, 7557, 4440, 5347, 2843, 6775, 6154, 2975, 9882, 4722,
+                    1060, 4141, 1861, 2748});
+  Tensor<double> corr_elem_3_0(
+      Range{7, 2}, {7609, 739, 2750, 6942, 1746, 7446, 5970, 4644, 2126, 4907,
+                    4580, 6016, 7547, 4932});
+  Tensor<double> corr_elem_3_1(
+      Range{7, 2}, {4809, 6050, 1551, 7512, 12258, 8509, 3927, 7984, 6616, 6923,
+                    1820, 3762, 3724, 11250});
+  Tensor<double> corr_elem_3_2(
+      Range{7, 2}, {4788, 3018, 2365, 8334, 3420, 8862, 2704, 6100, 4791, 4347,
+                    8432, 7764, 7498, 2601});
+  Tensor<double> corr_elem_3_3(
+      Range{7, 2}, {5180, 5163, 3003, 7548, 3159, 6206, 3106, 5052, 6132, 1953,
+                    1976, 7596, 5756, 11645});
+  Tensor<double> corr_elem_3_4(
+      Range{7, 2}, {6223, 5535, 737, 5880, 6993, 6432, 5610, 2880, 7303, 2989,
+                    1812, 10602, 8419, 3082});
+  Tensor<double> corr_elem_3_5(
+      Range{7, 2}, {1953, 2033, 3245, 3924, 1845, 3969, 4443, 8630, 11818, 1750,
+                    3500, 6048, 4535, 11779});
+  matrix_il corr_il{{corr_elem_0_0, corr_elem_0_1, corr_elem_0_2, corr_elem_0_3,
+                     corr_elem_0_4, corr_elem_0_5},
+                    {corr_elem_1_0, corr_elem_1_1, corr_elem_1_2, corr_elem_1_3,
+                     corr_elem_1_4, corr_elem_1_5},
+                    {corr_elem_2_0, corr_elem_2_1, corr_elem_2_2, corr_elem_2_3,
+                     corr_elem_2_4, corr_elem_2_5},
+                    {corr_elem_3_0, corr_elem_3_1, corr_elem_3_2, corr_elem_3_3,
+                     corr_elem_3_4, corr_elem_3_5}};
+  TiledRange corr_trange{{0, 2, 4}, {0, 2, 4, 6}};
   dist_array_t corr(world, corr_trange, corr_il);
   dist_array_t out = einsum(lhs("i,j;m,n"), rhs("j,k;m,n"), "i,k;m,n");
   const bool are_equal = ToTArrayFixture::are_equal(corr, out);
   BOOST_CHECK(are_equal);
 }
 
-BOOST_AUTO_TEST_CASE(ik_mn_eq_ij_mn_times_kj_mn){
+BOOST_AUTO_TEST_CASE(ik_mn_eq_ij_mn_times_kj_mn) {
   using dist_array_t = DistArray<Tensor<Tensor<double>>, DensePolicy>;
   using matrix_il = TiledArray::detail::matrix_il<Tensor<double>>;
   auto& world = TiledArray::get_default_world();
-  Tensor<double> lhs_elem_0_0(Range{7, 2}, {25, 18, 67, 84, 22, 81, 6, 31, 50, 17, 61, 2, 63, 58});
-  Tensor<double> lhs_elem_0_1(Range{7, 2}, {3, 11, 71, 19, 43, 94, 20, 93, 52, 62, 38, 59, 42, 88});
-  Tensor<double> lhs_elem_1_0(Range{7, 2}, {43, 50, 30, 27, 97, 41, 12, 21, 57, 8, 37, 81, 26, 94});
-  Tensor<double> lhs_elem_1_1(Range{7, 2}, {1, 84, 87, 69, 68, 26, 86, 99, 16, 88, 38, 55, 91, 56});
-  Tensor<double> lhs_elem_2_0(Range{7, 2}, {75, 9, 24, 79, 68, 7, 33, 16, 47, 11, 3, 26, 61, 48});
-  Tensor<double> lhs_elem_2_1(Range{7, 2}, {71, 41, 63, 70, 75, 87, 76, 31, 20, 67, 45, 84, 92, 17});
-  Tensor<double> lhs_elem_3_0(Range{7, 2}, {7, 69, 99, 84, 66, 28, 32, 28, 30, 74, 35, 78, 89, 73});
-  Tensor<double> lhs_elem_3_1(Range{7, 2}, {21, 91, 52, 94, 67, 63, 17, 20, 48, 88, 100, 53, 35, 29});
-  matrix_il lhs_il {{lhs_elem_0_0, lhs_elem_0_1},{lhs_elem_1_0, lhs_elem_1_1},{lhs_elem_2_0, lhs_elem_2_1},{lhs_elem_3_0, lhs_elem_3_1}};
-  TiledRange lhs_trange{{0, 2, 4},{0, 2}};
+  Tensor<double> lhs_elem_0_0(
+      Range{7, 2}, {25, 18, 67, 84, 22, 81, 6, 31, 50, 17, 61, 2, 63, 58});
+  Tensor<double> lhs_elem_0_1(
+      Range{7, 2}, {3, 11, 71, 19, 43, 94, 20, 93, 52, 62, 38, 59, 42, 88});
+  Tensor<double> lhs_elem_1_0(
+      Range{7, 2}, {43, 50, 30, 27, 97, 41, 12, 21, 57, 8, 37, 81, 26, 94});
+  Tensor<double> lhs_elem_1_1(
+      Range{7, 2}, {1, 84, 87, 69, 68, 26, 86, 99, 16, 88, 38, 55, 91, 56});
+  Tensor<double> lhs_elem_2_0(
+      Range{7, 2}, {75, 9, 24, 79, 68, 7, 33, 16, 47, 11, 3, 26, 61, 48});
+  Tensor<double> lhs_elem_2_1(
+      Range{7, 2}, {71, 41, 63, 70, 75, 87, 76, 31, 20, 67, 45, 84, 92, 17});
+  Tensor<double> lhs_elem_3_0(
+      Range{7, 2}, {7, 69, 99, 84, 66, 28, 32, 28, 30, 74, 35, 78, 89, 73});
+  Tensor<double> lhs_elem_3_1(
+      Range{7, 2}, {21, 91, 52, 94, 67, 63, 17, 20, 48, 88, 100, 53, 35, 29});
+  matrix_il lhs_il{{lhs_elem_0_0, lhs_elem_0_1},
+                   {lhs_elem_1_0, lhs_elem_1_1},
+                   {lhs_elem_2_0, lhs_elem_2_1},
+                   {lhs_elem_3_0, lhs_elem_3_1}};
+  TiledRange lhs_trange{{0, 2, 4}, {0, 2}};
   dist_array_t lhs(world, lhs_trange, lhs_il);
-  Tensor<double> rhs_elem_0_0(Range{7, 2}, {12, 52, 47, 53, 66, 87, 11, 48, 24, 83, 16, 38, 26, 39});
-  Tensor<double> rhs_elem_0_1(Range{7, 2}, {96, 38, 53, 99, 32, 16, 11, 69, 68, 17, 38, 53, 79, 83});
-  Tensor<double> rhs_elem_1_0(Range{7, 2}, {26, 27, 3, 57, 26, 24, 35, 11, 96, 26, 83, 94, 19, 90});
-  Tensor<double> rhs_elem_1_1(Range{7, 2}, {83, 98, 74, 21, 27, 14, 90, 75, 98, 75, 84, 5, 42, 88});
-  Tensor<double> rhs_elem_2_0(Range{7, 2}, {72, 77, 10, 51, 62, 81, 58, 50, 56, 43, 68, 64, 54, 82});
-  Tensor<double> rhs_elem_2_1(Range{7, 2}, {81, 20, 46, 1, 88, 39, 45, 79, 85, 48, 72, 1, 79, 89});
-  Tensor<double> rhs_elem_3_0(Range{7, 2}, {84, 52, 99, 71, 30, 54, 17, 70, 18, 30, 77, 16, 65, 69});
-  Tensor<double> rhs_elem_3_1(Range{7, 2}, {49, 80, 72, 71, 18, 51, 48, 22, 72, 43, 95, 22, 41, 88});
-  Tensor<double> rhs_elem_4_0(Range{7, 2}, {70, 14, 59, 72, 53, 91, 31, 90, 56, 58, 28, 7, 87, 82});
-  Tensor<double> rhs_elem_4_1(Range{7, 2}, {51, 95, 69, 13, 53, 75, 30, 71, 14, 10, 17, 44, 29, 77});
-  Tensor<double> rhs_elem_5_0(Range{7, 2}, {95, 8, 90, 64, 96, 71, 41, 3, 100, 32, 14, 42, 77, 23});
-  Tensor<double> rhs_elem_5_1(Range{7, 2}, {75, 96, 3, 89, 8, 11, 83, 18, 19, 24, 8, 69, 72, 38});
-  matrix_il rhs_il {{rhs_elem_0_0, rhs_elem_0_1},{rhs_elem_1_0, rhs_elem_1_1},{rhs_elem_2_0, rhs_elem_2_1},{rhs_elem_3_0, rhs_elem_3_1},{rhs_elem_4_0, rhs_elem_4_1},{rhs_elem_5_0, rhs_elem_5_1}};
-  TiledRange rhs_trange{{0, 2, 4, 6},{0, 2}};
+  Tensor<double> rhs_elem_0_0(
+      Range{7, 2}, {12, 52, 47, 53, 66, 87, 11, 48, 24, 83, 16, 38, 26, 39});
+  Tensor<double> rhs_elem_0_1(
+      Range{7, 2}, {96, 38, 53, 99, 32, 16, 11, 69, 68, 17, 38, 53, 79, 83});
+  Tensor<double> rhs_elem_1_0(
+      Range{7, 2}, {26, 27, 3, 57, 26, 24, 35, 11, 96, 26, 83, 94, 19, 90});
+  Tensor<double> rhs_elem_1_1(
+      Range{7, 2}, {83, 98, 74, 21, 27, 14, 90, 75, 98, 75, 84, 5, 42, 88});
+  Tensor<double> rhs_elem_2_0(
+      Range{7, 2}, {72, 77, 10, 51, 62, 81, 58, 50, 56, 43, 68, 64, 54, 82});
+  Tensor<double> rhs_elem_2_1(
+      Range{7, 2}, {81, 20, 46, 1, 88, 39, 45, 79, 85, 48, 72, 1, 79, 89});
+  Tensor<double> rhs_elem_3_0(
+      Range{7, 2}, {84, 52, 99, 71, 30, 54, 17, 70, 18, 30, 77, 16, 65, 69});
+  Tensor<double> rhs_elem_3_1(
+      Range{7, 2}, {49, 80, 72, 71, 18, 51, 48, 22, 72, 43, 95, 22, 41, 88});
+  Tensor<double> rhs_elem_4_0(
+      Range{7, 2}, {70, 14, 59, 72, 53, 91, 31, 90, 56, 58, 28, 7, 87, 82});
+  Tensor<double> rhs_elem_4_1(
+      Range{7, 2}, {51, 95, 69, 13, 53, 75, 30, 71, 14, 10, 17, 44, 29, 77});
+  Tensor<double> rhs_elem_5_0(
+      Range{7, 2}, {95, 8, 90, 64, 96, 71, 41, 3, 100, 32, 14, 42, 77, 23});
+  Tensor<double> rhs_elem_5_1(
+      Range{7, 2}, {75, 96, 3, 89, 8, 11, 83, 18, 19, 24, 8, 69, 72, 38});
+  matrix_il rhs_il{{rhs_elem_0_0, rhs_elem_0_1}, {rhs_elem_1_0, rhs_elem_1_1},
+                   {rhs_elem_2_0, rhs_elem_2_1}, {rhs_elem_3_0, rhs_elem_3_1},
+                   {rhs_elem_4_0, rhs_elem_4_1}, {rhs_elem_5_0, rhs_elem_5_1}};
+  TiledRange rhs_trange{{0, 2, 4, 6}, {0, 2}};
   dist_array_t rhs(world, rhs_trange, rhs_il);
-  Tensor<double> corr_elem_0_0(Range{7, 2}, {588, 1354, 6912, 6333, 2828, 8551, 286, 7905, 4736, 2465, 2420, 3203, 4956, 9566});
-  Tensor<double> corr_elem_0_1(Range{7, 2}, {899, 1564, 5455, 5187, 1733, 3260, 2010, 7316, 9896, 5092, 8255, 483, 2961, 12964});
-  Tensor<double> corr_elem_0_2(Range{7, 2}, {2043, 1606, 3936, 4303, 5148, 10227, 1248, 8897, 7220, 3707, 6884, 187, 6720, 12588});
-  Tensor<double> corr_elem_0_3(Range{7, 2}, {2247, 1816, 11745, 7313, 1434, 9168, 1062, 4216, 4644, 3176, 8307, 1330, 5817, 11746});
-  Tensor<double> corr_elem_0_4(Range{7, 2}, {1903, 1297, 8852, 6295, 3445, 14421, 786, 9393, 3528, 1606, 2354, 2610, 6699, 11532});
-  Tensor<double> corr_elem_0_5(Range{7, 2}, {2600, 1200, 6243, 7067, 2456, 6785, 1906, 1767, 5988, 2032, 1158, 4155, 7875, 4678});
-  Tensor<double> corr_elem_1_0(Range{7, 2}, {612, 5792, 6021, 8262, 8578, 3983, 1078, 7839, 2456, 2160, 2036, 5993, 7865, 8314});
-  Tensor<double> corr_elem_1_1(Range{7, 2}, {1201, 9582, 6528, 2988, 4358, 1348, 8160, 7656, 7040, 6808, 6263, 7889, 4316, 13388});
-  Tensor<double> corr_elem_1_2(Range{7, 2}, {3177, 5530, 4302, 1446, 11998, 4335, 4566, 8871, 4552, 4568, 5252, 5239, 8593, 12692});
-  Tensor<double> corr_elem_1_3(Range{7, 2}, {3661, 9320, 9234, 6816, 4134, 3540, 4332, 3648, 2178, 4024, 6459, 2506, 5421, 11414});
-  Tensor<double> corr_elem_1_4(Range{7, 2}, {3061, 8680, 7773, 2841, 8745, 5681, 2952, 8919, 3416, 1344, 1682, 2987, 4901, 12020});
-  Tensor<double> corr_elem_1_5(Range{7, 2}, {4160, 8464, 2961, 7869, 9856, 3197, 7630, 1845, 6004, 2368, 822, 7197, 8554, 4290});
-  Tensor<double> corr_elem_2_0(Range{7, 2}, {7716, 2026, 4467, 11117, 6888, 2001, 1199, 2907, 2488, 2052, 1758, 5440, 8854, 3283});
-  Tensor<double> corr_elem_2_1(Range{7, 2}, {7843, 4261, 4734, 5973, 3793, 1386, 7995, 2501, 6472, 5311, 4029, 2864, 5023, 5816});
-  Tensor<double> corr_elem_2_2(Range{7, 2}, {11151, 1513, 3138, 4099, 10816, 3960, 5334, 3249, 4332, 3689, 3444, 1748, 10562, 5449});
-  Tensor<double> corr_elem_2_3(Range{7, 2}, {9779, 3748, 6912, 10579, 3390, 4815, 4209, 1802, 2286, 3211, 4506, 2264, 7737, 4808});
-  Tensor<double> corr_elem_2_4(Range{7, 2}, {8871, 4021, 5763, 6598, 7579, 7162, 3303, 3641, 2912, 1308, 849, 3878, 7975, 5245});
-  Tensor<double> corr_elem_2_5(Range{7, 2}, {12450, 4008, 2349, 11286, 7128, 1454, 7661, 606, 5080, 1960, 402, 6888, 11321, 1750});
-  Tensor<double> corr_elem_3_0(Range{7, 2}, {2100, 7046, 7409, 13758, 6500, 3444, 539, 2724, 3984, 7638, 4360, 5773, 5079, 5254});
-  Tensor<double> corr_elem_3_1(Range{7, 2}, {1925, 10781, 4145, 6762, 3525, 1554, 2650, 1808, 7584, 8524, 11305, 7597, 3161, 9122});
-  Tensor<double> corr_elem_3_2(Range{7, 2}, {2205, 7133, 3382, 4378, 9988, 4725, 2621, 2980, 5760, 7406, 9580, 5045, 7571, 8567});
-  Tensor<double> corr_elem_3_3(Range{7, 2}, {1617, 10868, 13545, 12638, 3186, 4725, 1360, 2400, 3996, 6004, 12195, 2414, 7220, 7589});
-  Tensor<double> corr_elem_3_4(Range{7, 2}, {1561, 9611, 9429, 7270, 7049, 7273, 1502, 3940, 2352, 5172, 2680, 2878, 8758, 8219});
-  Tensor<double> corr_elem_3_5(Range{7, 2}, {2240, 9288, 9066, 13742, 6872, 2681, 2723, 444, 3912, 4480, 1290, 6933, 9373, 2781});
-  matrix_il corr_il {{corr_elem_0_0, corr_elem_0_1, corr_elem_0_2, corr_elem_0_3, corr_elem_0_4, corr_elem_0_5},{corr_elem_1_0, corr_elem_1_1, corr_elem_1_2, corr_elem_1_3, corr_elem_1_4, corr_elem_1_5},{corr_elem_2_0, corr_elem_2_1, corr_elem_2_2, corr_elem_2_3, corr_elem_2_4, corr_elem_2_5},{corr_elem_3_0, corr_elem_3_1, corr_elem_3_2, corr_elem_3_3, corr_elem_3_4, corr_elem_3_5}};
-  TiledRange corr_trange{{0, 2, 4},{0, 2, 4, 6}};
+  Tensor<double> corr_elem_0_0(
+      Range{7, 2}, {588, 1354, 6912, 6333, 2828, 8551, 286, 7905, 4736, 2465,
+                    2420, 3203, 4956, 9566});
+  Tensor<double> corr_elem_0_1(
+      Range{7, 2}, {899, 1564, 5455, 5187, 1733, 3260, 2010, 7316, 9896, 5092,
+                    8255, 483, 2961, 12964});
+  Tensor<double> corr_elem_0_2(
+      Range{7, 2}, {2043, 1606, 3936, 4303, 5148, 10227, 1248, 8897, 7220, 3707,
+                    6884, 187, 6720, 12588});
+  Tensor<double> corr_elem_0_3(
+      Range{7, 2}, {2247, 1816, 11745, 7313, 1434, 9168, 1062, 4216, 4644, 3176,
+                    8307, 1330, 5817, 11746});
+  Tensor<double> corr_elem_0_4(
+      Range{7, 2}, {1903, 1297, 8852, 6295, 3445, 14421, 786, 9393, 3528, 1606,
+                    2354, 2610, 6699, 11532});
+  Tensor<double> corr_elem_0_5(
+      Range{7, 2}, {2600, 1200, 6243, 7067, 2456, 6785, 1906, 1767, 5988, 2032,
+                    1158, 4155, 7875, 4678});
+  Tensor<double> corr_elem_1_0(
+      Range{7, 2}, {612, 5792, 6021, 8262, 8578, 3983, 1078, 7839, 2456, 2160,
+                    2036, 5993, 7865, 8314});
+  Tensor<double> corr_elem_1_1(
+      Range{7, 2}, {1201, 9582, 6528, 2988, 4358, 1348, 8160, 7656, 7040, 6808,
+                    6263, 7889, 4316, 13388});
+  Tensor<double> corr_elem_1_2(
+      Range{7, 2}, {3177, 5530, 4302, 1446, 11998, 4335, 4566, 8871, 4552, 4568,
+                    5252, 5239, 8593, 12692});
+  Tensor<double> corr_elem_1_3(
+      Range{7, 2}, {3661, 9320, 9234, 6816, 4134, 3540, 4332, 3648, 2178, 4024,
+                    6459, 2506, 5421, 11414});
+  Tensor<double> corr_elem_1_4(
+      Range{7, 2}, {3061, 8680, 7773, 2841, 8745, 5681, 2952, 8919, 3416, 1344,
+                    1682, 2987, 4901, 12020});
+  Tensor<double> corr_elem_1_5(
+      Range{7, 2}, {4160, 8464, 2961, 7869, 9856, 3197, 7630, 1845, 6004, 2368,
+                    822, 7197, 8554, 4290});
+  Tensor<double> corr_elem_2_0(
+      Range{7, 2}, {7716, 2026, 4467, 11117, 6888, 2001, 1199, 2907, 2488, 2052,
+                    1758, 5440, 8854, 3283});
+  Tensor<double> corr_elem_2_1(
+      Range{7, 2}, {7843, 4261, 4734, 5973, 3793, 1386, 7995, 2501, 6472, 5311,
+                    4029, 2864, 5023, 5816});
+  Tensor<double> corr_elem_2_2(
+      Range{7, 2}, {11151, 1513, 3138, 4099, 10816, 3960, 5334, 3249, 4332,
+                    3689, 3444, 1748, 10562, 5449});
+  Tensor<double> corr_elem_2_3(
+      Range{7, 2}, {9779, 3748, 6912, 10579, 3390, 4815, 4209, 1802, 2286, 3211,
+                    4506, 2264, 7737, 4808});
+  Tensor<double> corr_elem_2_4(
+      Range{7, 2}, {8871, 4021, 5763, 6598, 7579, 7162, 3303, 3641, 2912, 1308,
+                    849, 3878, 7975, 5245});
+  Tensor<double> corr_elem_2_5(
+      Range{7, 2}, {12450, 4008, 2349, 11286, 7128, 1454, 7661, 606, 5080, 1960,
+                    402, 6888, 11321, 1750});
+  Tensor<double> corr_elem_3_0(
+      Range{7, 2}, {2100, 7046, 7409, 13758, 6500, 3444, 539, 2724, 3984, 7638,
+                    4360, 5773, 5079, 5254});
+  Tensor<double> corr_elem_3_1(
+      Range{7, 2}, {1925, 10781, 4145, 6762, 3525, 1554, 2650, 1808, 7584, 8524,
+                    11305, 7597, 3161, 9122});
+  Tensor<double> corr_elem_3_2(
+      Range{7, 2}, {2205, 7133, 3382, 4378, 9988, 4725, 2621, 2980, 5760, 7406,
+                    9580, 5045, 7571, 8567});
+  Tensor<double> corr_elem_3_3(
+      Range{7, 2}, {1617, 10868, 13545, 12638, 3186, 4725, 1360, 2400, 3996,
+                    6004, 12195, 2414, 7220, 7589});
+  Tensor<double> corr_elem_3_4(
+      Range{7, 2}, {1561, 9611, 9429, 7270, 7049, 7273, 1502, 3940, 2352, 5172,
+                    2680, 2878, 8758, 8219});
+  Tensor<double> corr_elem_3_5(
+      Range{7, 2}, {2240, 9288, 9066, 13742, 6872, 2681, 2723, 444, 3912, 4480,
+                    1290, 6933, 9373, 2781});
+  matrix_il corr_il{{corr_elem_0_0, corr_elem_0_1, corr_elem_0_2, corr_elem_0_3,
+                     corr_elem_0_4, corr_elem_0_5},
+                    {corr_elem_1_0, corr_elem_1_1, corr_elem_1_2, corr_elem_1_3,
+                     corr_elem_1_4, corr_elem_1_5},
+                    {corr_elem_2_0, corr_elem_2_1, corr_elem_2_2, corr_elem_2_3,
+                     corr_elem_2_4, corr_elem_2_5},
+                    {corr_elem_3_0, corr_elem_3_1, corr_elem_3_2, corr_elem_3_3,
+                     corr_elem_3_4, corr_elem_3_5}};
+  TiledRange corr_trange{{0, 2, 4}, {0, 2, 4, 6}};
   dist_array_t corr(world, corr_trange, corr_il);
   dist_array_t out = einsum(lhs("i,j;m,n"), rhs("k,j;m,n"), "i,k;m,n");
   const bool are_equal = ToTArrayFixture::are_equal(corr, out);
   BOOST_CHECK(are_equal);
 }
 
-BOOST_AUTO_TEST_CASE(ij_mn_eq_ij_mn_times_ij_mn){
+BOOST_AUTO_TEST_CASE(ij_mn_eq_ij_mn_times_ij_mn) {
   using dist_array_t = DistArray<Tensor<Tensor<double>>, DensePolicy>;
   using matrix_il = TiledArray::detail::matrix_il<Tensor<double>>;
   auto& world = TiledArray::get_default_world();
-  Tensor<double> lhs_elem_0_0(Range{7, 2}, {86, 79, 35, 52, 36, 68, 39, 28, 83, 16, 18, 74, 83, 62});
-  Tensor<double> lhs_elem_0_1(Range{8, 3}, {99, 66, 95, 76, 38, 24, 6, 79, 85, 52, 93, 90, 5, 4, 41, 42, 49, 4, 42, 94, 60, 99, 69, 8});
-  Tensor<double> lhs_elem_1_0(Range{8, 3}, {5, 40, 94, 20, 25, 34, 25, 68, 94, 80, 61, 11, 94, 62, 25, 2, 64, 63, 28, 24, 7, 98, 59, 30});
-  Tensor<double> lhs_elem_1_1(Range{9, 4}, {37, 39, 26, 63, 10, 60, 5, 84, 72, 84, 10, 85, 33, 30, 12, 54, 63, 28, 21, 7, 27, 12, 47, 86, 58, 67, 99, 52, 92, 97, 72, 92, 10, 42, 23, 8});
-  Tensor<double> lhs_elem_2_0(Range{9, 4}, {81, 43, 70, 13, 91, 91, 2, 43, 85, 72, 69, 28, 20, 61, 96, 9, 80, 42, 17, 39, 85, 50, 18, 82, 56, 14, 95, 23, 22, 90, 80, 19, 83, 93, 43, 35});
-  Tensor<double> lhs_elem_2_1(Range{10, 5}, {20, 80, 94, 53, 72, 67, 77, 47, 81, 30, 65, 54, 61, 55, 48, 47, 91, 20, 64, 69, 38, 49, 24, 39, 57, 24, 2, 31, 85, 12, 25, 15, 21, 59, 99, 84, 8, 90, 45, 95, 55, 72, 46, 98, 40, 26, 2, 64, 46, 21});
-  Tensor<double> lhs_elem_3_0(Range{10, 5}, {30, 40, 24, 61, 11, 46, 35, 34, 79, 18, 55, 96, 43, 5, 11, 74, 78, 82, 19, 19, 19, 72, 17, 81, 64, 13, 55, 95, 98, 99, 28, 43, 51, 38, 33, 26, 6, 4, 97, 3, 91, 62, 89, 42, 71, 28, 81, 98, 72, 41});
-  Tensor<double> lhs_elem_3_1(Range{11, 6}, {100, 81, 93, 37, 58, 97, 90, 52, 94, 48, 63, 80, 12, 12, 13, 32, 93, 42, 6, 3, 13, 82, 46, 57, 2, 28, 95, 90, 14, 87, 29, 40, 39, 36, 69, 33, 10, 25, 57, 21, 77, 42, 68, 46, 4, 89, 21, 71, 20, 10, 31, 54, 64, 96, 82, 72, 17, 19, 6, 93, 22, 78, 7, 23, 52, 63});
-  matrix_il lhs_il {{lhs_elem_0_0, lhs_elem_0_1},{lhs_elem_1_0, lhs_elem_1_1},{lhs_elem_2_0, lhs_elem_2_1},{lhs_elem_3_0, lhs_elem_3_1}};
-  TiledRange lhs_trange{{0, 2, 4},{0, 2}};
+  Tensor<double> lhs_elem_0_0(
+      Range{7, 2}, {86, 79, 35, 52, 36, 68, 39, 28, 83, 16, 18, 74, 83, 62});
+  Tensor<double> lhs_elem_0_1(Range{8, 3},
+                              {99, 66, 95, 76, 38, 24, 6,  79, 85, 52, 93, 90,
+                               5,  4,  41, 42, 49, 4,  42, 94, 60, 99, 69, 8});
+  Tensor<double> lhs_elem_1_0(Range{8, 3},
+                              {5,  40, 94, 20, 25, 34, 25, 68, 94, 80, 61, 11,
+                               94, 62, 25, 2,  64, 63, 28, 24, 7,  98, 59, 30});
+  Tensor<double> lhs_elem_1_1(
+      Range{9, 4},
+      {37, 39, 26, 63, 10, 60, 5,  84, 72, 84, 10, 85, 33, 30, 12, 54, 63, 28,
+       21, 7,  27, 12, 47, 86, 58, 67, 99, 52, 92, 97, 72, 92, 10, 42, 23, 8});
+  Tensor<double> lhs_elem_2_0(
+      Range{9, 4},
+      {81, 43, 70, 13, 91, 91, 2,  43, 85, 72, 69, 28, 20, 61, 96, 9,  80, 42,
+       17, 39, 85, 50, 18, 82, 56, 14, 95, 23, 22, 90, 80, 19, 83, 93, 43, 35});
+  Tensor<double> lhs_elem_2_1(
+      Range{10, 5},
+      {20, 80, 94, 53, 72, 67, 77, 47, 81, 30, 65, 54, 61, 55, 48, 47, 91,
+       20, 64, 69, 38, 49, 24, 39, 57, 24, 2,  31, 85, 12, 25, 15, 21, 59,
+       99, 84, 8,  90, 45, 95, 55, 72, 46, 98, 40, 26, 2,  64, 46, 21});
+  Tensor<double> lhs_elem_3_0(
+      Range{10, 5},
+      {30, 40, 24, 61, 11, 46, 35, 34, 79, 18, 55, 96, 43, 5,  11, 74, 78,
+       82, 19, 19, 19, 72, 17, 81, 64, 13, 55, 95, 98, 99, 28, 43, 51, 38,
+       33, 26, 6,  4,  97, 3,  91, 62, 89, 42, 71, 28, 81, 98, 72, 41});
+  Tensor<double> lhs_elem_3_1(
+      Range{11, 6},
+      {100, 81, 93, 37, 58, 97, 90, 52, 94, 48, 63, 80, 12, 12, 13, 32, 93,
+       42,  6,  3,  13, 82, 46, 57, 2,  28, 95, 90, 14, 87, 29, 40, 39, 36,
+       69,  33, 10, 25, 57, 21, 77, 42, 68, 46, 4,  89, 21, 71, 20, 10, 31,
+       54,  64, 96, 82, 72, 17, 19, 6,  93, 22, 78, 7,  23, 52, 63});
+  matrix_il lhs_il{{lhs_elem_0_0, lhs_elem_0_1},
+                   {lhs_elem_1_0, lhs_elem_1_1},
+                   {lhs_elem_2_0, lhs_elem_2_1},
+                   {lhs_elem_3_0, lhs_elem_3_1}};
+  TiledRange lhs_trange{{0, 2, 4}, {0, 2}};
   dist_array_t lhs(world, lhs_trange, lhs_il);
-  Tensor<double> rhs_elem_0_0(Range{7, 2}, {51, 46, 7, 36, 56, 97, 4, 53, 67, 6, 35, 13, 62, 30});
-  Tensor<double> rhs_elem_0_1(Range{8, 3}, {20, 83, 5, 78, 25, 77, 5, 3, 59, 54, 92, 98, 32, 28, 5, 94, 81, 35, 71, 87, 60, 30, 57, 26});
-  Tensor<double> rhs_elem_1_0(Range{8, 3}, {56, 27, 42, 85, 52, 87, 70, 73, 63, 79, 33, 18, 8, 17, 18, 35, 97, 18, 6, 92, 14, 14, 13, 8});
-  Tensor<double> rhs_elem_1_1(Range{9, 4}, {32, 8, 91, 99, 88, 52, 41, 94, 14, 17, 1, 73, 43, 20, 89, 1, 63, 8, 54, 20, 20, 37, 37, 9, 85, 38, 76, 6, 67, 52, 7, 87, 82, 33, 93, 2});
-  Tensor<double> rhs_elem_2_0(Range{9, 4}, {48, 66, 62, 8, 22, 94, 97, 43, 22, 20, 16, 10, 38, 40, 18, 13, 21, 25, 73, 46, 91, 69, 13, 23, 94, 66, 66, 24, 51, 68, 89, 15, 69, 46, 9, 6});
-  Tensor<double> rhs_elem_2_1(Range{10, 5}, {86, 74, 40, 15, 11, 16, 2, 40, 24, 14, 95, 66, 58, 44, 30, 22, 88, 89, 45, 89, 51, 39, 70, 19, 39, 73, 6, 30, 72, 62, 34, 44, 79, 60, 81, 12, 68, 18, 68, 57, 83, 86, 47, 28, 20, 34, 60, 47, 99, 20});
-  Tensor<double> rhs_elem_3_0(Range{10, 5}, {84, 95, 77, 56, 80, 26, 91, 80, 74, 92, 76, 25, 43, 58, 28, 65, 67, 38, 60, 1, 65, 52, 77, 34, 52, 5, 47, 77, 65, 20, 30, 51, 97, 37, 23, 85, 100, 40, 91, 50, 14, 30, 97, 70, 83, 58, 28, 69, 26, 36});
-  Tensor<double> rhs_elem_3_1(Range{11, 6}, {3, 13, 87, 60, 90, 52, 7, 20, 4, 56, 41, 44, 83, 48, 41, 38, 65, 80, 60, 63, 55, 70, 37, 9, 45, 30, 18, 27, 4, 50, 81, 45, 19, 38, 54, 15, 71, 66, 42, 29, 42, 36, 20, 34, 79, 10, 81, 52, 85, 50, 18, 7, 96, 84, 64, 87, 68, 55, 45, 67, 29, 14, 76, 12, 89, 86});
-  matrix_il rhs_il {{rhs_elem_0_0, rhs_elem_0_1},{rhs_elem_1_0, rhs_elem_1_1},{rhs_elem_2_0, rhs_elem_2_1},{rhs_elem_3_0, rhs_elem_3_1}};
-  TiledRange rhs_trange{{0, 2, 4},{0, 2}};
+  Tensor<double> rhs_elem_0_0(
+      Range{7, 2}, {51, 46, 7, 36, 56, 97, 4, 53, 67, 6, 35, 13, 62, 30});
+  Tensor<double> rhs_elem_0_1(Range{8, 3},
+                              {20, 83, 5, 78, 25, 77, 5,  3,  59, 54, 92, 98,
+                               32, 28, 5, 94, 81, 35, 71, 87, 60, 30, 57, 26});
+  Tensor<double> rhs_elem_1_0(Range{8, 3},
+                              {56, 27, 42, 85, 52, 87, 70, 73, 63, 79, 33, 18,
+                               8,  17, 18, 35, 97, 18, 6,  92, 14, 14, 13, 8});
+  Tensor<double> rhs_elem_1_1(
+      Range{9, 4},
+      {32, 8,  91, 99, 88, 52, 41, 94, 14, 17, 1,  73, 43, 20, 89, 1,  63, 8,
+       54, 20, 20, 37, 37, 9,  85, 38, 76, 6,  67, 52, 7,  87, 82, 33, 93, 2});
+  Tensor<double> rhs_elem_2_0(
+      Range{9, 4},
+      {48, 66, 62, 8,  22, 94, 97, 43, 22, 20, 16, 10, 38, 40, 18, 13, 21, 25,
+       73, 46, 91, 69, 13, 23, 94, 66, 66, 24, 51, 68, 89, 15, 69, 46, 9,  6});
+  Tensor<double> rhs_elem_2_1(
+      Range{10, 5},
+      {86, 74, 40, 15, 11, 16, 2,  40, 24, 14, 95, 66, 58, 44, 30, 22, 88,
+       89, 45, 89, 51, 39, 70, 19, 39, 73, 6,  30, 72, 62, 34, 44, 79, 60,
+       81, 12, 68, 18, 68, 57, 83, 86, 47, 28, 20, 34, 60, 47, 99, 20});
+  Tensor<double> rhs_elem_3_0(
+      Range{10, 5},
+      {84, 95, 77,  56, 80, 26, 91, 80, 74, 92, 76, 25, 43, 58, 28, 65, 67,
+       38, 60, 1,   65, 52, 77, 34, 52, 5,  47, 77, 65, 20, 30, 51, 97, 37,
+       23, 85, 100, 40, 91, 50, 14, 30, 97, 70, 83, 58, 28, 69, 26, 36});
+  Tensor<double> rhs_elem_3_1(
+      Range{11, 6},
+      {3,  13, 87, 60, 90, 52, 7,  20, 4,  56, 41, 44, 83, 48, 41, 38, 65,
+       80, 60, 63, 55, 70, 37, 9,  45, 30, 18, 27, 4,  50, 81, 45, 19, 38,
+       54, 15, 71, 66, 42, 29, 42, 36, 20, 34, 79, 10, 81, 52, 85, 50, 18,
+       7,  96, 84, 64, 87, 68, 55, 45, 67, 29, 14, 76, 12, 89, 86});
+  matrix_il rhs_il{{rhs_elem_0_0, rhs_elem_0_1},
+                   {rhs_elem_1_0, rhs_elem_1_1},
+                   {rhs_elem_2_0, rhs_elem_2_1},
+                   {rhs_elem_3_0, rhs_elem_3_1}};
+  TiledRange rhs_trange{{0, 2, 4}, {0, 2}};
   dist_array_t rhs(world, rhs_trange, rhs_il);
-  Tensor<double> corr_elem_0_0(Range{7, 2}, {4386, 3634, 245, 1872, 2016, 6596, 156, 1484, 5561, 96, 630, 962, 5146, 1860});
-  Tensor<double> corr_elem_0_1(Range{8, 3}, {1980, 5478, 475, 5928, 950, 1848, 30, 237, 5015, 2808, 8556, 8820, 160, 112, 205, 3948, 3969, 140, 2982, 8178, 3600, 2970, 3933, 208});
-  Tensor<double> corr_elem_1_0(Range{8, 3}, {280, 1080, 3948, 1700, 1300, 2958, 1750, 4964, 5922, 6320, 2013, 198, 752, 1054, 450, 70, 6208, 1134, 168, 2208, 98, 1372, 767, 240});
-  Tensor<double> corr_elem_1_1(Range{9, 4}, {1184, 312, 2366, 6237, 880, 3120, 205, 7896, 1008, 1428, 10, 6205, 1419, 600, 1068, 54, 3969, 224, 1134, 140, 540, 444, 1739, 774, 4930, 2546, 7524, 312, 6164, 5044, 504, 8004, 820, 1386, 2139, 16});
-  Tensor<double> corr_elem_2_0(Range{9, 4}, {3888, 2838, 4340, 104, 2002, 8554, 194, 1849, 1870, 1440, 1104, 280, 760, 2440, 1728, 117, 1680, 1050, 1241, 1794, 7735, 3450, 234, 1886, 5264, 924, 6270, 552, 1122, 6120, 7120, 285, 5727, 4278, 387, 210});
-  Tensor<double> corr_elem_2_1(Range{10, 5}, {1720, 5920, 3760, 795, 792, 1072, 154, 1880, 1944, 420, 6175, 3564, 3538, 2420, 1440, 1034, 8008, 1780, 2880, 6141, 1938, 1911, 1680, 741, 2223, 1752, 12, 930, 6120, 744, 850, 660, 1659, 3540, 8019, 1008, 544, 1620, 3060, 5415, 4565, 6192, 2162, 2744, 800, 884, 120, 3008, 4554, 420});
-  Tensor<double> corr_elem_3_0(Range{10, 5}, {2520, 3800, 1848, 3416, 880, 1196, 3185, 2720, 5846, 1656, 4180, 2400, 1849, 290, 308, 4810, 5226, 3116, 1140, 19, 1235, 3744, 1309, 2754, 3328, 65, 2585, 7315, 6370, 1980, 840, 2193, 4947, 1406, 759, 2210, 600, 160, 8827, 150, 1274, 1860, 8633, 2940, 5893, 1624, 2268, 6762, 1872, 1476});
-  Tensor<double> corr_elem_3_1(Range{11, 6}, {300, 1053, 8091, 2220, 5220, 5044, 630, 1040, 376, 2688, 2583, 3520, 996, 576, 533, 1216, 6045, 3360, 360, 189, 715, 5740, 1702, 513, 90, 840, 1710, 2430, 56, 4350, 2349, 1800, 741, 1368, 3726, 495, 710, 1650, 2394, 609, 3234, 1512, 1360, 1564, 316, 890, 1701, 3692, 1700, 500, 558, 378, 6144, 8064, 5248, 6264, 1156, 1045, 270, 6231, 638, 1092, 532, 276, 4628, 5418});
-  matrix_il corr_il {{corr_elem_0_0, corr_elem_0_1},{corr_elem_1_0, corr_elem_1_1},{corr_elem_2_0, corr_elem_2_1},{corr_elem_3_0, corr_elem_3_1}};
-  TiledRange corr_trange{{0, 2, 4},{0, 2}};
+  Tensor<double> corr_elem_0_0(
+      Range{7, 2}, {4386, 3634, 245, 1872, 2016, 6596, 156, 1484, 5561, 96, 630,
+                    962, 5146, 1860});
+  Tensor<double> corr_elem_0_1(
+      Range{8, 3},
+      {1980, 5478, 475, 5928, 950,  1848, 30,   237,  5015, 2808, 8556, 8820,
+       160,  112,  205, 3948, 3969, 140,  2982, 8178, 3600, 2970, 3933, 208});
+  Tensor<double> corr_elem_1_0(
+      Range{8, 3},
+      {280, 1080, 3948, 1700, 1300, 2958, 1750, 4964, 5922, 6320, 2013, 198,
+       752, 1054, 450,  70,   6208, 1134, 168,  2208, 98,   1372, 767,  240});
+  Tensor<double> corr_elem_1_1(
+      Range{9, 4},
+      {1184, 312,  2366, 6237, 880,  3120, 205,  7896, 1008, 1428, 10,   6205,
+       1419, 600,  1068, 54,   3969, 224,  1134, 140,  540,  444,  1739, 774,
+       4930, 2546, 7524, 312,  6164, 5044, 504,  8004, 820,  1386, 2139, 16});
+  Tensor<double> corr_elem_2_0(
+      Range{9, 4},
+      {3888, 2838, 4340, 104, 2002, 8554, 194,  1849, 1870, 1440, 1104, 280,
+       760,  2440, 1728, 117, 1680, 1050, 1241, 1794, 7735, 3450, 234,  1886,
+       5264, 924,  6270, 552, 1122, 6120, 7120, 285,  5727, 4278, 387,  210});
+  Tensor<double> corr_elem_2_1(
+      Range{10, 5},
+      {1720, 5920, 3760, 795,  792,  1072, 154,  1880, 1944, 420,
+       6175, 3564, 3538, 2420, 1440, 1034, 8008, 1780, 2880, 6141,
+       1938, 1911, 1680, 741,  2223, 1752, 12,   930,  6120, 744,
+       850,  660,  1659, 3540, 8019, 1008, 544,  1620, 3060, 5415,
+       4565, 6192, 2162, 2744, 800,  884,  120,  3008, 4554, 420});
+  Tensor<double> corr_elem_3_0(
+      Range{10, 5},
+      {2520, 3800, 1848, 3416, 880,  1196, 3185, 2720, 5846, 1656,
+       4180, 2400, 1849, 290,  308,  4810, 5226, 3116, 1140, 19,
+       1235, 3744, 1309, 2754, 3328, 65,   2585, 7315, 6370, 1980,
+       840,  2193, 4947, 1406, 759,  2210, 600,  160,  8827, 150,
+       1274, 1860, 8633, 2940, 5893, 1624, 2268, 6762, 1872, 1476});
+  Tensor<double> corr_elem_3_1(
+      Range{11, 6},
+      {300,  1053, 8091, 2220, 5220, 5044, 630,  1040, 376,  2688, 2583,
+       3520, 996,  576,  533,  1216, 6045, 3360, 360,  189,  715,  5740,
+       1702, 513,  90,   840,  1710, 2430, 56,   4350, 2349, 1800, 741,
+       1368, 3726, 495,  710,  1650, 2394, 609,  3234, 1512, 1360, 1564,
+       316,  890,  1701, 3692, 1700, 500,  558,  378,  6144, 8064, 5248,
+       6264, 1156, 1045, 270,  6231, 638,  1092, 532,  276,  4628, 5418});
+  matrix_il corr_il{{corr_elem_0_0, corr_elem_0_1},
+                    {corr_elem_1_0, corr_elem_1_1},
+                    {corr_elem_2_0, corr_elem_2_1},
+                    {corr_elem_3_0, corr_elem_3_1}};
+  TiledRange corr_trange{{0, 2, 4}, {0, 2}};
   dist_array_t corr(world, corr_trange, corr_il);
   dist_array_t out = einsum(lhs("i,j;m,n"), rhs("i,j;m,n"), "i,j;m,n");
   const bool are_equal = ToTArrayFixture::are_equal(corr, out);
   BOOST_CHECK(are_equal);
 }
 
-BOOST_AUTO_TEST_CASE(ij_mn_eq_ij_mn_times_ji_mn){
+BOOST_AUTO_TEST_CASE(ij_mn_eq_ij_mn_times_ji_mn) {
   using dist_array_t = DistArray<Tensor<Tensor<double>>, DensePolicy>;
   using matrix_il = TiledArray::detail::matrix_il<Tensor<double>>;
   auto& world = TiledArray::get_default_world();
-  Tensor<double> lhs_elem_0_0(Range{7, 2}, {15, 75, 54, 54, 72, 62, 97, 90, 17, 94, 19, 54, 13, 31});
-  Tensor<double> lhs_elem_0_1(Range{8, 3}, {82, 91, 60, 11, 47, 38, 87, 13, 72, 39, 59, 90, 26, 38, 2, 34, 30, 32, 46, 6, 26, 92, 47, 14});
-  Tensor<double> lhs_elem_1_0(Range{8, 3}, {53, 88, 72, 12, 58, 85, 55, 6, 50, 76, 51, 52, 77, 13, 4, 99, 30, 12, 16, 21, 60, 75, 55, 99});
-  Tensor<double> lhs_elem_1_1(Range{9, 4}, {16, 65, 6, 84, 85, 30, 97, 79, 2, 13, 4, 90, 32, 98, 88, 40, 25, 27, 8, 50, 56, 5, 42, 11, 20, 3, 51, 55, 32, 75, 8, 25, 4, 99, 75, 50});
-  Tensor<double> lhs_elem_2_0(Range{9, 4}, {39, 24, 23, 32, 10, 22, 94, 47, 85, 22, 77, 22, 92, 28, 61, 53, 21, 81, 57, 63, 37, 75, 93, 91, 24, 14, 56, 69, 42, 100, 17, 44, 78, 47, 33, 67});
-  Tensor<double> lhs_elem_2_1(Range{10, 5}, {93, 27, 38, 15, 87, 88, 48, 19, 54, 81, 6, 60, 70, 75, 1, 21, 34, 6, 74, 26, 5, 5, 75, 21, 31, 62, 53, 18, 17, 14, 19, 33, 96, 56, 94, 12, 30, 14, 94, 31, 25, 59, 72, 88, 66, 98, 56, 79, 11, 50});
-  Tensor<double> lhs_elem_3_0(Range{10, 5}, {49, 46, 13, 98, 77, 100, 23, 99, 77, 64, 10, 31, 10, 70, 30, 18, 89, 45, 81, 24, 45, 39, 83, 31, 3, 89, 35, 93, 70, 84, 43, 26, 96, 59, 57, 1, 3, 33, 27, 53, 33, 3, 53, 7, 80, 54, 47, 77, 62, 23});
-  Tensor<double> lhs_elem_3_1(Range{11, 6}, {27, 61, 27, 63, 45, 14, 80, 20, 73, 74, 74, 9, 59, 92, 5, 4, 78, 27, 53, 94, 70, 74, 1, 48, 30, 97, 51, 42, 93, 93, 81, 94, 73, 67, 23, 98, 58, 17, 75, 73, 92, 16, 59, 5, 82, 22, 43, 58, 68, 44, 27, 69, 79, 42, 99, 48, 78, 18, 9, 63, 1, 50, 9, 10, 82, 39});
-  matrix_il lhs_il {{lhs_elem_0_0, lhs_elem_0_1},{lhs_elem_1_0, lhs_elem_1_1},{lhs_elem_2_0, lhs_elem_2_1},{lhs_elem_3_0, lhs_elem_3_1}};
-  TiledRange lhs_trange{{0, 2, 4},{0, 2}};
+  Tensor<double> lhs_elem_0_0(
+      Range{7, 2}, {15, 75, 54, 54, 72, 62, 97, 90, 17, 94, 19, 54, 13, 31});
+  Tensor<double> lhs_elem_0_1(Range{8, 3},
+                              {82, 91, 60, 11, 47, 38, 87, 13, 72, 39, 59, 90,
+                               26, 38, 2,  34, 30, 32, 46, 6,  26, 92, 47, 14});
+  Tensor<double> lhs_elem_1_0(Range{8, 3},
+                              {53, 88, 72, 12, 58, 85, 55, 6,  50, 76, 51, 52,
+                               77, 13, 4,  99, 30, 12, 16, 21, 60, 75, 55, 99});
+  Tensor<double> lhs_elem_1_1(
+      Range{9, 4},
+      {16, 65, 6,  84, 85, 30, 97, 79, 2,  13, 4,  90, 32, 98, 88, 40, 25, 27,
+       8,  50, 56, 5,  42, 11, 20, 3,  51, 55, 32, 75, 8,  25, 4,  99, 75, 50});
+  Tensor<double> lhs_elem_2_0(
+      Range{9, 4}, {39, 24, 23, 32, 10, 22,  94, 47, 85, 22, 77, 22,
+                    92, 28, 61, 53, 21, 81,  57, 63, 37, 75, 93, 91,
+                    24, 14, 56, 69, 42, 100, 17, 44, 78, 47, 33, 67});
+  Tensor<double> lhs_elem_2_1(
+      Range{10, 5},
+      {93, 27, 38, 15, 87, 88, 48, 19, 54, 81, 6,  60, 70, 75, 1,  21, 34,
+       6,  74, 26, 5,  5,  75, 21, 31, 62, 53, 18, 17, 14, 19, 33, 96, 56,
+       94, 12, 30, 14, 94, 31, 25, 59, 72, 88, 66, 98, 56, 79, 11, 50});
+  Tensor<double> lhs_elem_3_0(
+      Range{10, 5},
+      {49, 46, 13, 98, 77, 100, 23, 99, 77, 64, 10, 31, 10, 70, 30, 18, 89,
+       45, 81, 24, 45, 39, 83,  31, 3,  89, 35, 93, 70, 84, 43, 26, 96, 59,
+       57, 1,  3,  33, 27, 53,  33, 3,  53, 7,  80, 54, 47, 77, 62, 23});
+  Tensor<double> lhs_elem_3_1(
+      Range{11, 6},
+      {27, 61, 27, 63, 45, 14, 80, 20, 73, 74, 74, 9,  59, 92, 5,  4,  78,
+       27, 53, 94, 70, 74, 1,  48, 30, 97, 51, 42, 93, 93, 81, 94, 73, 67,
+       23, 98, 58, 17, 75, 73, 92, 16, 59, 5,  82, 22, 43, 58, 68, 44, 27,
+       69, 79, 42, 99, 48, 78, 18, 9,  63, 1,  50, 9,  10, 82, 39});
+  matrix_il lhs_il{{lhs_elem_0_0, lhs_elem_0_1},
+                   {lhs_elem_1_0, lhs_elem_1_1},
+                   {lhs_elem_2_0, lhs_elem_2_1},
+                   {lhs_elem_3_0, lhs_elem_3_1}};
+  TiledRange lhs_trange{{0, 2, 4}, {0, 2}};
   dist_array_t lhs(world, lhs_trange, lhs_il);
-  Tensor<double> rhs_elem_0_0(Range{7, 2}, {55, 2, 99, 28, 98, 27, 80, 69, 1, 66, 5, 9, 1, 80});
-  Tensor<double> rhs_elem_0_1(Range{8, 3}, {19, 23, 52, 93, 6, 89, 68, 10, 4, 23, 24, 20, 99, 85, 81, 36, 82, 54, 36, 46, 26, 85, 15, 28});
-  Tensor<double> rhs_elem_0_2(Range{9, 4}, {57, 32, 86, 49, 55, 32, 100, 46, 2, 82, 84, 69, 63, 69, 12, 62, 21, 87, 1, 40, 61, 56, 90, 53, 74, 72, 5, 21, 49, 97, 69, 83, 48, 38, 88, 9});
-  Tensor<double> rhs_elem_0_3(Range{10, 5}, {28, 7, 4, 92, 30, 7, 3, 70, 16, 51, 71, 14, 37, 33, 92, 90, 75, 29, 52, 59, 15, 15, 96, 50, 39, 72, 22, 60, 56, 95, 45, 33, 25, 22, 23, 100, 26, 27, 38, 88, 89, 36, 48, 46, 6, 88, 16, 100, 54, 43});
-  Tensor<double> rhs_elem_1_0(Range{8, 3}, {55, 21, 79, 3, 77, 82, 65, 83, 66, 12, 100, 9, 40, 55, 8, 75, 82, 85, 100, 78, 39, 42, 65, 56});
-  Tensor<double> rhs_elem_1_1(Range{9, 4}, {45, 21, 58, 73, 57, 33, 27, 58, 56, 45, 88, 79, 78, 97, 23, 4, 87, 22, 9, 21, 54, 44, 81, 98, 53, 60, 29, 70, 83, 75, 30, 56, 61, 67, 18, 61});
-  Tensor<double> rhs_elem_1_2(Range{10, 5}, {11, 17, 75, 95, 66, 51, 95, 79, 10, 2, 43, 3, 85, 64, 67, 50, 32, 8, 48, 58, 35, 20, 87, 82, 40, 46, 70, 39, 46, 37, 38, 81, 87, 64, 31, 32, 7, 14, 94, 21, 33, 75, 67, 5, 80, 80, 36, 53, 99, 93});
-  Tensor<double> rhs_elem_1_3(Range{11, 6}, {64, 8, 79, 99, 13, 5, 64, 76, 2, 81, 78, 89, 88, 89, 83, 99, 71, 50, 18, 59, 91, 100, 91, 99, 20, 54, 72, 9, 43, 21, 61, 57, 18, 80, 12, 27, 95, 31, 92, 4, 6, 59, 27, 82, 98, 32, 82, 53, 52, 8, 31, 32, 38, 63, 32, 47, 24, 86, 64, 29, 86, 46, 96, 79, 48, 58});
-  matrix_il rhs_il {{rhs_elem_0_0, rhs_elem_0_1, rhs_elem_0_2, rhs_elem_0_3},{rhs_elem_1_0, rhs_elem_1_1, rhs_elem_1_2, rhs_elem_1_3}};
-  TiledRange rhs_trange{{0, 2},{0, 2, 4}};
+  Tensor<double> rhs_elem_0_0(
+      Range{7, 2}, {55, 2, 99, 28, 98, 27, 80, 69, 1, 66, 5, 9, 1, 80});
+  Tensor<double> rhs_elem_0_1(Range{8, 3},
+                              {19, 23, 52, 93, 6,  89, 68, 10, 4,  23, 24, 20,
+                               99, 85, 81, 36, 82, 54, 36, 46, 26, 85, 15, 28});
+  Tensor<double> rhs_elem_0_2(
+      Range{9, 4},
+      {57, 32, 86, 49, 55, 32, 100, 46, 2, 82, 84, 69, 63, 69, 12, 62, 21, 87,
+       1,  40, 61, 56, 90, 53, 74,  72, 5, 21, 49, 97, 69, 83, 48, 38, 88, 9});
+  Tensor<double> rhs_elem_0_3(
+      Range{10, 5},
+      {28, 7,   4,  92, 30, 7,  3,  70, 16, 51, 71, 14, 37, 33,  92, 90, 75,
+       29, 52,  59, 15, 15, 96, 50, 39, 72, 22, 60, 56, 95, 45,  33, 25, 22,
+       23, 100, 26, 27, 38, 88, 89, 36, 48, 46, 6,  88, 16, 100, 54, 43});
+  Tensor<double> rhs_elem_1_0(
+      Range{8, 3}, {55, 21, 79, 3,  77, 82, 65,  83, 66, 12, 100, 9,
+                    40, 55, 8,  75, 82, 85, 100, 78, 39, 42, 65,  56});
+  Tensor<double> rhs_elem_1_1(
+      Range{9, 4},
+      {45, 21, 58, 73, 57, 33, 27, 58, 56, 45, 88, 79, 78, 97, 23, 4,  87, 22,
+       9,  21, 54, 44, 81, 98, 53, 60, 29, 70, 83, 75, 30, 56, 61, 67, 18, 61});
+  Tensor<double> rhs_elem_1_2(
+      Range{10, 5},
+      {11, 17, 75, 95, 66, 51, 95, 79, 10, 2,  43, 3,  85, 64, 67, 50, 32,
+       8,  48, 58, 35, 20, 87, 82, 40, 46, 70, 39, 46, 37, 38, 81, 87, 64,
+       31, 32, 7,  14, 94, 21, 33, 75, 67, 5,  80, 80, 36, 53, 99, 93});
+  Tensor<double> rhs_elem_1_3(
+      Range{11, 6},
+      {64, 8,  79, 99, 13,  5,  64, 76, 2,  81, 78, 89, 88, 89, 83, 99, 71,
+       50, 18, 59, 91, 100, 91, 99, 20, 54, 72, 9,  43, 21, 61, 57, 18, 80,
+       12, 27, 95, 31, 92,  4,  6,  59, 27, 82, 98, 32, 82, 53, 52, 8,  31,
+       32, 38, 63, 32, 47,  24, 86, 64, 29, 86, 46, 96, 79, 48, 58});
+  matrix_il rhs_il{{rhs_elem_0_0, rhs_elem_0_1, rhs_elem_0_2, rhs_elem_0_3},
+                   {rhs_elem_1_0, rhs_elem_1_1, rhs_elem_1_2, rhs_elem_1_3}};
+  TiledRange rhs_trange{{0, 2}, {0, 2, 4}};
   dist_array_t rhs(world, rhs_trange, rhs_il);
-  Tensor<double> corr_elem_0_0(Range{7, 2}, {825, 150, 5346, 1512, 7056, 1674, 7760, 6210, 17, 6204, 95, 486, 13, 2480});
-  Tensor<double> corr_elem_0_1(Range{8, 3}, {4510, 1911, 4740, 33, 3619, 3116, 5655, 1079, 4752, 468, 5900, 810, 1040, 2090, 16, 2550, 2460, 2720, 4600, 468, 1014, 3864, 3055, 784});
-  Tensor<double> corr_elem_1_0(Range{8, 3}, {1007, 2024, 3744, 1116, 348, 7565, 3740, 60, 200, 1748, 1224, 1040, 7623, 1105, 324, 3564, 2460, 648, 576, 966, 1560, 6375, 825, 2772});
-  Tensor<double> corr_elem_1_1(Range{9, 4}, {720, 1365, 348, 6132, 4845, 990, 2619, 4582, 112, 585, 352, 7110, 2496, 9506, 2024, 160, 2175, 594, 72, 1050, 3024, 220, 3402, 1078, 1060, 180, 1479, 3850, 2656, 5625, 240, 1400, 244, 6633, 1350, 3050});
-  Tensor<double> corr_elem_2_0(Range{9, 4}, {2223, 768, 1978, 1568, 550, 704, 9400, 2162, 170, 1804, 6468, 1518, 5796, 1932, 732, 3286, 441, 7047, 57, 2520, 2257, 4200, 8370, 4823, 1776, 1008, 280, 1449, 2058, 9700, 1173, 3652, 3744, 1786, 2904, 603});
-  Tensor<double> corr_elem_2_1(Range{10, 5}, {1023, 459, 2850, 1425, 5742, 4488, 4560, 1501, 540, 162, 258, 180, 5950, 4800, 67, 1050, 1088, 48, 3552, 1508, 175, 100, 6525, 1722, 1240, 2852, 3710, 702, 782, 518, 722, 2673, 8352, 3584, 2914, 384, 210, 196, 8836, 651, 825, 4425, 4824, 440, 5280, 7840, 2016, 4187, 1089, 4650});
-  Tensor<double> corr_elem_3_0(Range{10, 5}, {1372, 322, 52, 9016, 2310, 700, 69, 6930, 1232, 3264, 710, 434, 370, 2310, 2760, 1620, 6675, 1305, 4212, 1416, 675, 585, 7968, 1550, 117, 6408, 770, 5580, 3920, 7980, 1935, 858, 2400, 1298, 1311, 100, 78, 891, 1026, 4664, 2937, 108, 2544, 322, 480, 4752, 752, 7700, 3348, 989});
-  Tensor<double> corr_elem_3_1(Range{11, 6}, {1728, 488, 2133, 6237, 585, 70, 5120, 1520, 146, 5994, 5772, 801, 5192, 8188, 415, 396, 5538, 1350, 954, 5546, 6370, 7400, 91, 4752, 600, 5238, 3672, 378, 3999, 1953, 4941, 5358, 1314, 5360, 276, 2646, 5510, 527, 6900, 292, 552, 944, 1593, 410, 8036, 704, 3526, 3074, 3536, 352, 837, 2208, 3002, 2646, 3168, 2256, 1872, 1548, 576, 1827, 86, 2300, 864, 790, 3936, 2262});
-  matrix_il corr_il {{corr_elem_0_0, corr_elem_0_1},{corr_elem_1_0, corr_elem_1_1},{corr_elem_2_0, corr_elem_2_1},{corr_elem_3_0, corr_elem_3_1}};
-  TiledRange corr_trange{{0, 2, 4},{0, 2}};
+  Tensor<double> corr_elem_0_0(
+      Range{7, 2}, {825, 150, 5346, 1512, 7056, 1674, 7760, 6210, 17, 6204, 95,
+                    486, 13, 2480});
+  Tensor<double> corr_elem_0_1(
+      Range{8, 3},
+      {4510, 1911, 4740, 33,   3619, 3116, 5655, 1079, 4752, 468,  5900, 810,
+       1040, 2090, 16,   2550, 2460, 2720, 4600, 468,  1014, 3864, 3055, 784});
+  Tensor<double> corr_elem_1_0(
+      Range{8, 3},
+      {1007, 2024, 3744, 1116, 348,  7565, 3740, 60,  200,  1748, 1224, 1040,
+       7623, 1105, 324,  3564, 2460, 648,  576,  966, 1560, 6375, 825,  2772});
+  Tensor<double> corr_elem_1_1(
+      Range{9, 4},
+      {720,  1365, 348,  6132, 4845, 990,  2619, 4582, 112,  585,  352,  7110,
+       2496, 9506, 2024, 160,  2175, 594,  72,   1050, 3024, 220,  3402, 1078,
+       1060, 180,  1479, 3850, 2656, 5625, 240,  1400, 244,  6633, 1350, 3050});
+  Tensor<double> corr_elem_2_0(
+      Range{9, 4},
+      {2223, 768,  1978, 1568, 550,  704,  9400, 2162, 170,  1804, 6468, 1518,
+       5796, 1932, 732,  3286, 441,  7047, 57,   2520, 2257, 4200, 8370, 4823,
+       1776, 1008, 280,  1449, 2058, 9700, 1173, 3652, 3744, 1786, 2904, 603});
+  Tensor<double> corr_elem_2_1(
+      Range{10, 5},
+      {1023, 459,  2850, 1425, 5742, 4488, 4560, 1501, 540,  162,
+       258,  180,  5950, 4800, 67,   1050, 1088, 48,   3552, 1508,
+       175,  100,  6525, 1722, 1240, 2852, 3710, 702,  782,  518,
+       722,  2673, 8352, 3584, 2914, 384,  210,  196,  8836, 651,
+       825,  4425, 4824, 440,  5280, 7840, 2016, 4187, 1089, 4650});
+  Tensor<double> corr_elem_3_0(
+      Range{10, 5}, {1372, 322, 52,   9016, 2310, 700,  69,   6930, 1232, 3264,
+                     710,  434, 370,  2310, 2760, 1620, 6675, 1305, 4212, 1416,
+                     675,  585, 7968, 1550, 117,  6408, 770,  5580, 3920, 7980,
+                     1935, 858, 2400, 1298, 1311, 100,  78,   891,  1026, 4664,
+                     2937, 108, 2544, 322,  480,  4752, 752,  7700, 3348, 989});
+  Tensor<double> corr_elem_3_1(
+      Range{11, 6},
+      {1728, 488,  2133, 6237, 585,  70,   5120, 1520, 146,  5994, 5772,
+       801,  5192, 8188, 415,  396,  5538, 1350, 954,  5546, 6370, 7400,
+       91,   4752, 600,  5238, 3672, 378,  3999, 1953, 4941, 5358, 1314,
+       5360, 276,  2646, 5510, 527,  6900, 292,  552,  944,  1593, 410,
+       8036, 704,  3526, 3074, 3536, 352,  837,  2208, 3002, 2646, 3168,
+       2256, 1872, 1548, 576,  1827, 86,   2300, 864,  790,  3936, 2262});
+  matrix_il corr_il{{corr_elem_0_0, corr_elem_0_1},
+                    {corr_elem_1_0, corr_elem_1_1},
+                    {corr_elem_2_0, corr_elem_2_1},
+                    {corr_elem_3_0, corr_elem_3_1}};
+  TiledRange corr_trange{{0, 2, 4}, {0, 2}};
   dist_array_t corr(world, corr_trange, corr_il);
   dist_array_t out = einsum(lhs("i,j;m,n"), rhs("j,i;m,n"), "i,j;m,n");
   const bool are_equal = ToTArrayFixture::are_equal(corr, out);
@@ -240,38 +603,127 @@ BOOST_AUTO_TEST_CASE(xxx) {
   using dist_array_t = DistArray<Tensor<Tensor<double>>, DensePolicy>;
   using matrix_il = TiledArray::detail::matrix_il<Tensor<double>>;
   auto& world = TiledArray::get_default_world();
-  Tensor<double> lhs_elem_0_0(Range{7, 2}, {15, 75, 54, 54, 72, 62, 97, 90, 17, 94, 19, 54, 13, 31});
-  Tensor<double> lhs_elem_0_1(Range{8, 3}, {82, 91, 60, 11, 47, 38, 87, 13, 72, 39, 59, 90, 26, 38, 2, 34, 30, 32, 46, 6, 26, 92, 47, 14});
-  Tensor<double> lhs_elem_1_0(Range{8, 3}, {53, 88, 72, 12, 58, 85, 55, 6, 50, 76, 51, 52, 77, 13, 4, 99, 30, 12, 16, 21, 60, 75, 55, 99});
-  Tensor<double> lhs_elem_1_1(Range{9, 4}, {16, 65, 6, 84, 85, 30, 97, 79, 2, 13, 4, 90, 32, 98, 88, 40, 25, 27, 8, 50, 56, 5, 42, 11, 20, 3, 51, 55, 32, 75, 8, 25, 4, 99, 75, 50});
-  Tensor<double> lhs_elem_2_0(Range{9, 4}, {39, 24, 23, 32, 10, 22, 94, 47, 85, 22, 77, 22, 92, 28, 61, 53, 21, 81, 57, 63, 37, 75, 93, 91, 24, 14, 56, 69, 42, 100, 17, 44, 78, 47, 33, 67});
-  Tensor<double> lhs_elem_2_1(Range{10, 5}, {93, 27, 38, 15, 87, 88, 48, 19, 54, 81, 6, 60, 70, 75, 1, 21, 34, 6, 74, 26, 5, 5, 75, 21, 31, 62, 53, 18, 17, 14, 19, 33, 96, 56, 94, 12, 30, 14, 94, 31, 25, 59, 72, 88, 66, 98, 56, 79, 11, 50});
-  Tensor<double> lhs_elem_3_0(Range{10, 5}, {49, 46, 13, 98, 77, 100, 23, 99, 77, 64, 10, 31, 10, 70, 30, 18, 89, 45, 81, 24, 45, 39, 83, 31, 3, 89, 35, 93, 70, 84, 43, 26, 96, 59, 57, 1, 3, 33, 27, 53, 33, 3, 53, 7, 80, 54, 47, 77, 62, 23});
-  Tensor<double> lhs_elem_3_1(Range{11, 6}, {27, 61, 27, 63, 45, 14, 80, 20, 73, 74, 74, 9, 59, 92, 5, 4, 78, 27, 53, 94, 70, 74, 1, 48, 30, 97, 51, 42, 93, 93, 81, 94, 73, 67, 23, 98, 58, 17, 75, 73, 92, 16, 59, 5, 82, 22, 43, 58, 68, 44, 27, 69, 79, 42, 99, 48, 78, 18, 9, 63, 1, 50, 9, 10, 82, 39});
-  matrix_il lhs_il {{lhs_elem_0_0, lhs_elem_0_1},{lhs_elem_1_0, lhs_elem_1_1},{lhs_elem_2_0, lhs_elem_2_1},{lhs_elem_3_0, lhs_elem_3_1}};
-  TiledRange lhs_trange{{0, 2, 4},{0, 2}};
+  Tensor<double> lhs_elem_0_0(
+      Range{7, 2}, {15, 75, 54, 54, 72, 62, 97, 90, 17, 94, 19, 54, 13, 31});
+  Tensor<double> lhs_elem_0_1(Range{8, 3},
+                              {82, 91, 60, 11, 47, 38, 87, 13, 72, 39, 59, 90,
+                               26, 38, 2,  34, 30, 32, 46, 6,  26, 92, 47, 14});
+  Tensor<double> lhs_elem_1_0(Range{8, 3},
+                              {53, 88, 72, 12, 58, 85, 55, 6,  50, 76, 51, 52,
+                               77, 13, 4,  99, 30, 12, 16, 21, 60, 75, 55, 99});
+  Tensor<double> lhs_elem_1_1(
+      Range{9, 4},
+      {16, 65, 6,  84, 85, 30, 97, 79, 2,  13, 4,  90, 32, 98, 88, 40, 25, 27,
+       8,  50, 56, 5,  42, 11, 20, 3,  51, 55, 32, 75, 8,  25, 4,  99, 75, 50});
+  Tensor<double> lhs_elem_2_0(
+      Range{9, 4}, {39, 24, 23, 32, 10, 22,  94, 47, 85, 22, 77, 22,
+                    92, 28, 61, 53, 21, 81,  57, 63, 37, 75, 93, 91,
+                    24, 14, 56, 69, 42, 100, 17, 44, 78, 47, 33, 67});
+  Tensor<double> lhs_elem_2_1(
+      Range{10, 5},
+      {93, 27, 38, 15, 87, 88, 48, 19, 54, 81, 6,  60, 70, 75, 1,  21, 34,
+       6,  74, 26, 5,  5,  75, 21, 31, 62, 53, 18, 17, 14, 19, 33, 96, 56,
+       94, 12, 30, 14, 94, 31, 25, 59, 72, 88, 66, 98, 56, 79, 11, 50});
+  Tensor<double> lhs_elem_3_0(
+      Range{10, 5},
+      {49, 46, 13, 98, 77, 100, 23, 99, 77, 64, 10, 31, 10, 70, 30, 18, 89,
+       45, 81, 24, 45, 39, 83,  31, 3,  89, 35, 93, 70, 84, 43, 26, 96, 59,
+       57, 1,  3,  33, 27, 53,  33, 3,  53, 7,  80, 54, 47, 77, 62, 23});
+  Tensor<double> lhs_elem_3_1(
+      Range{11, 6},
+      {27, 61, 27, 63, 45, 14, 80, 20, 73, 74, 74, 9,  59, 92, 5,  4,  78,
+       27, 53, 94, 70, 74, 1,  48, 30, 97, 51, 42, 93, 93, 81, 94, 73, 67,
+       23, 98, 58, 17, 75, 73, 92, 16, 59, 5,  82, 22, 43, 58, 68, 44, 27,
+       69, 79, 42, 99, 48, 78, 18, 9,  63, 1,  50, 9,  10, 82, 39});
+  matrix_il lhs_il{{lhs_elem_0_0, lhs_elem_0_1},
+                   {lhs_elem_1_0, lhs_elem_1_1},
+                   {lhs_elem_2_0, lhs_elem_2_1},
+                   {lhs_elem_3_0, lhs_elem_3_1}};
+  TiledRange lhs_trange{{0, 2, 4}, {0, 2}};
   dist_array_t lhs(world, lhs_trange, lhs_il);
-  Tensor<double> rhs_elem_0_0(Range{7, 2}, {55, 2, 99, 28, 98, 27, 80, 69, 1, 66, 5, 9, 1, 80});
-  Tensor<double> rhs_elem_0_1(Range{8, 3}, {19, 23, 52, 93, 6, 89, 68, 10, 4, 23, 24, 20, 99, 85, 81, 36, 82, 54, 36, 46, 26, 85, 15, 28});
-  Tensor<double> rhs_elem_0_2(Range{9, 4}, {57, 32, 86, 49, 55, 32, 100, 46, 2, 82, 84, 69, 63, 69, 12, 62, 21, 87, 1, 40, 61, 56, 90, 53, 74, 72, 5, 21, 49, 97, 69, 83, 48, 38, 88, 9});
-  Tensor<double> rhs_elem_0_3(Range{10, 5}, {28, 7, 4, 92, 30, 7, 3, 70, 16, 51, 71, 14, 37, 33, 92, 90, 75, 29, 52, 59, 15, 15, 96, 50, 39, 72, 22, 60, 56, 95, 45, 33, 25, 22, 23, 100, 26, 27, 38, 88, 89, 36, 48, 46, 6, 88, 16, 100, 54, 43});
-  Tensor<double> rhs_elem_1_0(Range{8, 3}, {55, 21, 79, 3, 77, 82, 65, 83, 66, 12, 100, 9, 40, 55, 8, 75, 82, 85, 100, 78, 39, 42, 65, 56});
-  Tensor<double> rhs_elem_1_1(Range{9, 4}, {45, 21, 58, 73, 57, 33, 27, 58, 56, 45, 88, 79, 78, 97, 23, 4, 87, 22, 9, 21, 54, 44, 81, 98, 53, 60, 29, 70, 83, 75, 30, 56, 61, 67, 18, 61});
-  Tensor<double> rhs_elem_1_2(Range{10, 5}, {11, 17, 75, 95, 66, 51, 95, 79, 10, 2, 43, 3, 85, 64, 67, 50, 32, 8, 48, 58, 35, 20, 87, 82, 40, 46, 70, 39, 46, 37, 38, 81, 87, 64, 31, 32, 7, 14, 94, 21, 33, 75, 67, 5, 80, 80, 36, 53, 99, 93});
-  Tensor<double> rhs_elem_1_3(Range{11, 6}, {64, 8, 79, 99, 13, 5, 64, 76, 2, 81, 78, 89, 88, 89, 83, 99, 71, 50, 18, 59, 91, 100, 91, 99, 20, 54, 72, 9, 43, 21, 61, 57, 18, 80, 12, 27, 95, 31, 92, 4, 6, 59, 27, 82, 98, 32, 82, 53, 52, 8, 31, 32, 38, 63, 32, 47, 24, 86, 64, 29, 86, 46, 96, 79, 48, 58});
-  matrix_il rhs_il {{rhs_elem_0_0, rhs_elem_0_1, rhs_elem_0_2, rhs_elem_0_3},{rhs_elem_1_0, rhs_elem_1_1, rhs_elem_1_2, rhs_elem_1_3}};
-  TiledRange rhs_trange{{0, 2},{0, 2, 4}};
+  Tensor<double> rhs_elem_0_0(
+      Range{7, 2}, {55, 2, 99, 28, 98, 27, 80, 69, 1, 66, 5, 9, 1, 80});
+  Tensor<double> rhs_elem_0_1(Range{8, 3},
+                              {19, 23, 52, 93, 6,  89, 68, 10, 4,  23, 24, 20,
+                               99, 85, 81, 36, 82, 54, 36, 46, 26, 85, 15, 28});
+  Tensor<double> rhs_elem_0_2(
+      Range{9, 4},
+      {57, 32, 86, 49, 55, 32, 100, 46, 2, 82, 84, 69, 63, 69, 12, 62, 21, 87,
+       1,  40, 61, 56, 90, 53, 74,  72, 5, 21, 49, 97, 69, 83, 48, 38, 88, 9});
+  Tensor<double> rhs_elem_0_3(
+      Range{10, 5},
+      {28, 7,   4,  92, 30, 7,  3,  70, 16, 51, 71, 14, 37, 33,  92, 90, 75,
+       29, 52,  59, 15, 15, 96, 50, 39, 72, 22, 60, 56, 95, 45,  33, 25, 22,
+       23, 100, 26, 27, 38, 88, 89, 36, 48, 46, 6,  88, 16, 100, 54, 43});
+  Tensor<double> rhs_elem_1_0(
+      Range{8, 3}, {55, 21, 79, 3,  77, 82, 65,  83, 66, 12, 100, 9,
+                    40, 55, 8,  75, 82, 85, 100, 78, 39, 42, 65,  56});
+  Tensor<double> rhs_elem_1_1(
+      Range{9, 4},
+      {45, 21, 58, 73, 57, 33, 27, 58, 56, 45, 88, 79, 78, 97, 23, 4,  87, 22,
+       9,  21, 54, 44, 81, 98, 53, 60, 29, 70, 83, 75, 30, 56, 61, 67, 18, 61});
+  Tensor<double> rhs_elem_1_2(
+      Range{10, 5},
+      {11, 17, 75, 95, 66, 51, 95, 79, 10, 2,  43, 3,  85, 64, 67, 50, 32,
+       8,  48, 58, 35, 20, 87, 82, 40, 46, 70, 39, 46, 37, 38, 81, 87, 64,
+       31, 32, 7,  14, 94, 21, 33, 75, 67, 5,  80, 80, 36, 53, 99, 93});
+  Tensor<double> rhs_elem_1_3(
+      Range{11, 6},
+      {64, 8,  79, 99, 13,  5,  64, 76, 2,  81, 78, 89, 88, 89, 83, 99, 71,
+       50, 18, 59, 91, 100, 91, 99, 20, 54, 72, 9,  43, 21, 61, 57, 18, 80,
+       12, 27, 95, 31, 92,  4,  6,  59, 27, 82, 98, 32, 82, 53, 52, 8,  31,
+       32, 38, 63, 32, 47,  24, 86, 64, 29, 86, 46, 96, 79, 48, 58});
+  matrix_il rhs_il{{rhs_elem_0_0, rhs_elem_0_1, rhs_elem_0_2, rhs_elem_0_3},
+                   {rhs_elem_1_0, rhs_elem_1_1, rhs_elem_1_2, rhs_elem_1_3}};
+  TiledRange rhs_trange{{0, 2}, {0, 2, 4}};
   dist_array_t rhs(world, rhs_trange, rhs_il);
-  Tensor<double> corr_elem_0_0(Range{7, 2}, {825, 150, 5346, 1512, 7056, 1674, 7760, 6210, 17, 6204, 95, 486, 13, 2480});
-  Tensor<double> corr_elem_0_1(Range{8, 3}, {4510, 1911, 4740, 33, 3619, 3116, 5655, 1079, 4752, 468, 5900, 810, 1040, 2090, 16, 2550, 2460, 2720, 4600, 468, 1014, 3864, 3055, 784});
-  Tensor<double> corr_elem_1_0(Range{8, 3}, {1007, 2024, 3744, 1116, 348, 7565, 3740, 60, 200, 1748, 1224, 1040, 7623, 1105, 324, 3564, 2460, 648, 576, 966, 1560, 6375, 825, 2772});
-  Tensor<double> corr_elem_1_1(Range{9, 4}, {720, 1365, 348, 6132, 4845, 990, 2619, 4582, 112, 585, 352, 7110, 2496, 9506, 2024, 160, 2175, 594, 72, 1050, 3024, 220, 3402, 1078, 1060, 180, 1479, 3850, 2656, 5625, 240, 1400, 244, 6633, 1350, 3050});
-  Tensor<double> corr_elem_2_0(Range{9, 4}, {2223, 768, 1978, 1568, 550, 704, 9400, 2162, 170, 1804, 6468, 1518, 5796, 1932, 732, 3286, 441, 7047, 57, 2520, 2257, 4200, 8370, 4823, 1776, 1008, 280, 1449, 2058, 9700, 1173, 3652, 3744, 1786, 2904, 603});
-  Tensor<double> corr_elem_2_1(Range{10, 5}, {1023, 459, 2850, 1425, 5742, 4488, 4560, 1501, 540, 162, 258, 180, 5950, 4800, 67, 1050, 1088, 48, 3552, 1508, 175, 100, 6525, 1722, 1240, 2852, 3710, 702, 782, 518, 722, 2673, 8352, 3584, 2914, 384, 210, 196, 8836, 651, 825, 4425, 4824, 440, 5280, 7840, 2016, 4187, 1089, 4650});
-  Tensor<double> corr_elem_3_0(Range{10, 5}, {1372, 322, 52, 9016, 2310, 700, 69, 6930, 1232, 3264, 710, 434, 370, 2310, 2760, 1620, 6675, 1305, 4212, 1416, 675, 585, 7968, 1550, 117, 6408, 770, 5580, 3920, 7980, 1935, 858, 2400, 1298, 1311, 100, 78, 891, 1026, 4664, 2937, 108, 2544, 322, 480, 4752, 752, 7700, 3348, 989});
-  Tensor<double> corr_elem_3_1(Range{11, 6}, {1728, 488, 2133, 6237, 585, 70, 5120, 1520, 146, 5994, 5772, 801, 5192, 8188, 415, 396, 5538, 1350, 954, 5546, 6370, 7400, 91, 4752, 600, 5238, 3672, 378, 3999, 1953, 4941, 5358, 1314, 5360, 276, 2646, 5510, 527, 6900, 292, 552, 944, 1593, 410, 8036, 704, 3526, 3074, 3536, 352, 837, 2208, 3002, 2646, 3168, 2256, 1872, 1548, 576, 1827, 86, 2300, 864, 790, 3936, 2262});
-  matrix_il corr_il {{corr_elem_0_0, corr_elem_0_1},{corr_elem_1_0, corr_elem_1_1},{corr_elem_2_0, corr_elem_2_1},{corr_elem_3_0, corr_elem_3_1}};
-  TiledRange corr_trange{{0, 2, 4},{0, 2}};
+  Tensor<double> corr_elem_0_0(
+      Range{7, 2}, {825, 150, 5346, 1512, 7056, 1674, 7760, 6210, 17, 6204, 95,
+                    486, 13, 2480});
+  Tensor<double> corr_elem_0_1(
+      Range{8, 3},
+      {4510, 1911, 4740, 33,   3619, 3116, 5655, 1079, 4752, 468,  5900, 810,
+       1040, 2090, 16,   2550, 2460, 2720, 4600, 468,  1014, 3864, 3055, 784});
+  Tensor<double> corr_elem_1_0(
+      Range{8, 3},
+      {1007, 2024, 3744, 1116, 348,  7565, 3740, 60,  200,  1748, 1224, 1040,
+       7623, 1105, 324,  3564, 2460, 648,  576,  966, 1560, 6375, 825,  2772});
+  Tensor<double> corr_elem_1_1(
+      Range{9, 4},
+      {720,  1365, 348,  6132, 4845, 990,  2619, 4582, 112,  585,  352,  7110,
+       2496, 9506, 2024, 160,  2175, 594,  72,   1050, 3024, 220,  3402, 1078,
+       1060, 180,  1479, 3850, 2656, 5625, 240,  1400, 244,  6633, 1350, 3050});
+  Tensor<double> corr_elem_2_0(
+      Range{9, 4},
+      {2223, 768,  1978, 1568, 550,  704,  9400, 2162, 170,  1804, 6468, 1518,
+       5796, 1932, 732,  3286, 441,  7047, 57,   2520, 2257, 4200, 8370, 4823,
+       1776, 1008, 280,  1449, 2058, 9700, 1173, 3652, 3744, 1786, 2904, 603});
+  Tensor<double> corr_elem_2_1(
+      Range{10, 5},
+      {1023, 459,  2850, 1425, 5742, 4488, 4560, 1501, 540,  162,
+       258,  180,  5950, 4800, 67,   1050, 1088, 48,   3552, 1508,
+       175,  100,  6525, 1722, 1240, 2852, 3710, 702,  782,  518,
+       722,  2673, 8352, 3584, 2914, 384,  210,  196,  8836, 651,
+       825,  4425, 4824, 440,  5280, 7840, 2016, 4187, 1089, 4650});
+  Tensor<double> corr_elem_3_0(
+      Range{10, 5}, {1372, 322, 52,   9016, 2310, 700,  69,   6930, 1232, 3264,
+                     710,  434, 370,  2310, 2760, 1620, 6675, 1305, 4212, 1416,
+                     675,  585, 7968, 1550, 117,  6408, 770,  5580, 3920, 7980,
+                     1935, 858, 2400, 1298, 1311, 100,  78,   891,  1026, 4664,
+                     2937, 108, 2544, 322,  480,  4752, 752,  7700, 3348, 989});
+  Tensor<double> corr_elem_3_1(
+      Range{11, 6},
+      {1728, 488,  2133, 6237, 585,  70,   5120, 1520, 146,  5994, 5772,
+       801,  5192, 8188, 415,  396,  5538, 1350, 954,  5546, 6370, 7400,
+       91,   4752, 600,  5238, 3672, 378,  3999, 1953, 4941, 5358, 1314,
+       5360, 276,  2646, 5510, 527,  6900, 292,  552,  944,  1593, 410,
+       8036, 704,  3526, 3074, 3536, 352,  837,  2208, 3002, 2646, 3168,
+       2256, 1872, 1548, 576,  1827, 86,   2300, 864,  790,  3936, 2262});
+  matrix_il corr_il{{corr_elem_0_0, corr_elem_0_1},
+                    {corr_elem_1_0, corr_elem_1_1},
+                    {corr_elem_2_0, corr_elem_2_1},
+                    {corr_elem_3_0, corr_elem_3_1}};
+  TiledRange corr_trange{{0, 2, 4}, {0, 2}};
   dist_array_t corr(world, corr_trange, corr_il);
   dist_array_t r0 = einsum(lhs("i,h;m,n"), rhs("h,i;m,n"), "i,h;m,n");
   dist_array_t r1;
@@ -281,5 +733,227 @@ BOOST_AUTO_TEST_CASE(xxx) {
   BOOST_CHECK(are_equal);
 }
 
+BOOST_AUTO_TEST_CASE(ik_mn_eq_ij_times_jk_mn) {
+  using dist_array_t = DistArray<Tensor<Tensor<double>>, DensePolicy>;
+  using matrix_il = TiledArray::detail::matrix_il<Tensor<double>>;
+  auto& world = TiledArray::get_default_world();
+
+  TiledRange lhs_trange{{0, 2, 4}, {0, 2}};
+  TArrayD lhs(world, lhs_trange,
+              {{1728, 488}, {2133, 6237}, {585, 70}, {5120, 1520}});
+  Tensor<double> rhs_elem_0_0(Range{4, 2}, {15, 75, 54, 54, 72, 62, 97, 90});
+  Tensor<double> rhs_elem_0_1(Range{4, 2}, {53, 88, 72, 12, 58, 85, 55, 6});
+  Tensor<double> rhs_elem_0_2(Range{4, 2}, {39, 24, 23, 32, 10, 22, 94, 47});
+  Tensor<double> rhs_elem_0_3(Range{4, 2}, {49, 46, 13, 98, 77, 100, 23, 99});
+  Tensor<double> rhs_elem_1_0(Range{4, 2}, {82, 91, 60, 11, 47, 38, 87, 13});
+  Tensor<double> rhs_elem_1_1(Range{4, 2}, {16, 65, 6, 84, 85, 30, 97, 79});
+  Tensor<double> rhs_elem_1_2(Range{4, 2}, {93, 27, 38, 15, 87, 88, 48, 19});
+  Tensor<double> rhs_elem_1_3(Range{4, 2}, {27, 61, 27, 63, 45, 14, 80, 20});
+
+  matrix_il rhs_il{{rhs_elem_0_0, rhs_elem_0_1, rhs_elem_0_2, rhs_elem_0_3},
+                   {rhs_elem_1_0, rhs_elem_1_1, rhs_elem_1_2, rhs_elem_1_3}};
+  TiledRange rhs_trange{{0, 2, 4}, {0, 2}};
+  dist_array_t rhs(world, rhs_trange, rhs_il);
+  dist_array_t out = einsum(lhs("i,j"), rhs("j,k;m,n"), "i,k;m,n");
+
+  Tensor<double> corr_elem_0_0(Range{4, 2}, {65936, 174008, 122592, 98680,
+                                             147352, 125680, 210072, 161864});
+  Tensor<double> corr_elem_0_1(Range{4, 2}, {99392, 183784, 127344, 61728,
+                                             141704, 161520, 142376, 48920});
+  Tensor<double> corr_elem_0_2(
+      Range{4, 2}, {112776, 54648, 58288, 62616, 59736, 80960, 185856, 90488});
+  Tensor<double> corr_elem_0_3(Range{4, 2}, {97848, 109256, 35640, 200088,
+                                             155016, 179632, 78784, 180832});
+  Tensor<double> corr_elem_1_0(Range{4, 2}, {543429, 727542, 489402, 183789,
+                                             446715, 369252, 749520, 273051});
+  Tensor<double> corr_elem_1_1(Range{4, 2}, {212841, 593109, 190998, 549504,
+                                             653859, 368415, 722304, 505521});
+  Tensor<double> corr_elem_1_2(Range{4, 2}, {663228, 219591, 286065, 161811,
+                                             563949, 595782, 499878, 218754});
+  Tensor<double> corr_elem_1_3(Range{4, 2}, {272916, 478575, 196128, 601965,
+                                             444906, 300618, 548019, 335907});
+  Tensor<double> corr_elem_2_0(
+      Range{4, 2}, {14515, 50245, 35790, 32360, 45410, 38930, 62835, 53560});
+  Tensor<double> corr_elem_2_1(
+      Range{4, 2}, {32125, 56030, 42540, 12900, 39880, 51825, 38965, 9040});
+  Tensor<double> corr_elem_2_2(
+      Range{4, 2}, {29325, 15930, 16115, 19770, 11940, 19030, 58350, 28825});
+  Tensor<double> corr_elem_2_3(
+      Range{4, 2}, {30555, 31180, 9495, 61740, 48195, 59480, 19055, 59315});
+  Tensor<double> corr_elem_3_0(Range{4, 2}, {201440, 522320, 367680, 293200,
+                                             440080, 375200, 628880, 480560});
+  Tensor<double> corr_elem_3_1(Range{4, 2}, {295680, 549360, 377760, 189120,
+                                             426160, 480800, 429040, 150800});
+  Tensor<double> corr_elem_3_2(Range{4, 2}, {341040, 163920, 175520, 186640,
+                                             183440, 246400, 554240, 269520});
+  Tensor<double> corr_elem_3_3(Range{4, 2}, {291920, 328240, 107600, 597520,
+                                             462640, 533280, 239360, 537280});
+
+  matrix_il corr_il{
+      {corr_elem_0_0, corr_elem_0_1, corr_elem_0_2, corr_elem_0_3},
+      {corr_elem_1_0, corr_elem_1_1, corr_elem_1_2, corr_elem_1_3},
+      {corr_elem_2_0, corr_elem_2_1, corr_elem_2_2, corr_elem_2_3},
+      {corr_elem_3_0, corr_elem_3_1, corr_elem_3_2, corr_elem_3_3}};
+
+  dist_array_t corr(world, lhs_trange, corr_il);
+  std::cout << out << std::endl;
+  const bool are_equal = ToTArrayFixture::are_equal(out, corr);
+  BOOST_CHECK(are_equal);
+}
+
+BOOST_AUTO_TEST_CASE(ik_mn_eq_ij_times_kj_mn) {
+  using dist_array_t = DistArray<Tensor<Tensor<double>>, DensePolicy>;
+  using matrix_il = TiledArray::detail::matrix_il<Tensor<double>>;
+  auto& world = TiledArray::get_default_world();
+
+  TiledRange lhs_trange{{0, 2, 4}, {0, 2}};
+  TArrayD lhs(world, lhs_trange,
+              {{1728, 488}, {2133, 6237}, {585, 70}, {5120, 1520}});
+  Tensor<double> rhs_elem_0_0(Range{4, 2}, {15, 75, 54, 54, 72, 62, 97, 90});
+  Tensor<double> rhs_elem_0_1(Range{4, 2}, {82, 91, 60, 11, 47, 38, 87, 13});
+  Tensor<double> rhs_elem_1_0(Range{4, 2}, {53, 88, 72, 12, 58, 85, 55, 6});
+  Tensor<double> rhs_elem_1_1(Range{4, 2}, {16, 65, 6, 84, 85, 30, 97, 79});
+  Tensor<double> rhs_elem_2_0(Range{4, 2}, {39, 24, 23, 32, 10, 22, 94, 47});
+  Tensor<double> rhs_elem_2_1(Range{4, 2}, {93, 27, 38, 15, 87, 88, 48, 19});
+  Tensor<double> rhs_elem_3_0(Range{4, 2}, {49, 46, 13, 98, 77, 100, 23, 99});
+  Tensor<double> rhs_elem_3_1(Range{4, 2}, {27, 61, 27, 63, 45, 14, 80, 20});
+  matrix_il rhs_il{{rhs_elem_0_0, rhs_elem_0_1},
+                   {rhs_elem_1_0, rhs_elem_1_1},
+                   {rhs_elem_2_0, rhs_elem_2_1},
+                   {rhs_elem_3_0, rhs_elem_3_1}};
+  TiledRange rhs_trange{{0, 2, 4}, {0, 2}};
+  dist_array_t rhs(world, rhs_trange, rhs_il);
+  dist_array_t out = einsum(lhs("i,j"), rhs("k,j;m,n"), "i,k;m,n");
+
+  Tensor<double> corr_elem_0_0(Range{4, 2}, {65936, 174008, 122592, 98680,
+                                             147352, 125680, 210072, 161864});
+  Tensor<double> corr_elem_0_1(Range{4, 2}, {99392, 183784, 127344, 61728,
+                                             141704, 161520, 142376, 48920});
+  Tensor<double> corr_elem_0_2(
+      Range{4, 2}, {112776, 54648, 58288, 62616, 59736, 80960, 185856, 90488});
+  Tensor<double> corr_elem_0_3(Range{4, 2}, {97848, 109256, 35640, 200088,
+                                             155016, 179632, 78784, 180832});
+  Tensor<double> corr_elem_1_0(Range{4, 2}, {543429, 727542, 489402, 183789,
+                                             446715, 369252, 749520, 273051});
+  Tensor<double> corr_elem_1_1(Range{4, 2}, {212841, 593109, 190998, 549504,
+                                             653859, 368415, 722304, 505521});
+  Tensor<double> corr_elem_1_2(Range{4, 2}, {663228, 219591, 286065, 161811,
+                                             563949, 595782, 499878, 218754});
+  Tensor<double> corr_elem_1_3(Range{4, 2}, {272916, 478575, 196128, 601965,
+                                             444906, 300618, 548019, 335907});
+  Tensor<double> corr_elem_2_0(
+      Range{4, 2}, {14515, 50245, 35790, 32360, 45410, 38930, 62835, 53560});
+  Tensor<double> corr_elem_2_1(
+      Range{4, 2}, {32125, 56030, 42540, 12900, 39880, 51825, 38965, 9040});
+  Tensor<double> corr_elem_2_2(
+      Range{4, 2}, {29325, 15930, 16115, 19770, 11940, 19030, 58350, 28825});
+  Tensor<double> corr_elem_2_3(
+      Range{4, 2}, {30555, 31180, 9495, 61740, 48195, 59480, 19055, 59315});
+  Tensor<double> corr_elem_3_0(Range{4, 2}, {201440, 522320, 367680, 293200,
+                                             440080, 375200, 628880, 480560});
+  Tensor<double> corr_elem_3_1(Range{4, 2}, {295680, 549360, 377760, 189120,
+                                             426160, 480800, 429040, 150800});
+  Tensor<double> corr_elem_3_2(Range{4, 2}, {341040, 163920, 175520, 186640,
+                                             183440, 246400, 554240, 269520});
+  Tensor<double> corr_elem_3_3(Range{4, 2}, {291920, 328240, 107600, 597520,
+                                             462640, 533280, 239360, 537280});
+
+  matrix_il corr_il{
+      {corr_elem_0_0, corr_elem_0_1, corr_elem_0_2, corr_elem_0_3},
+      {corr_elem_1_0, corr_elem_1_1, corr_elem_1_2, corr_elem_1_3},
+      {corr_elem_2_0, corr_elem_2_1, corr_elem_2_2, corr_elem_2_3},
+      {corr_elem_3_0, corr_elem_3_1, corr_elem_3_2, corr_elem_3_3}};
+
+  dist_array_t corr(world, lhs_trange, corr_il);
+  std::cout << out << std::endl;
+  const bool are_equal = ToTArrayFixture::are_equal(out, corr);
+  BOOST_CHECK(are_equal);
+}
+
+BOOST_AUTO_TEST_CASE(ik_mn_eq_jm_times_ik_jn) {
+  using matrix_il = TiledArray::detail::matrix_il<Tensor<double>>;
+  auto& world = TiledArray::get_default_world();
+
+  TiledRange lhs_trange{{0, 2, 4}, {0, 2}};
+  TArrayD lhs(world, lhs_trange,
+              {{1728, 488}, {2133, 6237}, {585, 70}, {5120, 1520}});
+  Tensor<double> rhs_elem_0_0(Range{4, 2}, {15, 75, 54, 54, 72, 62, 97, 90});
+  Tensor<double> rhs_elem_0_1(Range{4, 2}, {82, 91, 60, 11, 47, 38, 87, 13});
+  Tensor<double> rhs_elem_1_0(Range{4, 2}, {53, 88, 72, 12, 58, 85, 55, 6});
+  Tensor<double> rhs_elem_1_1(Range{4, 2}, {16, 65, 6, 84, 85, 30, 97, 79});
+  Tensor<double> rhs_elem_2_0(Range{4, 2}, {39, 24, 23, 32, 10, 22, 94, 47});
+  Tensor<double> rhs_elem_2_1(Range{4, 2}, {93, 27, 38, 15, 87, 88, 48, 19});
+  Tensor<double> rhs_elem_3_0(Range{4, 2}, {49, 46, 13, 98, 77, 100, 23, 99});
+  Tensor<double> rhs_elem_3_1(Range{4, 2}, {27, 61, 27, 63, 45, 14, 80, 20});
+  matrix_il rhs_il{{rhs_elem_0_0, rhs_elem_0_1},
+                   {rhs_elem_1_0, rhs_elem_1_1},
+                   {rhs_elem_2_0, rhs_elem_2_1},
+                   {rhs_elem_3_0, rhs_elem_3_1}};
+  TiledRange rhs_trange{{0, 2, 4}, {0, 2}};
+  dist_array_t rhs(world, rhs_trange, rhs_il);
+  dist_array_t out = einsum(lhs("j,m"), rhs("i,k;j,n"), "i,k;m,n");
+
+  Tensor<double> corr_elem_0_0(Range{2, 2}, {679862, 741852, 496598, 514538});
+  Tensor<double> corr_elem_0_1(Range{2, 2}, {742611, 269501, 549766, 135435});
+  Tensor<double> corr_elem_1_0(Range{2, 2}, {560690, 258105, 562588, 132858});
+  Tensor<double> corr_elem_1_1(Range{2, 2}, {586811, 713522, 198620, 677808});
+  Tensor<double> corr_elem_2_0(Range{2, 2}, {603581, 363238, 306063, 284276});
+  Tensor<double> corr_elem_2_1(Range{2, 2}, {538413, 227411, 361440, 141771});
+  Tensor<double> corr_elem_3_0(Range{2, 2}, {275206, 853902, 145343, 791154});
+  Tensor<double> corr_elem_3_1(Range{2, 2}, {540172, 350377, 306325, 454079});
+
+  matrix_il corr_il{{corr_elem_0_0, corr_elem_0_1},
+                    {corr_elem_1_0, corr_elem_1_1},
+                    {corr_elem_2_0, corr_elem_2_1},
+                    {corr_elem_3_0, corr_elem_3_1}};
+
+  dist_array_t corr(world, lhs_trange, corr_il);
+  std::cout << out << std::endl;
+  const bool are_equal = ToTArrayFixture::are_equal(out, corr);
+  BOOST_CHECK(are_equal);
+}
+
+BOOST_AUTO_TEST_CASE(ik_mn_eq_jm_times_ik_nj) {
+  using matrix_il = TiledArray::detail::matrix_il<Tensor<double>>;
+  auto& world = TiledArray::get_default_world();
+
+  TiledRange lhs_trange{{0, 2, 4}, {0, 2}};
+  TArrayD lhs(world, lhs_trange,
+              {{1728, 488}, {2133, 6237}, {585, 70}, {5120, 1520}});
+  Tensor<double> rhs_elem_0_0(Range{2, 4}, {15, 54, 72, 97, 75, 54, 62, 90});
+  Tensor<double> rhs_elem_0_1(Range{2, 4}, {82, 60, 47, 87, 91, 11, 38, 13});
+  Tensor<double> rhs_elem_1_0(Range{2, 4}, {53, 72, 58, 55, 88, 12, 85, 6});
+  Tensor<double> rhs_elem_1_1(Range{2, 4}, {16, 6, 85, 97, 65, 84, 30, 79});
+  Tensor<double> rhs_elem_2_0(Range{2, 4}, {39, 23, 10, 94, 24, 32, 22, 47});
+  Tensor<double> rhs_elem_2_1(Range{2, 4}, {93, 38, 87, 48, 27, 15, 88, 19});
+  Tensor<double> rhs_elem_3_0(Range{2, 4}, {49, 13, 77, 23, 46, 98, 100, 99});
+  Tensor<double> rhs_elem_3_1(Range{2, 4}, {27, 27, 45, 80, 61, 63, 14, 20});
+  matrix_il rhs_il{{rhs_elem_0_0, rhs_elem_0_1},
+                   {rhs_elem_1_0, rhs_elem_1_1},
+                   {rhs_elem_2_0, rhs_elem_2_1},
+                   {rhs_elem_3_0, rhs_elem_3_1}};
+  TiledRange rhs_trange{{0, 2, 4}, {0, 2}};
+  dist_array_t rhs(world, rhs_trange, rhs_il);
+  dist_array_t out = einsum(lhs("j,m"), rhs("i,k;n,j"), "i,k;m,n");
+
+  Tensor<double> corr_elem_0_0(Range{2, 2}, {679862, 741852, 496598, 514538});
+  Tensor<double> corr_elem_0_1(Range{2, 2}, {742611, 269501, 549766, 135435});
+  Tensor<double> corr_elem_1_0(Range{2, 2}, {560690, 258105, 562588, 132858});
+  Tensor<double> corr_elem_1_1(Range{2, 2}, {586811, 713522, 198620, 677808});
+  Tensor<double> corr_elem_2_0(Range{2, 2}, {603581, 363238, 306063, 284276});
+  Tensor<double> corr_elem_2_1(Range{2, 2}, {538413, 227411, 361440, 141771});
+  Tensor<double> corr_elem_3_0(Range{2, 2}, {275206, 853902, 145343, 791154});
+  Tensor<double> corr_elem_3_1(Range{2, 2}, {540172, 350377, 306325, 454079});
+
+  matrix_il corr_il{{corr_elem_0_0, corr_elem_0_1},
+                    {corr_elem_1_0, corr_elem_1_1},
+                    {corr_elem_2_0, corr_elem_2_1},
+                    {corr_elem_3_0, corr_elem_3_1}};
+
+  dist_array_t corr(world, lhs_trange, corr_il);
+  std::cout << out << std::endl;
+  const bool are_equal = ToTArrayFixture::are_equal(out, corr);
+  BOOST_CHECK(are_equal);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/einsum.cpp
+++ b/tests/einsum.cpp
@@ -796,7 +796,6 @@ BOOST_AUTO_TEST_CASE(ik_mn_eq_ij_times_jk_mn) {
       {corr_elem_3_0, corr_elem_3_1, corr_elem_3_2, corr_elem_3_3}};
 
   dist_array_t corr(world, lhs_trange, corr_il);
-  std::cout << out << std::endl;
   const bool are_equal = ToTArrayFixture::are_equal(out, corr);
   BOOST_CHECK(are_equal);
 }
@@ -865,12 +864,12 @@ BOOST_AUTO_TEST_CASE(ik_mn_eq_ij_times_kj_mn) {
       {corr_elem_3_0, corr_elem_3_1, corr_elem_3_2, corr_elem_3_3}};
 
   dist_array_t corr(world, lhs_trange, corr_il);
-  std::cout << out << std::endl;
   const bool are_equal = ToTArrayFixture::are_equal(out, corr);
   BOOST_CHECK(are_equal);
 }
 
 BOOST_AUTO_TEST_CASE(ik_mn_eq_jm_times_ik_jn) {
+  using dist_array_t = DistArray<Tensor<Tensor<double>>, DensePolicy>;
   using matrix_il = TiledArray::detail::matrix_il<Tensor<double>>;
   auto& world = TiledArray::get_default_world();
 
@@ -908,12 +907,12 @@ BOOST_AUTO_TEST_CASE(ik_mn_eq_jm_times_ik_jn) {
                     {corr_elem_3_0, corr_elem_3_1}};
 
   dist_array_t corr(world, lhs_trange, corr_il);
-  std::cout << out << std::endl;
   const bool are_equal = ToTArrayFixture::are_equal(out, corr);
   BOOST_CHECK(are_equal);
 }
 
 BOOST_AUTO_TEST_CASE(ik_mn_eq_jm_times_ik_nj) {
+  using dist_array_t = DistArray<Tensor<Tensor<double>>, DensePolicy>;
   using matrix_il = TiledArray::detail::matrix_il<Tensor<double>>;
   auto& world = TiledArray::get_default_world();
 
@@ -951,7 +950,6 @@ BOOST_AUTO_TEST_CASE(ik_mn_eq_jm_times_ik_nj) {
                     {corr_elem_3_0, corr_elem_3_1}};
 
   dist_array_t corr(world, lhs_trange, corr_il);
-  std::cout << out << std::endl;
   const bool are_equal = ToTArrayFixture::are_equal(out, corr);
   BOOST_CHECK(are_equal);
 }


### PR DESCRIPTION
As far as I can tell `einsum` only supports multiplying ToTs with other ToTs. I need TA to be able to evaluate expressions like:

```.cpp
C("i,k;m,n") = A("i,j") * B("j,k;m,n");
C("i,k;m,n") = A("i,j") * B("k,j;m,n");
C("i,k;m,n") = A("j,m") * B("i,k;j,n");
C("i,k;m,n") = A("j,m") * B("i,k;n,j");
```
Right now all I have done is add unit tests for the desired operations (the code does not compile). If someone else thinks they can implement them in the near future that would be great; otherwise I'll poke around and see what I can do using what's in `einsum` already as a template.