### PR TITLE
[ci] dox fixes + introduced VALEEVGROUP_UBUNTU_TAG envvar to control …

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -12,3 +12,4 @@ Running new build of /home/andrey/github/tiledarray on andrey.tiledarray.build
 
 This builds targets `all check` on current Git branch in a docker container named `${USER}.$(basename $PWD).build` 
 
+To use a specific Ubuntu image tag, set environment variable `VALEEVGROUP_UBUNTU_TAG` to one of the [available values](https://hub.docker.com/r/valeevgroup/ubuntu/tags), e.g. `18:04`.

--- a/ci/docker-run-ci
+++ b/ci/docker-run-ci
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # build project via docker run, eg
-# usage: docker-run-ci <build-dir> [ VAR=VALUE ... ] [ target ... ]
-# example: ./ci/docker-run-ci ./build-dir MPQC_BUILD_DEPENDENCIES_FROM_SOURCE=OFF ENABLE_CUDA=ON all check
+# usage: docker-run-ci [ VAR=VALUE ... ] [ target ... ]
+# example: ./ci/docker-run-ci TA_PYTHON=OFF ENABLE_CUDA=ON all check
 
 project=$(basename $PWD)
-image=valeevgroup/ubuntu
+image=valeevgroup/ubuntu:${VALEEVGROUP_UBUNTU_TAG:-latest}
 name=$USER.${project}.build
 project_source_dir=$PWD
 


### PR DESCRIPTION
…which image is used for invoking docker-run-ci