### PR TITLE
[cmake] for cmake v3.28 set policy `CMP0146` to `OLD`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ variables:
     TA_UT_CTEST_TIMEOUT=3000
     ${TA_PYTHON}
     ${ENABLE_CUDA}
+    CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda
     ${BLA_VENDOR}
     ${BLA_THREADS}
     ${ENABLE_SCALAPACK}

--- a/external/umpire.cmake
+++ b/external/umpire.cmake
@@ -109,6 +109,15 @@ else()
         if (DEFINED CMAKE_CUDA_ARCHITECTURES)
             list(APPEND UMPIRE_CMAKE_ARGS "-DCMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}")
         endif(DEFINED CMAKE_CUDA_ARCHITECTURES)
+        # BLT will need FindCUDA until https://github.com/LLNL/blt/pull/585 is merged
+        # with CMake 3.28.1 needs to set CMP0146 to OLD
+        if (POLICY CMP0146)
+            list(APPEND UMPIRE_CMAKE_ARGS -DCMAKE_POLICY_DEFAULT_CMP0146=OLD)
+        endif()
+        # as of CMake 3.28+ FindCUDA seems to require CUDA_TOOLKIT_ROOT_DIR to be defined
+        if (DEFINED CUDA_TOOLKIT_ROOT_DIR)
+            list(APPEND UMPIRE_CMAKE_ARGS "-DCUDA_TOOLKIT_ROOT_DIR=${CUDA_TOOLKIT_ROOT_DIR}")
+        endif()
     endif(ENABLE_CUDA)
     if (ENABLE_HIP)
         list(APPEND UMPIRE_CMAKE_ARGS


### PR DESCRIPTION
 to satisfy BLT that still uses FindCUDA

resolves #438