### PR TITLE
fix distarray lifetime in init_tiles and assignment

### DIFF
--- a/src/TiledArray/dist_array.h
+++ b/src/TiledArray/dist_array.h
@@ -929,6 +929,10 @@ class DistArray : public madness::archive::ParallelSerializableObject {
         set(index, std::move(tile));
       }
     }
+
+    // N.B. to ensure that refs to pimpl outlive tasks defer pimpl reset to the
+    // netx fence
+    this->defer_deleter_to_next_fence();
   }
 
   /// Initialize elements of local, non-zero tiles with a user provided functor

--- a/src/TiledArray/dist_array.h
+++ b/src/TiledArray/dist_array.h
@@ -912,10 +912,12 @@ class DistArray : public madness::archive::ParallelSerializableObject {
               if (pimpl_ptr)
                 return op_shared_handle(
                     pimpl_ptr->trange().make_tile_range(index));
-              else
+              else {
+                TA_ASSERT(false);
                 return {};
+              }
             });
-        set(index, tile);
+        set(index, std::move(tile));
       }
     }
   }

--- a/src/TiledArray/dist_array.h
+++ b/src/TiledArray/dist_array.h
@@ -443,13 +443,7 @@ class DistArray : public madness::archive::ParallelSerializableObject {
   /// Use defer_deleter_to_next_fence() to defer the deletion of the destructor
   /// to the next fence.
   /// \sa defer_deleter_to_next_fence
-  ~DistArray() {
-    if (defer_deleter_to_next_fence_) {
-      madness::detail::deferred_cleanup(
-          this->world(), pimpl_,
-          /* do_not_check_that_pimpl_is_unique = */ true);
-    }
-  }
+  ~DistArray() { reset_pimpl(); }
 
   /// Defers deletion to the next fence
 
@@ -1618,6 +1612,18 @@ class DistArray : public madness::archive::ParallelSerializableObject {
   auto& impl_ref() {
     assert_pimpl();
     return *pimpl_;
+  }
+
+  /// resets pimpl immediately or, if
+  /// `this->deleter_deferred_to_next_fence()==true`, defers that until next
+  /// fence
+  void reset_pimpl() {
+    if (defer_deleter_to_next_fence_) {
+      madness::detail::deferred_cleanup(
+          this->world(), pimpl_,
+          /* do_not_check_that_pimpl_is_unique = */ true);
+    } else
+      pimpl_.reset();
   }
 
 };  // class DistArray

--- a/src/TiledArray/dist_array.h
+++ b/src/TiledArray/dist_array.h
@@ -525,7 +525,12 @@ class DistArray : public madness::archive::ParallelSerializableObject {
   /// This is a shallow copy, that is no data is copied.
   /// \param other The array to be copied
   DistArray& operator=(const DistArray& other) {
+    // N.B. reset pimpl_ respecting defer_deleter_to_next_fence_
+    reset_pimpl();
     pimpl_ = other.pimpl_;
+    // since *this and other share pimpl_ now makes sense for them to share
+    // defer_deleter_to_next_fence_
+    defer_deleter_to_next_fence_ = other.defer_deleter_to_next_fence_;
 
     return *this;
   }

--- a/src/TiledArray/dist_array.h
+++ b/src/TiledArray/dist_array.h
@@ -451,7 +451,7 @@ class DistArray : public madness::archive::ParallelSerializableObject {
     }
   }
 
-  /// Defers deletion to the next fene
+  /// Defers deletion to the next fence
 
   /// By default the destruction of the object's data occurs lazily, when
   /// all local references to the object are gone and all _remote_ references
@@ -460,9 +460,19 @@ class DistArray : public madness::archive::ParallelSerializableObject {
   /// lifetime of the object lasts to (just past)the next fence.
   void defer_deleter_to_next_fence() { defer_deleter_to_next_fence_ = true; }
 
+  /// Queries whether deletion is deferred to the next fence
+
+  /// \return true if deletion pf the object's data is deferred to the next
+  /// fence \sa defer_deleter_to_next_fence()
+  bool deleter_deferred_to_next_fence() const {
+    return defer_deleter_to_next_fence_;
+  }
+
   /// Create a deep copy of this array
 
   /// \return An array that is equal to this array
+  /// \warning `result.deleter_deferred_to_next_fence()` returns false even if
+  /// `this->deleter_deferred_to_next_fence()==true`
   DistArray clone() const { return TiledArray::clone(*this); }
 
   /// Accessor for the (shared_ptr to) implementation object

--- a/tests/dist_array.cpp
+++ b/tests/dist_array.cpp
@@ -512,6 +512,11 @@ BOOST_AUTO_TEST_CASE(make_replicated) {
   // Convert array to a replicated array.
   BOOST_REQUIRE_NO_THROW(a.make_replicated());
 
+  // check for cda7b8a33b85f9ebe92bc369d6a362c94f1eae40 bug
+  for (const auto &tile : a) {
+    BOOST_CHECK(tile.get().size() != 0);
+  }
+
   if (GlobalFixture::world->size() == 1)
     BOOST_CHECK(!a.pmap()->is_replicated());
   else
@@ -527,6 +532,7 @@ BOOST_AUTO_TEST_CASE(make_replicated) {
          it != tile.get().end(); ++it)
       BOOST_CHECK_EQUAL(*it, distributed_pmap->owner(i) + 1);
   }
+
 }
 
 BOOST_AUTO_TEST_CASE(serialization_by_tile) {


### PR DESCRIPTION
besides minor cosmetic changes this
- fixes `DistArray::operator=(other)` to respect `defer_deleter_to_next_fence_` just like `DistArray` dtor; it also copies the `other.defer_deleter_to_next_fence_` flag
- `DistArray::init_tiles` ensures that its tasks outlive `pimpl_` by deferring its destruction to the next fence 
