### PR TITLE
Fix `make_array` when target shape is rank-1

### DIFF
--- a/src/TiledArray/conversions/make_array.h
+++ b/src/TiledArray/conversions/make_array.h
@@ -155,7 +155,7 @@ inline Array make_array(
   int task_count = 0;
   auto task = [&](const ordinal_type index) -> value_type {
     value_type tile;
-    tile_norms[index] = op(tile, trange.make_tile_range(index));
+    tile_norms.at_ordinal(index) = op(tile, trange.make_tile_range(index));
     ++counter;
     return tile;
   };


### PR DESCRIPTION
Current [HEAD](84efffd50a233b9f87b6ec4a2864efdb75083480) catches an ambiguity in `Tensor::operator[](index)` / `Tensor::operator[](ordinal)` for rank-1 tensors. This was not being handled properly in `make_array` when the target shape was rank-1.