### PR TITLE
Change ExternalProject prefixes to always match the FetchContent location

### DIFF
--- a/external/cutt.cmake
+++ b/external/cutt.cmake
@@ -23,9 +23,9 @@ else()
     enable_language(C)
 
     # set source and build path for cuTT in the TiledArray project
-    set(EXTERNAL_SOURCE_DIR   ${CMAKE_BINARY_DIR}/_deps/cutt-src)
+    set(EXTERNAL_SOURCE_DIR   ${FETCHCONTENT_BASE_DIR}/cutt-src)
     # cutt only supports in source build
-    set(EXTERNAL_BUILD_DIR  ${CMAKE_BINARY_DIR}/_deps/cutt-build)
+    set(EXTERNAL_BUILD_DIR  ${FETCHCONTENT_BASE_DIR}/cutt-build)
     set(EXTERNAL_INSTALL_DIR ${CMAKE_INSTALL_PREFIX})
 
     if (NOT CUTT_URL)
@@ -92,8 +92,8 @@ else()
 
     ExternalProject_Add(cutt
             PREFIX ${CMAKE_INSTALL_PREFIX}
-            STAMP_DIR ${CMAKE_BINARY_DIR}/_deps/cutt-ep-artifacts
-            TMP_DIR ${CMAKE_BINARY_DIR}/_deps/cutt-ep-artifacts  # needed in case CMAKE_INSTALL_PREFIX is not writable
+            STAMP_DIR ${FETCHCONTENT_BASE_DIR}/cutt-ep-artifacts
+            TMP_DIR ${FETCHCONTENT_BASE_DIR}/cutt-ep-artifacts  # needed in case CMAKE_INSTALL_PREFIX is not writable
             #--Download step--------------
             DOWNLOAD_DIR ${EXTERNAL_SOURCE_DIR}
             GIT_REPOSITORY ${CUTT_URL}

--- a/external/eigen.cmake
+++ b/external/eigen.cmake
@@ -93,8 +93,8 @@ else()
   include(ExternalProject)
 
   # Set source and build path for Eigen3 in the TiledArray Project
-  set(EXTERNAL_SOURCE_DIR   ${CMAKE_BINARY_DIR}/_deps/eigen-src)
-  set(EXTERNAL_BUILD_DIR  ${CMAKE_BINARY_DIR}/_deps/eigen-build)
+  set(EXTERNAL_SOURCE_DIR   ${FETCHCONTENT_BASE_DIR}/eigen-src)
+  set(EXTERNAL_BUILD_DIR  ${FETCHCONTENT_BASE_DIR}/eigen-build)
 
   message("** Will build Eigen from ${EIGEN3_URL}")
 

--- a/external/umpire.cmake
+++ b/external/umpire.cmake
@@ -29,8 +29,8 @@ else()
     enable_language(C)
 
     # set source and build path for Umpire in the TiledArray project
-    set(EXTERNAL_SOURCE_DIR ${CMAKE_BINARY_DIR}/_deps/umpire-src)
-    set(EXTERNAL_BUILD_DIR ${CMAKE_BINARY_DIR}/_deps/umpire-build)
+    set(EXTERNAL_SOURCE_DIR ${FETCHCONTENT_BASE_DIR}/umpire-src)
+    set(EXTERNAL_BUILD_DIR ${FETCHCONTENT_BASE_DIR}/umpire-build)
     set(EXTERNAL_INSTALL_DIR ${CMAKE_INSTALL_PREFIX})
 
     if (NOT UMPIRE_URL)
@@ -116,8 +116,8 @@ else()
 
     ExternalProject_Add(Umpire
             PREFIX ${CMAKE_INSTALL_PREFIX}
-            STAMP_DIR ${CMAKE_BINARY_DIR}/_deps/umpire-ep-artifacts
-            TMP_DIR ${CMAKE_BINARY_DIR}/_deps/umpire-ep-artifacts   # needed in case CMAKE_INSTALL_PREFIX is not writable
+            STAMP_DIR ${FETCHCONTENT_BASE_DIR}/umpire-ep-artifacts
+            TMP_DIR ${FETCHCONTENT_BASE_DIR}/umpire-ep-artifacts   # needed in case CMAKE_INSTALL_PREFIX is not writable
             #--Download step--------------
             DOWNLOAD_DIR ${EXTERNAL_SOURCE_DIR}
             GIT_REPOSITORY ${UMPIRE_URL}


### PR DESCRIPTION
FetchContent will download and create the artifact directories in `FETCHCONTENT_BASE_DIR`, which defaults to `${CMAKE_BINARY_DIR}/_deps`. Currently, projects that are still managed by ExternalProject in TiledArray hard code the path `${CMAKE_BINARY_DIR}/_deps` to be their download/artifact directories. While this doesn't cause a problem for TiledArray on its own, it does create an inconsistency in dependency download locations for projects that pull in TiledArray and set a non-standard `FETCHCONTENT_BASE_DIR`. This pull request changes the ExternalProject locations to always be consistent with the FetchContent locations.