### PR TITLE
Implements support for more corner cases involving ToT times T.

### DIFF
--- a/src/TiledArray/tensor/kernels.h
+++ b/src/TiledArray/tensor/kernels.h
@@ -1280,7 +1280,6 @@ auto tensor_hadamard(TensorA const& A, Annot const& aA, TensorB const& B,
   } else {
     auto pA = A.permute(perm.AC);
     return pA.mult_to(B.permute(perm.BC));
-    return pA;
   }
 }
 

--- a/tests/einsum.cpp
+++ b/tests/einsum.cpp
@@ -404,6 +404,26 @@ BOOST_AUTO_TEST_CASE(corner_cases) {
                                            {{0, 3, 5}, {0, 3, 8}},          //
                                            {{0, 3, 8}, {0, 3, 5}, {0, 2}},  //
                                            {3, 9})));
+
+  BOOST_REQUIRE(check_manual_eval<ArrayT>("bi,bi->i",        //
+                                          {{0, 2}, {0, 4}},  //
+                                          {{0, 2}, {0, 4}}));
+
+  BOOST_REQUIRE(check_manual_eval<ArrayToT>("bi;a,bi;a->i;a",  //
+                                            {{0, 2}, {0, 4}},  //
+                                            {{0, 2}, {0, 4}},  //
+                                            {3}, {3}));
+
+  BOOST_REQUIRE(
+      (check_manual_eval<ArrayToT, ArrayT>("jk;a,ijk->i;a",           //
+                                           {{0, 2}, {0, 4}},          //
+                                           {{0, 3}, {0, 2}, {0, 4}},  //
+                                           {5})));
+
+  BOOST_REQUIRE((check_manual_eval<ArrayToT, ArrayT>("bi;a,bi->i;a",       //
+                                                     {{0, 4, 8}, {0, 4}},  //
+                                                     {{0, 4, 8}, {0, 4}},  //
+                                                     {8})));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Specifically, `A(bi;a) * B(bi) -> C(i;a)` kind of evaluations were not supported before this.

Notation: `A` is a ToT with two external modes (`b` and `i`) and an internal mode (`a`).