### PR TITLE
function for element-wise operations with coordinate index

### DIFF
--- a/tests/foreach.cpp
+++ b/tests/foreach.cpp
@@ -119,6 +119,30 @@ BOOST_AUTO_TEST_CASE(foreach_unary) {
   }
 }
 
+BOOST_AUTO_TEST_CASE(forall_unary) {
+
+  TArrayI result = a.clone();
+  forall (result, [](TensorI& tile, Range::index_type &coord_idx) {
+    if (coord_idx[0] < coord_idx[1]) 
+      tile[coord_idx] = coord_idx[0] * tile[coord_idx];
+    else
+      tile[coord_idx] = coord_idx[1] * tile[coord_idx];
+  }, true);
+
+  for (auto index : *result.pmap()) {
+    TensorI tile0 = a.find(index).get();
+    TensorI tile = result.find(index).get();
+    const Range &range = tile0.range();
+    for (std::size_t i = 0; i < tile.size(); ++i) {
+      const Range::index_type &coord_idx = range.idx(i);
+      if (coord_idx[0] < coord_idx[1])
+        BOOST_CHECK_EQUAL(tile[i], coord_idx[0] * tile0[i]);
+      else
+        BOOST_CHECK_EQUAL(tile[i], coord_idx[1] * tile0[i]);
+    }
+  }
+}
+
 BOOST_AUTO_TEST_CASE(foreach_unary_sparse) {
   TSpArrayI result =
       foreach (c, [](TensorI& result, const TensorI& arg) -> float {


### PR DESCRIPTION
Adds a function `forall` that behaves like `foreach_inplace`, but also passes in the coordinate index with each tile. I've used this code in my projects with tiledarray to cleanly extract, fill, and modify the upper diagonal elements of a tiledarray object.

The function uses `foreach_inplace` and a recursive loop for iteration. The recursion helps the user focus on element-wise operations without explicitly creating loops for each dimension that use the `lobound` and `upbound` of each tile.

I added a test in `tests/foreach.cpp` to show its usage and ensure it works as intended. If you find this feature useful and everything looks good, feel free to merge. If this feature already exists elsewhere, please let me know. Thank you for your consideration!