### PR TITLE
[Umpire] thread-safety provided by umpire_allocator_impl

### DIFF
--- a/examples/dgemm/ta_dense.cpp
+++ b/examples/dgemm/ta_dense.cpp
@@ -142,13 +142,12 @@ void gemm_(TiledArray::World& world, const TiledArray::TiledRange& trange,
 #ifdef TA_TENSOR_MEM_PROFILE
     {
       world.gop.fence();
-      std::cout << str << ": TA::Tensor allocated "
-                << umpire::ResourceManager::getInstance()
-                       .getAllocator("HOST")
-                       .getHighWatermark()
-                << " bytes and used "
-                << TA::hostEnv::instance()->host_allocator().getHighWatermark()
-                << " bytes" << std::endl;
+      std::cout
+          << str << ": TA::Tensor allocated "
+          << TA::hostEnv::instance()->host_allocator_getActualHighWatermark()
+          << " bytes and used "
+          << TA::hostEnv::instance()->host_allocator().getHighWatermark()
+          << " bytes" << std::endl;
     }
 #endif
   };

--- a/external/librett.cmake
+++ b/external/librett.cmake
@@ -66,6 +66,8 @@ else()
         -DCMAKE_CUDA_STANDARD=${CMAKE_CUDA_STANDARD}
         -DCMAKE_CUDA_EXTENSIONS=${CMAKE_CUDA_EXTENSIONS}
         -DENABLE_UMPIRE=OFF
+        # N.B. ThreadSafeUMDynamicPool this no longer exists!!! Must teach LibreTT to take allocate/deallocate methods
+        # from the user code
         -DLIBRETT_USES_THIS_UMPIRE_ALLOCATOR=ThreadSafeUMDynamicPool
         -DCMAKE_PREFIX_PATH=${_UMPIRE_INSTALL_DIR}
         -DENABLE_NO_ALIGNED_ALLOC=ON

--- a/src/TiledArray/cuda/um_allocator.h
+++ b/src/TiledArray/cuda/um_allocator.h
@@ -49,7 +49,7 @@ class cuda_um_allocator_impl
   using typename base_type::value_type;
 
   cuda_um_allocator_impl() noexcept
-      : base_type(&cudaEnv::instance()->um_dynamic_pool()) {}
+      : base_type(&cudaEnv::instance()->um_allocator()) {}
 
   template <class U>
   cuda_um_allocator_impl(const cuda_um_allocator_impl<U>& rhs) noexcept

--- a/src/TiledArray/cuda/um_allocator.h
+++ b/src/TiledArray/cuda/um_allocator.h
@@ -36,12 +36,12 @@
 
 namespace TiledArray {
 
-/// CUDA UM allocator, based on boilerplate by Howard Hinnant
-/// (https://howardhinnant.github.io/allocator_boilerplate.html)
+/// pooled thread-safe CUDA UM allocator
 template <class T>
-class cuda_um_allocator_impl : public umpire_allocator_impl<T> {
+class cuda_um_allocator_impl
+    : public umpire_allocator_impl<T, detail::MutexLock<cudaEnv>> {
  public:
-  using base_type = umpire_allocator_impl<T>;
+  using base_type = umpire_allocator_impl<T, detail::MutexLock<cudaEnv>>;
   using typename base_type::const_pointer;
   using typename base_type::const_reference;
   using typename base_type::pointer;

--- a/src/TiledArray/external/umpire.h
+++ b/src/TiledArray/external/umpire.h
@@ -140,7 +140,7 @@ class umpire_allocator_impl {
 template <class T1, class T2>
 bool operator==(const umpire_allocator_impl<T1>& lhs,
                 const umpire_allocator_impl<T2>& rhs) noexcept {
-  return lhs.um_dynamic_pool() == rhs.um_dynamic_pool();
+  return lhs.umpire_allocator() == rhs.umpire_allocator();
 }
 
 template <class T1, class T2>

--- a/src/TiledArray/external/umpire.h
+++ b/src/TiledArray/external/umpire.h
@@ -32,17 +32,43 @@
 #include <umpire/Umpire.hpp>
 #include <umpire/strategy/QuickPool.hpp>
 #include <umpire/strategy/SizeLimiter.hpp>
-#include <umpire/strategy/ThreadSafeAllocator.hpp>
 
 #include <memory>
 #include <stdexcept>
 
 namespace TiledArray {
 
-/// wraps Umpire allocator into a standard-compliant allocator,
-/// based on the boilerplate by Howard Hinnant
+namespace detail {
+
+struct NullLock {
+  static void lock() {}
+  static void unlock() {}
+};
+
+template <typename Tag = void>
+class MutexLock {
+  static std::mutex mtx_;
+
+ public:
+  static void lock() { mtx_.lock(); }
+  static void unlock() { mtx_.unlock(); }
+};
+
+template <typename Tag>
+std::mutex MutexLock<Tag>::mtx_;
+
+}  // namespace detail
+
+/// wraps a Umpire allocator into a
+/// *standard-compliant* C++ allocator
+
+/// Optionally can be made thread safe by providing an appropriate \p StaticLock
+/// \details based on the boilerplate by Howard Hinnant
 /// (https://howardhinnant.github.io/allocator_boilerplate.html)
-template <class T>
+/// \tparam T type of allocated objects
+/// \tparam StaticLock a type providing static `lock()` and `unlock()` methods ;
+///         defaults to NullLock which does not lock
+template <class T, class StaticLock = detail::NullLock>
 class umpire_allocator_impl {
  public:
   using value_type = T;
@@ -73,12 +99,16 @@ class umpire_allocator_impl {
     TA_ASSERT(umpalloc_);
 
     size_t nbytes = n * sizeof(T);
+    pointer result = nullptr;
+    auto* allocation_strategy = umpalloc_->getAllocationStrategy();
 
+    // critical section
+    StaticLock::lock();
     // this, instead of umpalloc_->allocate(n*sizeof(T)), profiles memory use
     // even if introspection is off
-    pointer result = nullptr;
-    result = static_cast<pointer>(
-        umpalloc_->getAllocationStrategy()->allocate_internal(nbytes));
+    result =
+        static_cast<pointer>(allocation_strategy->allocate_internal(nbytes));
+    StaticLock::unlock();
 
     return result;
   }
@@ -86,15 +116,21 @@ class umpire_allocator_impl {
   /// deallocate memory using umpire dynamic pool
   void deallocate(pointer ptr, size_t n) {
     TA_ASSERT(umpalloc_);
+
     const auto nbytes = n * sizeof(T);
-    // this, instead of umpalloc_->deallocate(ptr, nbytes), profiles memory use
-    // even if introspection is off
+    auto* allocation_strategy = umpalloc_->getAllocationStrategy();
+
     // N.B. with multiple threads would have to do this test in
     // the critical section of Umpire's ThreadSafeAllocator::deallocate
-    // TA_ASSERT(nbytes <= umpalloc_->getCurrentSize());
-    umpalloc_->getAllocationStrategy()->deallocate_internal(ptr, nbytes);
+    StaticLock::lock();
+    TA_ASSERT(nbytes <= allocation_strategy->getCurrentSize());
+    // this, instead of umpalloc_->deallocate(ptr, nbytes), profiles memory use
+    // even if introspection is off
+    allocation_strategy->deallocate_internal(ptr, nbytes);
+    StaticLock::unlock();
   }
 
+  /// @return the underlying Umpire allocator
   const umpire::Allocator* umpire_allocator() const { return umpalloc_; }
 
  private:

--- a/src/TiledArray/host/allocator.h
+++ b/src/TiledArray/host/allocator.h
@@ -36,12 +36,12 @@
 
 namespace TiledArray {
 
-/// CUDA UM allocator, based on boilerplate by Howard Hinnant
-/// (https://howardhinnant.github.io/allocator_boilerplate.html)
+/// pooled, thread-safe allocator for host memory
 template <class T>
-class host_allocator_impl : public umpire_allocator_impl<T> {
+class host_allocator_impl
+    : public umpire_allocator_impl<T, detail::MutexLock<hostEnv>> {
  public:
-  using base_type = umpire_allocator_impl<T>;
+  using base_type = umpire_allocator_impl<T, detail::MutexLock<hostEnv>>;
   using typename base_type::const_pointer;
   using typename base_type::const_reference;
   using typename base_type::pointer;

--- a/src/TiledArray/host/env.h
+++ b/src/TiledArray/host/env.h
@@ -112,6 +112,19 @@ class hostEnv {
   ///          wrapped into umpire_allocator_impl
   umpire::Allocator& host_allocator() { return host_allocator_; }
 
+  // clang-format off
+  /// @return the max actual amount of memory held by host_allocator()
+  /// @details returns the value provided by `umpire::strategy::QuickPool::getHighWatermark()`
+  /// @note if there is only 1 Umpire allocator using HOST memory this should be identical to the value returned by `umpire::ResourceManager::getInstance().getAllocator("HOST").getHighWatermark()`
+  // clang-format on
+  std::size_t host_allocator_getActualHighWatermark() {
+    TA_ASSERT(dynamic_cast<umpire::strategy::QuickPool*>(
+                  host_allocator_.getAllocationStrategy()) != nullptr);
+    return dynamic_cast<umpire::strategy::QuickPool*>(
+               host_allocator_.getAllocationStrategy())
+        ->getActualHighwaterMark();
+  }
+
  protected:
   hostEnv(World& world, umpire::Allocator host_alloc)
       : world_(&world), host_allocator_(host_alloc) {}

--- a/src/TiledArray/util/ptr_registry.cpp
+++ b/src/TiledArray/util/ptr_registry.cpp
@@ -121,8 +121,8 @@ void PtrRegistry::insert(void* ptr, std::size_t sz, const std::string& context,
          << std::endl
 #ifdef TA_TENSOR_MEM_PROFILE
          << "  TA::Tensor allocator status {"
-         << "hw=" << hostEnv::instance()->host_allocator().getHighWatermark()
-         << ","
+         << "hw="
+         << hostEnv::instance()->host_allocator_getActualHighWatermark() << ","
          << "cur=" << hostEnv::instance()->host_allocator().getCurrentSize()
          << ","
          << "act=" << hostEnv::instance()->host_allocator().getActualSize()
@@ -160,8 +160,8 @@ void PtrRegistry::erase(void* ptr, std::size_t sz, const std::string& context,
          << std::endl
 #ifdef TA_TENSOR_MEM_PROFILE
          << "  TA::Tensor allocator status {"
-         << "hw=" << hostEnv::instance()->host_allocator().getHighWatermark()
-         << ","
+         << "hw="
+         << hostEnv::instance()->host_allocator_getActualHighWatermark() << ","
          << "cur=" << hostEnv::instance()->host_allocator().getCurrentSize()
          << ","
          << "act=" << hostEnv::instance()->host_allocator().getActualSize()


### PR DESCRIPTION
... rather than by ThreadSafeAllocator to allow Umpire allocation accounting even with introspection/logging off

*WARNING* this breaks usability of Umpire by LibreTT