### PR TITLE
umpire allocator fixes

### DIFF
--- a/src/TiledArray/external/umpire.h
+++ b/src/TiledArray/external/umpire.h
@@ -87,8 +87,11 @@ class umpire_allocator_impl {
   void deallocate(pointer ptr, size_t n) {
     TA_ASSERT(umpalloc_);
     const auto nbytes = n * sizeof(T);
-    // this, instead of umpalloc_->deallocate(ptr, nbytes), profiles mmeory use
+    // this, instead of umpalloc_->deallocate(ptr, nbytes), profiles memory use
     // even if introspection is off
+    // N.B. with multiple threads would have to do this test in
+    // the critical section of Umpire's ThreadSafeAllocator::deallocate
+    // TA_ASSERT(nbytes <= umpalloc_->getCurrentSize());
     umpalloc_->getAllocationStrategy()->deallocate_internal(ptr, nbytes);
   }
 

--- a/src/TiledArray/external/umpire.h
+++ b/src/TiledArray/external/umpire.h
@@ -68,26 +68,28 @@ class umpire_allocator_impl {
   umpire_allocator_impl(const umpire_allocator_impl<U>& rhs) noexcept
       : umpalloc_(rhs.umpalloc_) {}
 
-  /// allocates um memory using umpire dynamic pool
+  /// allocates memory using umpire dynamic pool
   pointer allocate(size_t n) {
-    pointer result = nullptr;
-
     TA_ASSERT(umpalloc_);
+
+    size_t nbytes = n * sizeof(T);
 
     // this, instead of umpalloc_->allocate(n*sizeof(T)), profiles memory use
     // even if introspection is off
+    pointer result = nullptr;
     result = static_cast<pointer>(
-        umpalloc_->getAllocationStrategy()->allocate_internal(n * sizeof(T)));
+        umpalloc_->getAllocationStrategy()->allocate_internal(nbytes));
 
     return result;
   }
 
-  /// deallocate um memory using umpire dynamic pool
-  void deallocate(pointer ptr, size_t size) {
+  /// deallocate memory using umpire dynamic pool
+  void deallocate(pointer ptr, size_t n) {
     TA_ASSERT(umpalloc_);
-    // this, instead of umpalloc_->deallocate(ptr, size), profiles mmeory use
+    const auto nbytes = n * sizeof(T);
+    // this, instead of umpalloc_->deallocate(ptr, nbytes), profiles mmeory use
     // even if introspection is off
-    umpalloc_->getAllocationStrategy()->deallocate_internal(ptr, size);
+    umpalloc_->getAllocationStrategy()->deallocate_internal(ptr, nbytes);
   }
 
   const umpire::Allocator* umpire_allocator() const { return umpalloc_; }

--- a/src/TiledArray/tensor/tensor.h
+++ b/src/TiledArray/tensor/tensor.h
@@ -127,7 +127,7 @@ class Tensor {
     auto deleter = [allocator = std::move(allocator),
                     size](auto&& ptr) mutable {
       std::destroy_n(ptr, size);
-      allocator.deallocate(ptr, size * sizeof(T));
+      allocator.deallocate(ptr, size);
     };
     this->data_ = std::shared_ptr<value_type>(ptr, std::move(deleter));
   }

--- a/src/TiledArray/tensor/tensor.h
+++ b/src/TiledArray/tensor/tensor.h
@@ -107,7 +107,7 @@ class Tensor {
       std::uninitialized_default_construct_n(ptr, size);
       // std::uninitialized_value_construct_n(ptr, size);
     }
-    auto deleter = [this, allocator = std::move(allocator),
+    auto deleter = [allocator = std::move(allocator),
                     size](auto&& ptr) mutable {
       std::destroy_n(ptr, size);
       allocator.deallocate(ptr, size);
@@ -124,7 +124,7 @@ class Tensor {
       std::uninitialized_default_construct_n(ptr, size);
       // std::uninitialized_value_construct_n(ptr, size);
     }
-    auto deleter = [this, allocator = std::move(allocator),
+    auto deleter = [allocator = std::move(allocator),
                     size](auto&& ptr) mutable {
       std::destroy_n(ptr, size);
       allocator.deallocate(ptr, size * sizeof(T));


### PR DESCRIPTION
- `umpire_allocator_impl<T>::deallocate(ptr, n)` deallocated `n` bytes instead of `n*sizeof(T)` bytes
- TA::Tensor: allocator.deallocate() sometimes invoked with incorrect size