### PR TITLE
`ExternalProject_Add` avoids touching install directory at configure time

### DIFF
--- a/external/eigen.cmake
+++ b/external/eigen.cmake
@@ -103,7 +103,7 @@ else()
   message("** Will build Eigen from ${EIGEN3_URL}")
 
   ExternalProject_Add(eigen3
-    PREFIX ${CMAKE_INSTALL_PREFIX}
+    PREFIX ${FETCHCONTENT_BASE_DIR}
     STAMP_DIR ${FETCHCONTENT_BASE_DIR}/eigen3-ep-artifacts
     TMP_DIR ${FETCHCONTENT_BASE_DIR}/eigen3-ep-artifacts  # needed in case CMAKE_INSTALL_PREFIX is not writable
     #--Download step--------------

--- a/external/eigen.cmake
+++ b/external/eigen.cmake
@@ -104,7 +104,9 @@ else()
 
   ExternalProject_Add(eigen3
     PREFIX ${CMAKE_INSTALL_PREFIX}
-   #--Download step--------------
+    STAMP_DIR ${FETCHCONTENT_BASE_DIR}/eigen3-ep-artifacts
+    TMP_DIR ${FETCHCONTENT_BASE_DIR}/eigen3-ep-artifacts  # needed in case CMAKE_INSTALL_PREFIX is not writable
+    #--Download step--------------
     DOWNLOAD_DIR ${EXTERNAL_SOURCE_DIR}
     URL ${EIGEN3_URL}
     URL_HASH ${EIGEN3_URL_HASH}

--- a/external/librett.cmake
+++ b/external/librett.cmake
@@ -109,7 +109,7 @@ else()
     message(STATUS "custom target librett is expected to build these byproducts: ${LIBRETT_BUILD_BYPRODUCTS}")
 
     ExternalProject_Add(librett
-            PREFIX ${CMAKE_INSTALL_PREFIX}
+            PREFIX ${FETCHCONTENT_BASE_DIR}
             STAMP_DIR ${FETCHCONTENT_BASE_DIR}/librett-ep-artifacts
             TMP_DIR ${FETCHCONTENT_BASE_DIR}/librett-ep-artifacts  # needed in case CMAKE_INSTALL_PREFIX is not writable
             #--Download step--------------

--- a/external/umpire.cmake
+++ b/external/umpire.cmake
@@ -163,7 +163,7 @@ else()
     message(STATUS "custom target Umpire is expected to build these byproducts: ${UMPIRE_BUILD_BYPRODUCTS}")
 
     ExternalProject_Add(Umpire
-            PREFIX ${CMAKE_INSTALL_PREFIX}
+            PREFIX ${FETCHCONTENT_BASE_DIR}
             STAMP_DIR ${FETCHCONTENT_BASE_DIR}/umpire-ep-artifacts
             TMP_DIR ${FETCHCONTENT_BASE_DIR}/umpire-ep-artifacts   # needed in case CMAKE_INSTALL_PREFIX is not writable
             #--Download step--------------


### PR DESCRIPTION
- `eigen3`: `ExternalProject_add` specifies `STAMP_DIR` and `TMP_DIR`
- `eigen3`, `librett`, `umpire`: `ExternalProject_add` uses `FETCHCONTENT_BASE_DIR` as `PREFIX`

resolves #402