### PR TITLE
fix sparse shape threshold

### DIFF
--- a/src/TiledArray/conversions/foreach.h
+++ b/src/TiledArray/conversions/foreach.h
@@ -222,7 +222,7 @@ inline std::
               op_caller;
           return op_caller(std::move(op_shared_handle), arg_tile, arg_tiles...);
         },
-        arg.find(index), args.find(index)...);
+        arg.find_local(index), args.find(index)...);
 
     // Store result tile
     result.set(index, tile);
@@ -307,8 +307,8 @@ inline std::
       for (auto index : *(arg.pmap())) {
         if (is_zero_intersection({arg.is_zero(index), args.is_zero(index)...}))
           continue;
-        auto result_tile =
-            world.taskq.add(task, index, arg.find(index), args.find(index)...);
+        auto result_tile = world.taskq.add(task, index, arg.find_local(index),
+                                           args.find(index)...);
         ++task_count;
         tiles.emplace_back(index, std::move(result_tile));
         if (op_returns_void)  // if Op does not evaluate norms, use the (scaled)

--- a/src/TiledArray/pmap/pmap.h
+++ b/src/TiledArray/pmap/pmap.h
@@ -69,7 +69,7 @@ class Pmap {
       local_;  ///< A list of local tiles (may be empty, if not needed)
   size_type local_size_;  ///< The number of tiles mapped to this process (if
                           ///< local_ is not empty, this equals local_.size());
-                          ///< if local_size_known()==false this is not used
+                          ///< if known_local_size()==false this is not used
 
  private:
   Pmap(const Pmap&) = delete;

--- a/src/TiledArray/tensor_impl.h
+++ b/src/TiledArray/tensor_impl.h
@@ -119,12 +119,14 @@ class TensorImpl : private NO_DEFAULTS {
   /// \throw nothing
   ordinal_type size() const { return trange_.tiles_range().volume(); }
 
-  /// Local element count
+  /// Max count of local tiles
 
   /// This function is primarily available for debugging  purposes. The
   /// returned value is volatile and may change at any time; you should not
   /// rely on it in your algorithms.
-  /// \return The current number of local tiles stored in the tensor.
+  /// \return The max count of local tiles; for dense array this will be equal
+  /// to the actual number of local tiles stored, but for a sparse array
+  /// the actual number of stored tiles will be less than or equal to this.
   ordinal_type local_size() const {
     return static_cast<ordinal_type>(pmap_->local_size());
   }

--- a/tests/sparse_shape_fixture.h
+++ b/tests/sparse_shape_fixture.h
@@ -43,7 +43,7 @@ struct SparseShapeFixture : public TiledRangeFixture {
         tolerance(0.0001)
 
   {
-    SparseShape<float>::threshold(0.001);
+    SparseShape<float>::threshold(default_threshold);
   }
 
   ~SparseShapeFixture() {}
@@ -84,12 +84,27 @@ struct SparseShapeFixture : public TiledRangeFixture {
     return Permutation(temp.begin(), temp.end());
   }
 
+  static void reset_threshold() {
+    SparseShape<float>::threshold(default_threshold);
+  }
+
+  static auto set_threshold_to_max() {
+    SparseShape<float>::threshold(std::numeric_limits<float>::max());
+    return std::shared_ptr<void>(nullptr, [](void*) { reset_threshold(); });
+  }
+
+  static auto tweak_threshold() {
+    SparseShape<float>::threshold(10 * SparseShape<float>::threshold());
+    return std::shared_ptr<void>(nullptr, [](void*) { reset_threshold(); });
+  }
+
   SparseShape<float> sparse_shape;
   SparseShape<float> left;
   SparseShape<float> right;
   Permutation perm;
   TiledArray::detail::PermIndex perm_index;
   const float tolerance;
+  static constexpr float default_threshold = 0.001;
 };  // SparseShapeFixture
 
 }  // namespace TiledArray


### PR DESCRIPTION
handling of thresholds by SparseShape was inconsistent. For example:
- `SparseShape::mask` would produce a shape screened using `this->my_threshold_`, whereas other unary operations would use global threshold
- `SparseShape::update_block` would screen the result using global threshold and use `this->my_threshold_` to construct the result

Now all unary operations use `this->init_threshold()` (returning `this->my_threshold_`) for the result and all binary operations use global threshold.
