### PR TITLE
better support for zero-volume ranges

### DIFF
--- a/src/TiledArray/block_range.h
+++ b/src/TiledArray/block_range.h
@@ -85,7 +85,7 @@ class BlockRange : public Range {
       upper[d] = upper_bound_d;
       // Check input dimensions
       TA_ASSERT(lower[d] >= range.lobound(d));
-      TA_ASSERT(lower[d] < upper[d]);
+      TA_ASSERT(lower[d] <= upper[d]);
       TA_ASSERT(upper[d] <= range.upbound(d));
       extent[d] = upper[d] - lower[d];
       TA_ASSERT(extent[d] ==
@@ -132,7 +132,7 @@ class BlockRange : public Range {
       upper[d] = upper_bound_d;
       // Check input dimensions
       TA_ASSERT(lower[d] >= range.lobound(d));
-      TA_ASSERT(lower[d] < upper[d]);
+      TA_ASSERT(lower[d] <= upper[d]);
       TA_ASSERT(upper[d] <= range.upbound(d));
       extent[d] = upper[d] - lower[d];
       TA_ASSERT(extent[d] ==
@@ -177,9 +177,10 @@ class BlockRange : public Range {
   /// \param range the host Range
   /// \param lower_bound A sequence of lower bounds for each dimension
   /// \param upper_bound A sequence of upper bounds for each dimension
+  /// \note Zero-extent blocks along any mode is possible, i.e. `lower_bound[d] == upper_bound[d]` is supported
   /// \throw TiledArray::Exception When the size of \p lower_bound is not
   /// equal to that of \p upper_bound.
-  /// \throw TiledArray::Exception When `lower_bound[i] >= upper_bound[i]`
+  /// \throw TiledArray::Exception When `lower_bound[i] > upper_bound[i]`
   // clang-format on
   template <typename Index1, typename Index2,
             typename = std::enable_if_t<detail::is_integral_range_v<Index1> &&
@@ -204,9 +205,10 @@ class BlockRange : public Range {
   /// \param range the host Range
   /// \param lower_bound An initializer list of lower bounds for each dimension
   /// \param upper_bound An initializer list of upper bounds for each dimension
+  /// \note Zero-extent blocks along any mode is possible, i.e. `lower_bound[d] == upper_bound[d]` is supported
   /// \throw TiledArray::Exception When the size of \p lower_bound is not
   /// equal to that of \p upper_bound.
-  /// \throw TiledArray::Exception When `lower_bound[i] >= upper_bound[i]`
+  /// \throw TiledArray::Exception When `lower_bound[i] > upper_bound[i]`
   // clang-format on
   template <typename Index1, typename Index2,
             typename = std::enable_if_t<std::is_integral_v<Index1> &&
@@ -247,7 +249,8 @@ class BlockRange : public Range {
   /// \endcode
   /// \tparam PairRange Type representing a range of generalized pairs (see TiledArray::detail::is_gpair_v )
   /// \param bounds A range of {lower,upper} bounds for each dimension
-  /// \throw TiledArray::Exception When `bounds[i].lower>=bounds[i].upper` for any \c i .
+  /// \note Zero-extent blocks along any mode is possible, i.e. `bounds[d].lower == bounds[d].upper` is supported
+  /// \throw TiledArray::Exception When `bounds[i].lower>bounds[i].upper` for any \c i .
   // clang-format on
   template <typename PairRange,
             typename = std::enable_if_t<detail::is_gpair_range_v<PairRange>>>
@@ -264,8 +267,9 @@ class BlockRange : public Range {
   ///   BlockRange br0(r, {std::make_pair(0,4), std::pair{1,6}, std::pair(2,8)});
   /// \endcode
   /// \tparam GPair a generalized pair of integral types
-  /// \param bound A range of {lower,upper} bounds for each dimension
-  /// \throw TiledArray::Exception When `bound[i].lower>=bound[i].upper` for any \c i .
+  /// \param bounds A range of {lower,upper} bounds for each dimension
+  /// \note Zero-extent blocks along any mode is possible, i.e. `bounds[d].lower == bounds[d].upper` is supported
+  /// \throw TiledArray::Exception When `bounds[i].lower>bounds[i].upper` for any \c i .
   // clang-format on
   template <typename GPair>
   BlockRange(const Range& range, const std::initializer_list<GPair>& bounds,
@@ -290,8 +294,9 @@ class BlockRange : public Range {
   ///   BlockRange br0(r, {{0,4}, {1,6}, {2,8}});
   /// \endcode
   /// \tparam Index An integral type
-  /// \param bound A range of {lower,upper} bounds for each dimension
-  /// \throw TiledArray::Exception When `bound[i].lower>=bound[i].upper` for any \c i .
+  /// \param bounds A range of {lower,upper} bounds for each dimension
+  /// \note Zero-extent blocks along any mode is possible, i.e. `bounds[d].lower == bounds[d].upper` is supported
+  /// \throw TiledArray::Exception When `bounds[i].lower>bounds[i].upper` for any \c i .
   // clang-format on
   template <typename Index,
             typename = std::enable_if_t<std::is_integral_v<Index>>>
@@ -354,6 +359,8 @@ class BlockRange : public Range {
   /// \return The ordinal index in the
   /// \throw TiledArray::Exception When \c index is not included in this range
   ordinal_type ordinal(ordinal_type ord) const {
+    // ordinals are useless for zero-volume ranges
+    TA_ASSERT(volume() != 0);
     // Check that ord is contained by this range.
     TA_ASSERT(Range::includes_ordinal(ord));
 
@@ -414,7 +421,7 @@ class BlockRange : public Range {
   template <typename Archive>
   void serialize(Archive& ar) const {
     Range::serialize(ar);
-    ar& block_offset_;
+    ar & block_offset_;
   }
 };  // BlockRange
 

--- a/src/TiledArray/device/btas.h
+++ b/src/TiledArray/device/btas.h
@@ -77,10 +77,12 @@ template <typename T, typename Scalar, typename Range, typename Storage,
   gemm_helper.compute_matrix_sizes(m, n, k, left.range(), right.range());
 
   // Get the leading dimension for left and right matrices.
-  const integer lda =
-      (gemm_helper.left_op() == TiledArray::math::blas::Op::NoTrans ? k : m);
-  const integer ldb =
-      (gemm_helper.right_op() == TiledArray::math::blas::Op::NoTrans ? n : k);
+  const integer lda = std::max(
+      integer{1},
+      (gemm_helper.left_op() == TiledArray::math::blas::Op::NoTrans ? k : m));
+  const integer ldb = std::max(
+      integer{1},
+      (gemm_helper.right_op() == TiledArray::math::blas::Op::NoTrans ? n : k));
 
   T factor_t = T(factor);
   T zero(0);
@@ -112,10 +114,11 @@ template <typename T, typename Scalar, typename Range, typename Storage,
 
     static_assert(::btas::boxrange_iteration_order<Range>::value ==
                   ::btas::boxrange_iteration_order<Range>::row_major);
+    const integer ldc = std::max(integer{1}, n);
     blas::gemm(blas::Layout::ColMajor, gemm_helper.right_op(),
                gemm_helper.left_op(), n, m, k, factor_t,
                device_data(right.storage()), ldb, device_data(left.storage()),
-               lda, zero, device_data(result.storage()), n, queue);
+               lda, zero, device_data(result.storage()), ldc, queue);
 
     device::sync_madness_task_with(stream);
   }
@@ -185,10 +188,12 @@ void gemm(::btas::Tensor<T, Range, Storage> &result,
   gemm_helper.compute_matrix_sizes(m, n, k, left.range(), right.range());
 
   // Get the leading dimension for left and right matrices.
-  const integer lda =
-      (gemm_helper.left_op() == TiledArray::math::blas::Op::NoTrans ? k : m);
-  const integer ldb =
-      (gemm_helper.right_op() == TiledArray::math::blas::Op::NoTrans ? n : k);
+  const integer lda = std::max(
+      integer{1},
+      (gemm_helper.left_op() == TiledArray::math::blas::Op::NoTrans ? k : m));
+  const integer ldb = std::max(
+      integer{1},
+      (gemm_helper.right_op() == TiledArray::math::blas::Op::NoTrans ? n : k));
 
   auto &queue = blasqueue_for(result.range());
   const auto stream = device::Stream(queue.device(), queue.stream());
@@ -207,10 +212,11 @@ void gemm(::btas::Tensor<T, Range, Storage> &result,
 
     static_assert(::btas::boxrange_iteration_order<Range>::value ==
                   ::btas::boxrange_iteration_order<Range>::row_major);
+    const integer ldc = std::max(integer{1}, n);
     blas::gemm(blas::Layout::ColMajor, gemm_helper.right_op(),
                gemm_helper.left_op(), n, m, k, factor_t,
                device_data(right.storage()), ldb, device_data(left.storage()),
-               lda, one, device_data(result.storage()), n, queue);
+               lda, one, device_data(result.storage()), ldc, queue);
     device::sync_madness_task_with(stream);
   }
 }

--- a/src/TiledArray/dist_eval/contraction_eval.h
+++ b/src/TiledArray/dist_eval/contraction_eval.h
@@ -891,9 +891,9 @@ class Summa
   ordinal_type initialize(const DenseShape&) {
     // Construct static broadcast groups for dense arguments
     const madness::DistributedID col_did(DistEvalImpl_::id(), 0ul);
-    col_group_ = proc_grid_.make_col_group(col_did);
+    if (k_ > 0) col_group_ = proc_grid_.make_col_group(col_did);
     const madness::DistributedID row_did(DistEvalImpl_::id(), k_);
-    row_group_ = proc_grid_.make_row_group(row_did);
+    if (k_ > 0) row_group_ = proc_grid_.make_row_group(row_did);
 
 #ifdef TILEDARRAY_ENABLE_SUMMA_TRACE_INITIALIZE
     std::stringstream ss;
@@ -1347,7 +1347,6 @@ class Summa
 
     template <typename Derived>
     void make_next_step_tasks(Derived* task, ordinal_type depth) {
-      TA_ASSERT(depth > 0);
       // Set the depth to be no greater than the maximum number steps
       if (depth > owner_->k_) depth = owner_->k_;
 
@@ -1705,6 +1704,9 @@ class Summa
       ordinal_type depth =
           std::max(ProcGrid::size_type(2),
                    std::min(proc_grid_.proc_rows(), proc_grid_.proc_cols()));
+
+      // corner case: empty result
+      if (k_ == 0) return 0;
 
       // Construct the first SUMMA iteration task
       if (TensorImpl_::shape().is_dense()) {

--- a/src/TiledArray/dist_eval/contraction_eval.h
+++ b/src/TiledArray/dist_eval/contraction_eval.h
@@ -889,45 +889,63 @@ class Summa
 
   /// Initialize reduce tasks and construct broadcast groups
   ordinal_type initialize(const DenseShape&) {
-    // Construct static broadcast groups for dense arguments
-    const madness::DistributedID col_did(DistEvalImpl_::id(), 0ul);
-    if (k_ > 0) col_group_ = proc_grid_.make_col_group(col_did);
-    const madness::DistributedID row_did(DistEvalImpl_::id(), k_);
-    if (k_ > 0) row_group_ = proc_grid_.make_row_group(row_did);
+    // if contraction is over zero-volume range just initialize tiles to zero
+    if (k_ == 0) {
+      ordinal_type tile_count = 0;
+      const auto& tiles_range = this->trange().tiles_range();
+      for (auto&& tile_idx : tiles_range) {
+        auto tile_ord = tiles_range.ordinal(tile_idx);
+        if (this->is_local(tile_ord)) {
+          this->world().taskq.add([this, tile_ord, tile_idx]() {
+            this->set_tile(tile_ord,
+                           value_type(this->trange().tile(tile_idx),
+                                      typename value_type::value_type{}));
+          });
+          ++tile_count;
+        }
+      }
+      return tile_count;
+    } else {
+      // Construct static broadcast groups for dense arguments
+      const madness::DistributedID col_did(DistEvalImpl_::id(), 0ul);
+      col_group_ = proc_grid_.make_col_group(col_did);
+      const madness::DistributedID row_did(DistEvalImpl_::id(), k_);
+      row_group_ = proc_grid_.make_row_group(row_did);
 
 #ifdef TILEDARRAY_ENABLE_SUMMA_TRACE_INITIALIZE
-    std::stringstream ss;
-    ss << "init: rank=" << TensorImpl_::world().rank() << "\n    col_group_=("
-       << col_did.first << ", " << col_did.second << ") { ";
-    for (ProcessID gproc = 0ul; gproc < col_group_.size(); ++gproc)
-      ss << col_group_.world_rank(gproc) << " ";
-    ss << "}\n    row_group_=(" << row_did.first << ", " << row_did.second
-       << ") { ";
-    for (ProcessID gproc = 0ul; gproc < row_group_.size(); ++gproc)
-      ss << row_group_.world_rank(gproc) << " ";
-    ss << "}\n";
-    printf(ss.str().c_str());
+      std::stringstream ss;
+      ss << "init: rank=" << TensorImpl_::world().rank() << "\n    col_group_=("
+         << col_did.first << ", " << col_did.second << ") { ";
+      for (ProcessID gproc = 0ul; gproc < col_group_.size(); ++gproc)
+        ss << col_group_.world_rank(gproc) << " ";
+      ss << "}\n    row_group_=(" << row_did.first << ", " << row_did.second
+         << ") { ";
+      for (ProcessID gproc = 0ul; gproc < row_group_.size(); ++gproc)
+        ss << row_group_.world_rank(gproc) << " ";
+      ss << "}\n";
+      printf(ss.str().c_str());
 #endif  // TILEDARRAY_ENABLE_SUMMA_TRACE_INITIALIZE
 
-    // Allocate memory for the reduce pair tasks.
-    std::allocator<ReducePairTask<op_type>> alloc;
-    reduce_tasks_ = alloc.allocate(proc_grid_.local_size());
+      // Allocate memory for the reduce pair tasks.
+      std::allocator<ReducePairTask<op_type>> alloc;
+      reduce_tasks_ = alloc.allocate(proc_grid_.local_size());
 
-    // Iterate over all local tiles
-    const ordinal_type n = proc_grid_.local_size();
-    for (ordinal_type t = 0ul; t < n; ++t) {
-      // Initialize the reduction task
-      ReducePairTask<op_type>* MADNESS_RESTRICT const reduce_task =
-          reduce_tasks_ + t;
-      new (reduce_task) ReducePairTask<op_type>(TensorImpl_::world(), op_
+      // Iterate over all local tiles
+      const ordinal_type n = proc_grid_.local_size();
+      for (ordinal_type t = 0ul; t < n; ++t) {
+        // Initialize the reduction task
+        ReducePairTask<op_type>* MADNESS_RESTRICT const reduce_task =
+            reduce_tasks_ + t;
+        new (reduce_task) ReducePairTask<op_type>(TensorImpl_::world(), op_
 #ifdef TILEDARRAY_ENABLE_SUMMA_TRACE_INITIALIZE
-                                                ,
-                                                nullptr, t
+                                                  ,
+                                                  nullptr, t
 #endif  // TILEDARRAY_ENABLE_SUMMA_TRACE_INITIALIZE
-      );
+        );
+      }
+
+      return proc_grid_.local_size();
     }
-
-    return proc_grid_.local_size();
   }
 
   /// Initialize reduce tasks
@@ -937,6 +955,9 @@ class Summa
     std::stringstream ss;
     ss << "    initialize rank=" << TensorImpl_::world().rank() << " tiles={ ";
 #endif  // TILEDARRAY_ENABLE_SUMMA_TRACE_INITIALIZE
+
+    // fast return if there is no work to do
+    if (k_ == 0) return 0;
 
     // Allocate memory for the reduce pair tasks.
     std::allocator<ReducePairTask<op_type>> alloc;
@@ -1705,59 +1726,78 @@ class Summa
           std::max(ProcGrid::size_type(2),
                    std::min(proc_grid_.proc_rows(), proc_grid_.proc_cols()));
 
-      // corner case: empty result
-      if (k_ == 0) return 0;
+      // watch out for the corner case: contraction over zero-volume range
+      // producing nonzero-volume result ... in that case there is nothing to do
+      // the appropriate initialization was performed in the initialize() method
+      if (k_ != 0) {
+        // Construct the first SUMMA iteration task
+        if (TensorImpl_::shape().is_dense()) {
+          // We cannot have more iterations than there are blocks in the k
+          // dimension
+          if (depth > k_) depth = k_;
 
-      // Construct the first SUMMA iteration task
-      if (TensorImpl_::shape().is_dense()) {
-        // We cannot have more iterations than there are blocks in the k
-        // dimension
-        if (depth > k_) depth = k_;
+          // Modify the number of concurrent iterations based on the available
+          // memory.
+          depth = mem_bound_depth(depth, 0.0f, 0.0f);
 
-        // Modify the number of concurrent iterations based on the available
-        // memory.
-        depth = mem_bound_depth(depth, 0.0f, 0.0f);
+          // Enforce user defined depth bound
+          if (max_depth_) depth = std::min(depth, max_depth_);
 
-        // Enforce user defined depth bound
-        if (max_depth_) depth = std::min(depth, max_depth_);
+          TensorImpl_::world().taskq.add(
+              new DenseStepTask(shared_from_this(), depth));
+        } else {
+          // Increase the depth based on the amount of sparsity in an iteration.
 
-        TensorImpl_::world().taskq.add(
-            new DenseStepTask(shared_from_this(), depth));
-      } else {
-        // Increase the depth based on the amount of sparsity in an iteration.
+          // Get the sparsity fractions for the left- and right-hand arguments.
+          const float left_sparsity = left_.shape().sparsity();
+          const float right_sparsity = right_.shape().sparsity();
 
-        // Get the sparsity fractions for the left- and right-hand arguments.
-        const float left_sparsity = left_.shape().sparsity();
-        const float right_sparsity = right_.shape().sparsity();
+          // Compute the fraction of non-zero result tiles in a single SUMMA
+          // iteration.
+          const float frac_non_zero = (1.0f - std::min(left_sparsity, 0.9f)) *
+                                      (1.0f - std::min(right_sparsity, 0.9f));
 
-        // Compute the fraction of non-zero result tiles in a single SUMMA
-        // iteration.
-        const float frac_non_zero = (1.0f - std::min(left_sparsity, 0.9f)) *
-                                    (1.0f - std::min(right_sparsity, 0.9f));
+          // Compute the new depth based on sparsity of the arguments
+          depth = float(depth) * (1.0f - 1.35638f * std::log2(frac_non_zero)) +
+                  0.5f;
 
-        // Compute the new depth based on sparsity of the arguments
-        depth =
-            float(depth) * (1.0f - 1.35638f * std::log2(frac_non_zero)) + 0.5f;
+          // We cannot have more iterations than there are blocks in the k
+          // dimension
+          if (depth > k_) depth = k_;
 
-        // We cannot have more iterations than there are blocks in the k
-        // dimension
-        if (depth > k_) depth = k_;
+          // Modify the number of concurrent iterations based on the available
+          // memory and sparsity of the argument tensors.
+          depth = mem_bound_depth(depth, left_sparsity, right_sparsity);
 
-        // Modify the number of concurrent iterations based on the available
-        // memory and sparsity of the argument tensors.
-        depth = mem_bound_depth(depth, left_sparsity, right_sparsity);
+          // Enforce user defined depth bound
+          if (max_depth_) depth = std::min(depth, max_depth_);
 
-        // Enforce user defined depth bound
-        if (max_depth_) depth = std::min(depth, max_depth_);
-
-        TensorImpl_::world().taskq.add(
-            new SparseStepTask(shared_from_this(), depth));
-      }
+          TensorImpl_::world().taskq.add(
+              new SparseStepTask(shared_from_this(), depth));
+        }
+      }  // k_ != 0
     }
 
 #ifdef TILEDARRAY_ENABLE_SUMMA_TRACE_EVAL
     printf("eval: start wait children rank=%i\n", TensorImpl_::world().rank());
 #endif  // TILEDARRAY_ENABLE_SUMMA_TRACE_EVAL
+
+    // corner case: if left or right are zero-volume no tasks were scheduled, so
+    // need to discard all of their tiles manually
+    if (left_.range().volume() == 0) {
+      for (auto&& tile_idx : right_.range()) {
+        auto tile_ord = right_.range().ordinal(tile_idx);
+        if (right_.is_local(tile_ord) && !right_.is_zero(tile_ord))
+          right_.discard(tile_ord);
+      }
+    }
+    if (right_.range().volume() == 0) {
+      for (auto&& tile_idx : left_.range()) {
+        auto tile_ord = left_.range().ordinal(tile_idx);
+        if (left_.is_local(tile_ord) && !left_.is_zero(tile_ord))
+          left_.discard(tile_ord);
+      }
+    }
 
     // Wait for child tensors to be evaluated, and process tasks while waiting.
     left_.wait();

--- a/src/TiledArray/expressions/blk_tsr_expr.h
+++ b/src/TiledArray/expressions/blk_tsr_expr.h
@@ -179,7 +179,7 @@ class BlkTsrExprBase : public Expr<Derived> {
     const bool lower_upper_bound_check =
         std::equal(std::begin(lower_bound_), std::end(lower_bound_),
                    std::begin(upper_bound_),
-                   [](std::size_t l, std::size_t r) { return l < r; });
+                   [](std::size_t l, std::size_t r) { return l <= r; });
     if (!lower_upper_bound_check) {
       if (TiledArray::get_default_world().rank() == 0) {
         using TiledArray::operator<<;

--- a/src/TiledArray/expressions/cont_engine.h
+++ b/src/TiledArray/expressions/cont_engine.h
@@ -350,7 +350,7 @@ class ContEngine : public BinaryEngine<Derived> {
     left_.init_distribution(world, proc_grid_.make_row_phase_pmap(K_));
     right_.init_distribution(world, proc_grid_.make_col_phase_pmap(K_));
 
-    // Initialize the process map in not already defined
+    // Initialize the process map if not already defined
     if (!pmap) pmap = proc_grid_.make_pmap();
     ExprEngine_::init_distribution(world, pmap);
   }

--- a/src/TiledArray/expressions/cont_engine.h
+++ b/src/TiledArray/expressions/cont_engine.h
@@ -343,16 +343,26 @@ class ContEngine : public BinaryEngine<Derived> {
       n *= right_element_size[i];
     }
 
-    // Construct the process grid.
-    proc_grid_ = TiledArray::detail::ProcGrid(*world, M, N, m, n);
+    // corner case: zero-volume result ... easier to skip proc_grid_
+    // construction alltogether
+    if (M == 0 || N == 0) {
+      left_.init_distribution(world, {});
+      right_.init_distribution(world, {});
+      ExprEngine_::init_distribution(
+          world, (pmap ? pmap : policy::default_pmap(*world, M * N)));
+    } else {  // M!=0 && N!=0
 
-    // Initialize children
-    left_.init_distribution(world, proc_grid_.make_row_phase_pmap(K_));
-    right_.init_distribution(world, proc_grid_.make_col_phase_pmap(K_));
+      // Construct the process grid.
+      proc_grid_ = TiledArray::detail::ProcGrid(*world, M, N, m, n);
 
-    // Initialize the process map if not already defined
-    if (!pmap) pmap = proc_grid_.make_pmap();
-    ExprEngine_::init_distribution(world, pmap);
+      // Initialize children
+      left_.init_distribution(world, proc_grid_.make_row_phase_pmap(K_));
+      right_.init_distribution(world, proc_grid_.make_col_phase_pmap(K_));
+
+      // Initialize the process map if not already defined
+      if (!pmap) pmap = proc_grid_.make_pmap();
+      ExprEngine_::init_distribution(world, pmap);
+    }
   }
 
   /// Tiled range factory function

--- a/src/TiledArray/expressions/expr.h
+++ b/src/TiledArray/expressions/expr.h
@@ -504,8 +504,11 @@ class Expr {
     // Move the data from dist_eval into the sub-block of result array.
     // This step may involve communication when the tiles are moved from the
     // sub-block distribution to the array distribution.
-    {
+    // N.B. handle the corner case of zero-volume host array, then no data needs
+    // to be moved
+    if (tsr.array().trange().tiles_range().volume() != 0) {
       // N.B. must deep copy
+      TA_ASSERT(tsr.array().trange().tiles_range().includes(tsr.lower_bound()));
       const container::svector<long> shift =
           tsr.array().trange().make_tile_range(tsr.lower_bound()).lobound();
 

--- a/src/TiledArray/external/btas.h
+++ b/src/TiledArray/external/btas.h
@@ -661,16 +661,19 @@ inline btas::Tensor<T, Range, Storage> gemm(
   gemm_helper.compute_matrix_sizes(m, n, k, left.range(), right.range());
 
   // Get the leading dimension for left and right matrices.
-  const integer lda =
-      (gemm_helper.left_op() == TiledArray::math::blas::Op::NoTrans ? k : m);
-  const integer ldb =
-      (gemm_helper.right_op() == TiledArray::math::blas::Op::NoTrans ? n : k);
+  const integer lda = std::max(
+      integer{1},
+      (gemm_helper.left_op() == TiledArray::math::blas::Op::NoTrans ? k : m));
+  const integer ldb = std::max(
+      integer{1},
+      (gemm_helper.right_op() == TiledArray::math::blas::Op::NoTrans ? n : k));
 
   T factor_t(factor);
 
+  const integer ldc = std::max(integer{1}, n);
   TiledArray::math::blas::gemm(gemm_helper.left_op(), gemm_helper.right_op(), m,
                                n, k, factor_t, left.data(), lda, right.data(),
-                               ldb, T(0), result.data(), n);
+                               ldb, T(0), result.data(), ldc);
 
   return result;
 }
@@ -736,16 +739,19 @@ inline void gemm(btas::Tensor<T, Range, Storage>& result,
   gemm_helper.compute_matrix_sizes(m, n, k, left.range(), right.range());
 
   // Get the leading dimension for left and right matrices.
-  const integer lda =
-      (gemm_helper.left_op() == TiledArray::math::blas::Op::NoTrans ? k : m);
-  const integer ldb =
-      (gemm_helper.right_op() == TiledArray::math::blas::Op::NoTrans ? n : k);
+  const integer lda = std::max(
+      integer{1},
+      (gemm_helper.left_op() == TiledArray::math::blas::Op::NoTrans ? k : m));
+  const integer ldb = std::max(
+      integer{1},
+      (gemm_helper.right_op() == TiledArray::math::blas::Op::NoTrans ? n : k));
 
   T factor_t(factor);
 
+  const integer ldc = std::max(integer{1}, n);
   TiledArray::math::blas::gemm(gemm_helper.left_op(), gemm_helper.right_op(), m,
                                n, k, factor_t, left.data(), lda, right.data(),
-                               ldb, T(1), result.data(), n);
+                               ldb, T(1), result.data(), ldc);
 }
 
 // sum of the hyperdiagonal elements

--- a/src/TiledArray/pmap/cyclic_pmap.h
+++ b/src/TiledArray/pmap/cyclic_pmap.h
@@ -84,10 +84,6 @@ class CyclicPmap : public Pmap {
         cols_(cols),
         proc_cols_(proc_cols),
         proc_rows_(proc_rows) {
-    // Check that the size is non-zero
-    TA_ASSERT(rows_ >= 1ul);
-    TA_ASSERT(cols_ >= 1ul);
-
     // Check limits of process rows and columns
     TA_ASSERT(proc_rows_ >= 1ul);
     TA_ASSERT(proc_cols_ >= 1ul);

--- a/src/TiledArray/proc_grid.h
+++ b/src/TiledArray/proc_grid.h
@@ -288,12 +288,6 @@ class ProcGrid {
         local_rows_(0ul),
         local_cols_(0ul),
         local_size_(0ul) {
-    // Check for non-zero sizes
-    TA_ASSERT(rows_ >= 1u);
-    TA_ASSERT(cols_ >= 1u);
-    TA_ASSERT(row_size >= 1ul);
-    TA_ASSERT(col_size >= 1ul);
-
     init(world_->rank(), world_->size(), row_size, col_size);
   }
 

--- a/src/TiledArray/sparse_shape.h
+++ b/src/TiledArray/sparse_shape.h
@@ -516,10 +516,13 @@ class SparseShape {
 
   /// Sparsity of the shape
 
-  /// \return The fraction of tiles that are zero.
+  /// \return The fraction of tiles that are zero. Always returns 0 if
+  /// `this->data().size()` is zero.
   float sparsity() const {
     TA_ASSERT(!tile_norms_.empty());
-    return float(zero_tile_count_) / float(tile_norms_.size());
+    return tile_norms_.size() != 0
+               ? float(zero_tile_count_) / float(tile_norms_.size())
+               : 0.f;
   }
 
   // clang-format off
@@ -1679,23 +1682,23 @@ class SparseShape {
             typename std::enable_if<madness::is_input_archive_v<
                 std::decay_t<Archive>>>::type* = nullptr>
   void serialize(Archive& ar) {
-    ar& tile_norms_;
+    ar & tile_norms_;
     const unsigned int dim = tile_norms_.range().rank();
     // allocate size_vectors_
     size_vectors_ = std::move(std::shared_ptr<vector_type>(
         new vector_type[dim], std::default_delete<vector_type[]>()));
-    for (unsigned d = 0; d != dim; ++d) ar& size_vectors_.get()[d];
-    ar& zero_tile_count_;
+    for (unsigned d = 0; d != dim; ++d) ar & size_vectors_.get()[d];
+    ar & zero_tile_count_;
   }
 
   template <typename Archive,
             typename std::enable_if<madness::is_output_archive_v<
                 std::decay_t<Archive>>>::type* = nullptr>
   void serialize(Archive& ar) const {
-    ar& tile_norms_;
+    ar & tile_norms_;
     const unsigned int dim = tile_norms_.range().rank();
-    for (unsigned d = 0; d != dim; ++d) ar& size_vectors_.get()[d];
-    ar& zero_tile_count_;
+    for (unsigned d = 0; d != dim; ++d) ar & size_vectors_.get()[d];
+    ar & zero_tile_count_;
   }
 
  private:

--- a/src/TiledArray/sparse_shape.h
+++ b/src/TiledArray/sparse_shape.h
@@ -840,7 +840,7 @@ class SparseShape {
 
       // Check that the input indices are in range
       TA_ASSERT(lower_d >= tile_norms_.range().lobound(d));
-      TA_ASSERT(lower_d < upper_d);
+      TA_ASSERT(lower_d <= upper_d);
       TA_ASSERT(upper_d <= tile_norms_.range().upbound(d));
 
       // Construct the size vector for rank i
@@ -874,7 +874,7 @@ class SparseShape {
 
       // Check that the input indices are in range
       TA_ASSERT(lower_d >= tile_norms_.range().lobound(d));
-      TA_ASSERT(lower_d < upper_d);
+      TA_ASSERT(lower_d <= upper_d);
       TA_ASSERT(upper_d <= tile_norms_.range().upbound(d));
 
       // Construct the size vector for rank i

--- a/src/TiledArray/tensor/permute.h
+++ b/src/TiledArray/tensor/permute.h
@@ -127,6 +127,9 @@ inline void permute(InputOp&& input_op, OutputOp&& output_op, Result& result,
   const unsigned int ndim1 = ndim - 1;
   const auto volume = arg0.range().volume();
 
+  // handle the corner case of empty result/args
+  if (volume == 0) return;
+
   // Get pointer to arg extent
   const auto* MADNESS_RESTRICT const arg0_extent = arg0.range().extent_data();
 

--- a/src/TiledArray/tensor/tensor.h
+++ b/src/TiledArray/tensor/tensor.h
@@ -2648,10 +2648,13 @@ void gemm(Alpha alpha, const Tensor<As...>& A, const Tensor<Bs...>& B,
     gemm_helper.compute_matrix_sizes(m, n, k, A.range(), B.range());
 
     // Get the leading dimension for left and right matrices.
-    const integer lda =
-        (gemm_helper.left_op() == TiledArray::math::blas::NoTranspose ? k : m);
-    const integer ldb =
-        (gemm_helper.right_op() == TiledArray::math::blas::NoTranspose ? n : k);
+    const integer lda = std::max(
+        integer{1},
+        (gemm_helper.left_op() == TiledArray::math::blas::NoTranspose ? k : m));
+    const integer ldb = std::max(
+        integer{1},
+        (gemm_helper.right_op() == TiledArray::math::blas::NoTranspose ? n
+                                                                       : k));
 
     // may need to split gemm into multiply + accumulate for tracing purposes
 #ifdef TA_ENABLE_TILE_OPS_LOGGING
@@ -2719,8 +2722,9 @@ void gemm(Alpha alpha, const Tensor<As...>& A, const Tensor<Bs...>& B,
       }
     }
 #else   // TA_ENABLE_TILE_OPS_LOGGING
+    const integer ldc = std::max(integer{1}, n);
     math::blas::gemm(gemm_helper.left_op(), gemm_helper.right_op(), m, n, k,
-                     alpha, A.data(), lda, B.data(), ldb, beta, C.data(), n);
+                     alpha, A.data(), lda, B.data(), ldb, beta, C.data(), ldc);
 #endif  // TA_ENABLE_TILE_OPS_LOGGING
   }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(executable ta_test)
 set(ta_test_src_files  ta_test.cpp
     range1.cpp
     range.cpp
+    block_range.cpp
     type_traits.cpp
     tensor.cpp
     tensor_of_tensor.cpp

--- a/tests/block_range.cpp
+++ b/tests/block_range.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(block_zero_lower_bound) {
       for (unsigned int i = 0u; i < upper.size(); ++i) ++(upper[i]);
 
       if (std::equal(lower.begin(), lower.end(), upper.begin(),
-                     [](std::size_t l, std::size_t r0) { return l < r0; })) {
+                     [](std::size_t l, std::size_t r0) { return l <= r0; })) {
         if (count_valid == target_count) continue;
         ++count_valid;
 
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(block) {
       for (unsigned int i = 0u; i < r.rank(); ++i) ++(upper[i]);
 
       if (std::equal(lower.begin(), lower.end(), upper.begin(),
-                     [](std::size_t l, std::size_t r) { return l < r; })) {
+                     [](std::size_t l, std::size_t r) { return l <= r; })) {
         if (count_valid == target_count) continue;
         ++count_valid;
 
@@ -267,6 +267,28 @@ BOOST_AUTO_TEST_CASE(block) {
     }
   }
 end:;
+}
+
+BOOST_AUTO_TEST_CASE(empty_trange1) {
+  using TiledArray::eigen::iv;
+  // host range is non-empty but one of the dimensions will have no tiles
+  {
+    BOOST_CHECK_NO_THROW(BlockRange(r, iv(3, 3, 3), iv(4, 3, 5)));
+    BlockRange br(r, iv(3, 3, 3), iv(4, 3, 5));
+    BOOST_CHECK_EQUAL(br.volume(), 0);
+    BOOST_CHECK_TA_ASSERT(br.ordinal(0), Exception);
+  }
+
+  // host range is non-empty but one of the dimensions will have no tiles
+  {
+    BOOST_CHECK_NO_THROW(
+        BlockRange(Range({Range1{0, 3}, Range1{}, Range1{0, 4}}), iv(0, 0, 0),
+                   iv(1, 0, 1)));
+    BlockRange br(Range({Range1{0, 3}, Range1{}, Range1{0, 4}}), iv(0, 0, 0),
+                  iv(1, 0, 1));
+    BOOST_CHECK_EQUAL(br.volume(), 0);
+    BOOST_CHECK_TA_ASSERT(br.ordinal(0), Exception);
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/cyclic_pmap.cpp
+++ b/tests/cyclic_pmap.cpp
@@ -61,12 +61,6 @@ BOOST_AUTO_TEST_CASE(constructor) {
   ProcessID size = GlobalFixture::world->size();
 
   BOOST_CHECK_TA_ASSERT(TiledArray::detail::CyclicPmap pmap(
-                            *GlobalFixture::world, 0ul, 10ul, 1, 1),
-                        TiledArray::Exception);
-  BOOST_CHECK_TA_ASSERT(TiledArray::detail::CyclicPmap pmap(
-                            *GlobalFixture::world, 10ul, 0ul, 1, 1),
-                        TiledArray::Exception);
-  BOOST_CHECK_TA_ASSERT(TiledArray::detail::CyclicPmap pmap(
                             *GlobalFixture::world, 10ul, 10ul, 0, 1),
                         TiledArray::Exception);
   BOOST_CHECK_TA_ASSERT(TiledArray::detail::CyclicPmap pmap(

--- a/tests/expressions_fixture.h
+++ b/tests/expressions_fixture.h
@@ -62,9 +62,11 @@ struct ExpressionsFixture : public TiledRangeFixture {
         s_tr1_1(make_random_sparseshape(trange1)),
         s_tr1_2(make_random_sparseshape(trange1)),
         s_tr2(make_random_sparseshape(trange2)),
+        s_trC(make_random_sparseshape(trangeC)),
         a(*GlobalFixture::world, tr, s_tr_1),
         b(*GlobalFixture::world, tr, s_tr_2),
         c(*GlobalFixture::world, tr, s_tr_2),
+        aC(*GlobalFixture::world, trangeC, s_trC),
         u(*GlobalFixture::world, trange1, s_tr1_1),
         v(*GlobalFixture::world, trange1, s_tr1_2),
         w(*GlobalFixture::world, trange2, s_tr2) {
@@ -72,6 +74,7 @@ struct ExpressionsFixture : public TiledRangeFixture {
     random_fill(b);
     random_fill(u);
     random_fill(v);
+    random_fill(aC);
     GlobalFixture::world->gop.fence();
     a.truncate();
     b.truncate();
@@ -88,11 +91,13 @@ struct ExpressionsFixture : public TiledRangeFixture {
         c(*GlobalFixture::world, tr),
         u(*GlobalFixture::world, trange1),
         v(*GlobalFixture::world, trange1),
-        w(*GlobalFixture::world, trange2) {
+        w(*GlobalFixture::world, trange2),
+        aC(*GlobalFixture::world, trangeC) {
     random_fill(a);
     random_fill(b);
     random_fill(u);
     random_fill(v);
+    random_fill(aC);
     GlobalFixture::world->gop.fence();
   }
 
@@ -213,17 +218,22 @@ struct ExpressionsFixture : public TiledRangeFixture {
   const TiledRange trange1{{0, 2, 5, 10, 17, 28, 41}};
   const TiledRange trange2{{0, 2, 5, 10, 17, 28, 41},
                            {0, 3, 6, 11, 18, 29, 42}};
+  // contains empty trange1
+  const TiledRange trangeC{TiledRange1{0, 2, 5, 10}, TiledRange1{},
+                           TiledRange1{0, 2, 7, 11}};
   SparseShape<float> s_tr_1;
   SparseShape<float> s_tr_2;
   SparseShape<float> s_tr1_1;
   SparseShape<float> s_tr1_2;
   SparseShape<float> s_tr2;
+  SparseShape<float> s_trC;
   TArray a;
   TArray b;
   TArray c;
   TArray u;
   TArray v;
   TArray w;
+  TArray aC;
 };  // ExpressionsFixture
 
 #endif  // TILEDARRAY_TEST_EXPRESSIONS_FIXTURE_H

--- a/tests/expressions_fixture.h
+++ b/tests/expressions_fixture.h
@@ -63,10 +63,12 @@ struct ExpressionsFixture : public TiledRangeFixture {
         s_tr1_2(make_random_sparseshape(trange1)),
         s_tr2(make_random_sparseshape(trange2)),
         s_trC(make_random_sparseshape(trangeC)),
+        s_trC_f(make_random_sparseshape(trangeC_f)),
         a(*GlobalFixture::world, tr, s_tr_1),
         b(*GlobalFixture::world, tr, s_tr_2),
         c(*GlobalFixture::world, tr, s_tr_2),
         aC(*GlobalFixture::world, trangeC, s_trC),
+        aC_f(*GlobalFixture::world, trangeC_f, s_trC_f),
         u(*GlobalFixture::world, trange1, s_tr1_1),
         v(*GlobalFixture::world, trange1, s_tr1_2),
         w(*GlobalFixture::world, trange2, s_tr2) {
@@ -92,12 +94,14 @@ struct ExpressionsFixture : public TiledRangeFixture {
         u(*GlobalFixture::world, trange1),
         v(*GlobalFixture::world, trange1),
         w(*GlobalFixture::world, trange2),
-        aC(*GlobalFixture::world, trangeC) {
+        aC(*GlobalFixture::world, trangeC),
+        aC_f(*GlobalFixture::world, trangeC_f) {
     random_fill(a);
     random_fill(b);
     random_fill(u);
     random_fill(v);
     random_fill(aC);
+    random_fill(aC_f);
     GlobalFixture::world->gop.fence();
   }
 
@@ -221,12 +225,17 @@ struct ExpressionsFixture : public TiledRangeFixture {
   // contains empty trange1
   const TiledRange trangeC{TiledRange1{0, 2, 5, 10}, TiledRange1{},
                            TiledRange1{0, 2, 7, 11}};
+  // like trC, but with all dimension nonempty
+  const TiledRange trangeC_f{trangeC.dim(0), TiledRange1{0, 4, 7},
+                             trangeC.dim(2)};
+
   SparseShape<float> s_tr_1;
   SparseShape<float> s_tr_2;
   SparseShape<float> s_tr1_1;
   SparseShape<float> s_tr1_2;
   SparseShape<float> s_tr2;
   SparseShape<float> s_trC;
+  SparseShape<float> s_trC_f;
   TArray a;
   TArray b;
   TArray c;
@@ -234,6 +243,7 @@ struct ExpressionsFixture : public TiledRangeFixture {
   TArray v;
   TArray w;
   TArray aC;
+  TArray aC_f;
 };  // ExpressionsFixture
 
 #endif  // TILEDARRAY_TEST_EXPRESSIONS_FIXTURE_H

--- a/tests/expressions_impl.h
+++ b/tests/expressions_impl.h
@@ -2947,24 +2947,48 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(empty_trange1, F, Fixtures, F) {
   auto& c = F::c;
   auto& aC = F::aC;
 
-  BOOST_CHECK_NO_THROW(c("a,b,c") = aC("a,b,c"));
-  BOOST_CHECK_NO_THROW(c("a,b,c") += aC("a,b,c"));
-  BOOST_CHECK_NO_THROW(c("a,b,c") *= aC("a,b,c"));
-  BOOST_CHECK_NO_THROW(c("a,b,c") *= 2 * aC("a,b,c"));
-  BOOST_CHECK_NO_THROW(c("a,b,c") += 2 * aC("a,b,c").conj());
-  BOOST_CHECK_NO_THROW(c("a,b,c") = aC("a,c,b"));
-  BOOST_CHECK_NO_THROW(c("a,b,c") += 2 * aC("a,c,b").conj());
-  BOOST_CHECK_NO_THROW(c("a,b,c") *= 2 * aC("a,c,b").conj());
+  // unary/binary expressions
+  {
+    BOOST_CHECK_NO_THROW(c("a,b,c") = aC("a,b,c"));
+    BOOST_CHECK_NO_THROW(c("a,b,c") += aC("a,b,c"));
+    BOOST_CHECK_NO_THROW(c("a,b,c") *= aC("a,b,c"));
+    BOOST_CHECK_NO_THROW(c("a,b,c") *= 2 * aC("a,b,c"));
+    BOOST_CHECK_NO_THROW(c("a,b,c") += 2 * aC("a,b,c").conj());
+    BOOST_CHECK_NO_THROW(c("a,b,c") = aC("a,c,b"));
+    BOOST_CHECK_NO_THROW(c("a,b,c") += 2 * aC("a,c,b").conj());
+    BOOST_CHECK_NO_THROW(c("a,b,c") *= 2 * aC("a,c,b").conj());
+  }
 
   using TiledArray::eigen::iv;
   const std::array<int, 3> lobound{{0, 0, 1}};
   const std::array<int, 3> upbound{{1, 0, 2}};
 
-  BOOST_CHECK_NO_THROW(c("a,b,c") = aC("a,b,c").block(lobound, upbound));
-  BOOST_CHECK_NO_THROW(c("a,b,c") +=
-                       2 * aC("a,b,c").block(lobound, upbound).conj());
-  BOOST_CHECK_NO_THROW(c("a,b,c") =
-                           2 * conj(aC("a,c,b").block(lobound, upbound)));
+  // unary/binary block expressions
+  {
+    BOOST_CHECK_NO_THROW(c("a,b,c") = aC("a,b,c").block(lobound, upbound));
+    BOOST_CHECK_NO_THROW(c("a,b,c") +=
+                         2 * aC("a,b,c").block(lobound, upbound).conj());
+    BOOST_CHECK_NO_THROW(c("a,b,c") =
+                             2 * conj(aC("a,c,b").block(lobound, upbound)));
+  }
+
+  // contraction expressions
+  {
+    std::decay_t<decltype(c)> t2, t4;
+    // contraction over empty dim
+    BOOST_CHECK_NO_THROW(t4("a,c,e,d") = aC("a,b,c") * aC("d,b,e"));
+    // contraction over empty and nonempty dims
+    BOOST_CHECK_NO_THROW(t2("a,d") = aC("a,b,c") * aC("d,b,c"));
+    // contraction over nonempty dims
+    BOOST_CHECK_NO_THROW(t4("b,a,e,d") = aC("a,b,c") * aC("d,e,c"));
+  }
+
+  // reduction expressions
+  {
+    // contraction over empty dim
+    BOOST_CHECK_NO_THROW(aC("a,b,c").dot(2 * aC("a,b,c").conj()).get());
+    BOOST_CHECK_EQUAL(aC("a,b,c").dot(2 * aC("a,b,c").conj()).get(), 0);
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/expressions_impl.h
+++ b/tests/expressions_impl.h
@@ -31,6 +31,7 @@ constexpr int nrepeats = 5;
 BOOST_FIXTURE_TEST_CASE_TEMPLATE(tensor_factories, F, Fixtures, F) {
   auto& a = F::a;
   auto& c = F::c;
+  auto& aC = F::aC;
 
   const auto& ca = a;
   const std::array<int, 3> lobound{{3, 3, 3}};
@@ -2939,6 +2940,31 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(inner_product, F, Fixtures, F) {
 
   // Check the result of dot
   BOOST_CHECK_EQUAL(result, expected);
+}
+
+// corner case: expressions involving array with empty trange1
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(empty_trange1, F, Fixtures, F) {
+  auto& c = F::c;
+  auto& aC = F::aC;
+
+  BOOST_CHECK_NO_THROW(c("a,b,c") = aC("a,b,c"));
+  BOOST_CHECK_NO_THROW(c("a,b,c") += aC("a,b,c"));
+  BOOST_CHECK_NO_THROW(c("a,b,c") *= aC("a,b,c"));
+  BOOST_CHECK_NO_THROW(c("a,b,c") *= 2 * aC("a,b,c"));
+  BOOST_CHECK_NO_THROW(c("a,b,c") += 2 * aC("a,b,c").conj());
+  BOOST_CHECK_NO_THROW(c("a,b,c") = aC("a,c,b"));
+  BOOST_CHECK_NO_THROW(c("a,b,c") += 2 * aC("a,c,b").conj());
+  BOOST_CHECK_NO_THROW(c("a,b,c") *= 2 * aC("a,c,b").conj());
+
+  using TiledArray::eigen::iv;
+  const std::array<int, 3> lobound{{0, 0, 1}};
+  const std::array<int, 3> upbound{{1, 0, 2}};
+
+  BOOST_CHECK_NO_THROW(c("a,b,c") = aC("a,b,c").block(lobound, upbound));
+  BOOST_CHECK_NO_THROW(c("a,b,c") +=
+                       2 * aC("a,b,c").block(lobound, upbound).conj());
+  BOOST_CHECK_NO_THROW(c("a,b,c") =
+                           2 * conj(aC("a,c,b").block(lobound, upbound)));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/expressions_impl.h
+++ b/tests/expressions_impl.h
@@ -2946,6 +2946,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(inner_product, F, Fixtures, F) {
 BOOST_FIXTURE_TEST_CASE_TEMPLATE(empty_trange1, F, Fixtures, F) {
   auto& c = F::c;
   auto& aC = F::aC;
+  auto& aC_f = F::aC_f;
 
   // unary/binary expressions
   {
@@ -2981,6 +2982,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(empty_trange1, F, Fixtures, F) {
     BOOST_CHECK_NO_THROW(t2("a,d") = aC("a,b,c") * aC("d,b,c"));
     // contraction over nonempty dims
     BOOST_CHECK_NO_THROW(t4("b,a,e,d") = aC("a,b,c") * aC("d,e,c"));
+    // contraction over nonempty dims, involving expressions with nonzero-volume
+    BOOST_CHECK_NO_THROW(t4("b,a,e,d") = aC("a,b,c") * (2. * aC_f("d,e,c")));
   }
 
   // reduction expressions

--- a/tests/range1.cpp
+++ b/tests/range1.cpp
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(constructors) {
   BOOST_CHECK_NO_THROW((Range1{1, 1}));
   BOOST_CHECK_NO_THROW(Range1(1, 1));
   BOOST_CHECK_EQUAL(Range1(1, 1).first, 1);
-  BOOST_CHECK_EQUAL(Range1(1, 1).first, 1);
+  BOOST_CHECK_EQUAL(Range1(1, 1).second, 1);
 
   BOOST_CHECK_NO_THROW((Range1{-11, 13}));
   BOOST_CHECK_EQUAL(Range1(-11, 13).first, -11);
@@ -86,6 +86,15 @@ BOOST_AUTO_TEST_CASE(accessors) {
   BOOST_CHECK_EQUAL(r.upbound(), 10);
   BOOST_CHECK_NO_THROW(r.extent());
   BOOST_CHECK_EQUAL(r.extent(), 9);
+
+  // corner case: empty range
+  Range1 r1{1, 1};
+  BOOST_CHECK_NO_THROW(r1.lobound());
+  BOOST_CHECK_EQUAL(r1.lobound(), 1);
+  BOOST_CHECK_NO_THROW(r1.upbound());
+  BOOST_CHECK_EQUAL(r1.upbound(), 1);
+  BOOST_CHECK_NO_THROW(r.extent());
+  BOOST_CHECK_EQUAL(r1.extent(), 0);
 }
 
 BOOST_AUTO_TEST_CASE(iteration) {
@@ -134,13 +143,13 @@ BOOST_AUTO_TEST_CASE(serialization) {
   std::size_t buf_size = sizeof(Range1);
   unsigned char* buf = new unsigned char[buf_size];
   madness::archive::BufferOutputArchive oar(buf, buf_size);
-  oar& r;
+  oar & r;
   std::size_t nbyte = oar.size();
   oar.close();
 
   Range1 rs;
   madness::archive::BufferInputArchive iar(buf, nbyte);
-  iar& rs;
+  iar & rs;
   iar.close();
 
   delete[] buf;

--- a/tests/sparse_shape.cpp
+++ b/tests/sparse_shape.cpp
@@ -121,9 +121,12 @@ BOOST_AUTO_TEST_CASE(non_comm_constructor) {
     }
   }
 
-  BOOST_CHECK_CLOSE(x.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      x.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
   BOOST_CHECK(x.nnz() == x.data().size() - zero_tile_count);
 
   // use the sparse ctor
@@ -194,9 +197,12 @@ BOOST_AUTO_TEST_CASE(comm_constructor) {
     }
   }
 
-  BOOST_CHECK_CLOSE(x.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      x.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
   BOOST_CHECK_EQUAL(x.nnz(), x.data().size() - zero_tile_count);
 
   // use the sparse ctor
@@ -321,7 +327,9 @@ BOOST_AUTO_TEST_CASE(block) {
         }
         BOOST_CHECK_CLOSE(
             result.sparsity(),
-            float(zero_tile_count) / float(result.data().range().volume()),
+            result.data().range().volume() > 0
+                ? float(zero_tile_count) / float(result.data().range().volume())
+                : 0,
             tolerance);
 
         // validate other block functions
@@ -413,7 +421,9 @@ BOOST_AUTO_TEST_CASE(block_scale) {
         }
         BOOST_CHECK_CLOSE(
             result.sparsity(),
-            float(zero_tile_count) / float(result.data().range().volume()),
+            result.data().range().volume() > 0
+                ? float(zero_tile_count) / float(result.data().range().volume())
+                : 0,
             tolerance);
 
         // validate other block functions
@@ -513,7 +523,9 @@ BOOST_AUTO_TEST_CASE(block_perm) {
         }
         BOOST_CHECK_CLOSE(
             result.sparsity(),
-            float(zero_tile_count) / float(result.data().range().volume()),
+            result.data().range().volume() > 0
+                ? float(zero_tile_count) / float(result.data().range().volume())
+                : 0,
             tolerance);
 
         // validate other block functions
@@ -614,7 +626,9 @@ BOOST_AUTO_TEST_CASE(block_scale_perm) {
         }
         BOOST_CHECK_CLOSE(
             result.sparsity(),
-            float(zero_tile_count) / float(result.data().range().volume()),
+            result.data().range().volume() > 0
+                ? float(zero_tile_count) / float(result.data().range().volume())
+                : 0,
             tolerance);
 
         // validate other block functions
@@ -706,9 +720,12 @@ BOOST_AUTO_TEST_CASE(transform) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(mask) {
@@ -745,9 +762,12 @@ BOOST_AUTO_TEST_CASE(mask) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(scale) {
@@ -778,9 +798,12 @@ BOOST_AUTO_TEST_CASE(scale) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(scale_perm) {
@@ -812,9 +835,12 @@ BOOST_AUTO_TEST_CASE(scale_perm) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(add) {
@@ -848,9 +874,12 @@ BOOST_AUTO_TEST_CASE(add) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
   BOOST_CHECK_EQUAL(result.nnz(), result.data().size() - zero_tile_count);
 }
 
@@ -885,9 +914,12 @@ BOOST_AUTO_TEST_CASE(add_scale) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(add_perm) {
@@ -922,9 +954,12 @@ BOOST_AUTO_TEST_CASE(add_perm) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(add_scale_perm) {
@@ -959,9 +994,12 @@ BOOST_AUTO_TEST_CASE(add_scale_perm) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(add_const) {
@@ -998,9 +1036,12 @@ BOOST_AUTO_TEST_CASE(add_const) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(add_const_perm) {
@@ -1037,9 +1078,12 @@ BOOST_AUTO_TEST_CASE(add_const_perm) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(subt) {
@@ -1073,9 +1117,12 @@ BOOST_AUTO_TEST_CASE(subt) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(subt_scale) {
@@ -1109,9 +1156,12 @@ BOOST_AUTO_TEST_CASE(subt_scale) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(subt_perm) {
@@ -1146,9 +1196,12 @@ BOOST_AUTO_TEST_CASE(subt_perm) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(subt_scale_perm) {
@@ -1183,9 +1236,12 @@ BOOST_AUTO_TEST_CASE(subt_scale_perm) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(subt_const) {
@@ -1220,9 +1276,12 @@ BOOST_AUTO_TEST_CASE(subt_const) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(subt_const_perm) {
@@ -1260,9 +1319,12 @@ BOOST_AUTO_TEST_CASE(subt_const_perm) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(mult) {
@@ -1295,9 +1357,12 @@ BOOST_AUTO_TEST_CASE(mult) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(mult_scale) {
@@ -1330,9 +1395,12 @@ BOOST_AUTO_TEST_CASE(mult_scale) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(mult_perm) {
@@ -1368,9 +1436,12 @@ BOOST_AUTO_TEST_CASE(mult_perm) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(mult_scale_perm) {
@@ -1406,9 +1477,12 @@ BOOST_AUTO_TEST_CASE(mult_scale_perm) {
     }
   }
 
-  BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(tr.tiles_range().volume()),
-                    tolerance);
+  BOOST_CHECK_CLOSE(
+      result.sparsity(),
+      tr.tiles_range().volume() > 0
+          ? float(zero_tile_count) / float(tr.tiles_range().volume())
+          : 0,
+      tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(gemm) {
@@ -1470,7 +1544,9 @@ BOOST_AUTO_TEST_CASE(gemm) {
   }
 
   BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(result_norms.size()),
+                    result_norms.size() > 0
+                        ? float(zero_tile_count) / float(result_norms.size())
+                        : 0,
                     tolerance);
 }
 
@@ -1538,7 +1614,9 @@ BOOST_AUTO_TEST_CASE(gemm_perm) {
   }
 
   BOOST_CHECK_CLOSE(result.sparsity(),
-                    float(zero_tile_count) / float(result_norms.size()),
+                    result_norms.size() > 0
+                        ? float(zero_tile_count) / float(result_norms.size())
+                        : 0,
                     tolerance);
 }
 

--- a/tests/sparse_shape.cpp
+++ b/tests/sparse_shape.cpp
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE(block) {
   // change default threshold to make sure it's not inherited
   auto resetter = set_threshold_to_max();
 
-  auto less = std::less<std::size_t>();
+  auto less_equal = std::less_equal<std::size_t>();
 
   for (auto lower_it = tr.tiles_range().begin();
        lower_it != tr.tiles_range().end(); ++lower_it) {
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(block) {
       auto upper = *upper_it;
       for (auto it = upper.begin(); it != upper.end(); ++it) *it += 1;
 
-      if (std::equal(lower.begin(), lower.end(), upper.begin(), less)) {
+      if (std::equal(lower.begin(), lower.end(), upper.begin(), less_equal)) {
         // Check that the block function does not throw an exception
         SparseShape<float> result;
         BOOST_REQUIRE_NO_THROW(result = sparse_shape.block(lower, upper));
@@ -369,7 +369,7 @@ BOOST_AUTO_TEST_CASE(block_scale) {
   // change default threshold to make sure it's not inherited
   auto resetter = set_threshold_to_max();
 
-  auto less = std::less<std::size_t>();
+  auto less_equal = std::less_equal<std::size_t>();
   const float factor = 3.3;
 
   for (auto lower_it = tr.tiles_range().begin();
@@ -381,7 +381,7 @@ BOOST_AUTO_TEST_CASE(block_scale) {
       auto upper = *upper_it;
       for (auto it = upper.begin(); it != upper.end(); ++it) *it += 1;
 
-      if (std::equal(lower.begin(), lower.end(), upper.begin(), less)) {
+      if (std::equal(lower.begin(), lower.end(), upper.begin(), less_equal)) {
         // Check that the block function does not throw an exception
         SparseShape<float> result;
         BOOST_REQUIRE_NO_THROW(result =
@@ -468,7 +468,7 @@ BOOST_AUTO_TEST_CASE(block_perm) {
   // change default threshold to make sure it's not inherited
   auto resetter = set_threshold_to_max();
 
-  auto less = std::less<std::size_t>();
+  auto less_equal = std::less_equal<std::size_t>();
   const auto inv_perm = perm.inv();
 
   for (auto lower_it = tr.tiles_range().begin();
@@ -480,7 +480,7 @@ BOOST_AUTO_TEST_CASE(block_perm) {
       auto upper = *upper_it;
       for (auto it = upper.begin(); it != upper.end(); ++it) *it += 1;
 
-      if (std::equal(lower.begin(), lower.end(), upper.begin(), less)) {
+      if (std::equal(lower.begin(), lower.end(), upper.begin(), less_equal)) {
         // Check that the block function does not throw an exception
         SparseShape<float> result;
         BOOST_REQUIRE_NO_THROW(result = sparse_shape.block(lower, upper, perm));
@@ -569,7 +569,7 @@ BOOST_AUTO_TEST_CASE(block_scale_perm) {
   // change default threshold to make sure it's not inherited
   auto resetter = set_threshold_to_max();
 
-  auto less = std::less<std::size_t>();
+  auto less_equal = std::less_equal<std::size_t>();
   const float factor = 3.3;
   const auto inv_perm = perm.inv();
 
@@ -582,7 +582,7 @@ BOOST_AUTO_TEST_CASE(block_scale_perm) {
       auto upper = *upper_it;
       for (auto it = upper.begin(); it != upper.end(); ++it) *it += 1;
 
-      if (std::equal(lower.begin(), lower.end(), upper.begin(), less)) {
+      if (std::equal(lower.begin(), lower.end(), upper.begin(), less_equal)) {
         // Check that the block function does not throw an exception
         SparseShape<float> result;
         BOOST_REQUIRE_NO_THROW(

--- a/tests/tiled_range.cpp
+++ b/tests/tiled_range.cpp
@@ -58,6 +58,14 @@ BOOST_AUTO_TEST_CASE(constructor) {
     BOOST_CHECK_EQUAL(r1.elements_range().area(), 0);
   }
 
+  // construct with ranges containing empty tiles only
+  {
+    BOOST_REQUIRE_NO_THROW(TiledRange r1({dims[0], TiledRange1{1, 1, 1}}));
+    TiledRange r1{dims[0], TiledRange1{1, 1, 1}};
+    BOOST_CHECK_EQUAL(r1.tiles_range().area(), dims[0].tile_extent() * 2);
+    BOOST_CHECK_EQUAL(r1.elements_range().area(), 0);
+  }
+
   // check initializer list of initializer list constructor
   {
     TiledRange r1{

--- a/tests/tiled_range1.cpp
+++ b/tests/tiled_range1.cpp
@@ -152,6 +152,32 @@ BOOST_AUTO_TEST_CASE(constructor) {
     }
   }
 
+  // corner cases
+  {
+    // range with 1 empty tile
+    {
+      TiledRange1 r{0, 0};
+      BOOST_CHECK_EQUAL(r.tiles_range().first, 0);
+      BOOST_CHECK_EQUAL(r.tiles_range().second, 1);
+      BOOST_CHECK_EQUAL(r.elements_range().first, 0);
+      BOOST_CHECK_EQUAL(r.elements_range().second, 0);
+      BOOST_CHECK(r.tile(0) == Range1(0, 0));
+    }
+    // range with some empty tiles
+    {
+      TiledRange1 r{1, 3, 3, 5, 5};
+      BOOST_CHECK_EQUAL(r.tiles_range().first, 0);
+      BOOST_CHECK_EQUAL(r.tiles_range().second, 4);
+      BOOST_CHECK_EQUAL(r.elements_range().first, 1);
+      BOOST_CHECK_EQUAL(r.elements_range().second, 5);
+      // test tiles
+      BOOST_CHECK(r.tile(0) == Range1(1, 3));
+      BOOST_CHECK(r.tile(1) == Range1(3, 3));
+      BOOST_CHECK(r.tile(2) == Range1(3, 5));
+      BOOST_CHECK(r.tile(3) == Range1(5, 5));
+    }
+  }
+
   // Check that invalid input throws an exception.
 #ifndef NDEBUG
   {
@@ -195,6 +221,20 @@ BOOST_AUTO_TEST_CASE(element_to_tile) {
 
   // Check that the expected and internal element to tile maps match.
   BOOST_CHECK_EQUAL_COLLECTIONS(c.begin(), c.end(), e.begin(), e.end());
+
+  // corner case: empty tiles
+  {
+    // range with some empty tiles
+    {
+      TiledRange1 r{1, 3, 3, 5, 5};
+      BOOST_CHECK_TA_ASSERT(r.element_to_tile(0), Exception);
+      BOOST_CHECK_EQUAL(r.element_to_tile(1), 0);
+      BOOST_CHECK_EQUAL(r.element_to_tile(2), 0);
+      BOOST_CHECK_EQUAL(r.element_to_tile(3), 2);
+      BOOST_CHECK_EQUAL(r.element_to_tile(4), 2);
+      BOOST_CHECK_TA_ASSERT(r.element_to_tile(5), Exception);
+    }
+  }
 }
 
 BOOST_AUTO_TEST_CASE(comparison) {


### PR DESCRIPTION
to simplify composition it would be useful to handle the corner case of zero-volume objects automatically ... this attempt to do that by adding support for
- empty tiles in `TiledRange1` and their use in `TiledRange`
- zero-volume`BlockRange`
- `SparseShape` with for zero-volume `Range`
- `Tensor` with zero-volume range
- expressions involving zero-volume `DistArray`s
- GEMM calls respect the standard API insistence on leading dimension >= 1
