### PR TITLE
TiledArray_{UMPIRE,CUTT} targets usable from the build tree at configure time

### DIFF
--- a/external/cutt.cmake
+++ b/external/cutt.cmake
@@ -115,6 +115,9 @@ else()
             STEP_TARGETS build
             )
 
+    # TiledArray_CUTT target depends on existence of this directory to be usable from the build tree at configure time
+    execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory "${EXTERNAL_SOURCE_DIR}/src")
+
     # do install of cuTT as part of building TiledArray's install target
     install(CODE
             "execute_process(

--- a/external/umpire.cmake
+++ b/external/umpire.cmake
@@ -139,6 +139,10 @@ else()
             STEP_TARGETS build
             )
 
+    # TiledArray_UMPIRE target depends on existence of these directories to be usable from the build tree at configure time
+    execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory "${EXTERNAL_SOURCE_DIR}/src/umpire/tpl/camp/include")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory "${EXTERNAL_BUILD_DIR}/include")
+
     # do install of Umpire as part of building TiledArray's install target
     install(CODE
             "execute_process(


### PR DESCRIPTION
this creates extra dirs in umpire/cutt source and build dirs at configure time