### PR TITLE
gemm examples support nonuniform tiling

### DIFF
--- a/examples/device/ta_cc_abcd_device.cpp
+++ b/examples/device/ta_cc_abcd_device.cpp
@@ -182,8 +182,8 @@ void cc_abcd(TA::World& world, const TA::TiledRange1& trange_occ,
   const double flops_per_fma =
       (complex_T ? 8 : 2);  // 1 multiply takes 6/1 flops for complex/real
                             // 1 add takes 2/1 flops for complex/real
-  const double n_gflop = flops_per_fma * std::pow(n_occ, 2) *
-                         std::pow(n_uocc, 4) / std::pow(1024., 3);
+  const double n_gflop =
+      flops_per_fma * std::pow(n_occ, 2) * std::pow(n_uocc, 4) / 1e9;
 
   using deviceTile =
       btas::Tensor<T, TA::Range, TiledArray::device_um_btas_varray<T>>;

--- a/examples/device/ta_dense_device.cpp
+++ b/examples/device/ta_dense_device.cpp
@@ -36,10 +36,6 @@ void do_main_body(TiledArray::World &world, const long Nm, const long Bm,
   using RT = TiledArray::detail::scalar_t<Storage>;
   constexpr auto complex_T = TiledArray::detail::is_complex_v<T>;
 
-  const std::size_t Tm = Nm / Bm;
-  const std::size_t Tn = Nn / Bn;
-  const std::size_t Tk = Nk / Bk;
-
   const std::int64_t nflops =
       (complex_T ? 8 : 2)  // 1 multiply takes 6/1 flops for complex/real
                            // 1 add takes 2/1 flops for complex/real
@@ -64,16 +60,16 @@ void do_main_body(TiledArray::World &world, const long Nm, const long Bm,
 
   // Construct TiledRange
   std::vector<unsigned int> blocking_m;
-  blocking_m.reserve(Tm + 1);
   for (long i = 0l; i <= Nm; i += Bm) blocking_m.push_back(i);
+  const std::size_t Tm = blocking_m.size() - 1;
 
   std::vector<unsigned int> blocking_n;
-  blocking_n.reserve(Tn + 1);
   for (long i = 0l; i <= Nn; i += Bn) blocking_n.push_back(i);
+  const std::size_t Tn = blocking_n.size() - 1;
 
   std::vector<unsigned int> blocking_k;
-  blocking_k.reserve(Tk + 1);
   for (long i = 0l; i <= Nk; i += Bk) blocking_k.push_back(i);
+  const std::size_t Tk = blocking_k.size();
 
   // Structure of c
   std::vector<TiledArray::TiledRange1> blocking_C;
@@ -253,11 +249,6 @@ int try_main(int argc, char **argv) {
   }
   if (Bm <= 0 || Bn <= 0 || Bk <= 0) {
     std::cerr << "Error: block sizes must be greater than zero.\n";
-    return 1;
-  }
-  if ((Nm % Bm) != 0ul || Nn % Bn != 0ul || Nk % Bk != 0ul) {
-    std::cerr
-        << "Error: dimension size must be evenly divisible by block size.\n";
     return 1;
   }
   const long nrepeat = (argc >= 8 ? atol(argv[7]) : 5);

--- a/examples/gemm/ta_cc_abcd.cpp
+++ b/examples/gemm/ta_cc_abcd.cpp
@@ -211,8 +211,8 @@ void cc_abcd(TA::World& world, const TA::TiledRange1& trange_occ,
   const double flops_per_fma =
       (complex_T ? 8 : 2);  // 1 multiply takes 6/1 flops for complex/real
                             // 1 add takes 2/1 flops for complex/real
-  const double gflops_per_call = flops_per_fma * std::pow(n_occ, 2) *
-                                 std::pow(n_uocc, 4) / std::pow(1024., 3);
+  const double gflops_per_call =
+      flops_per_fma * std::pow(n_occ, 2) * std::pow(n_uocc, 4) / 1e9;
 
   // Construct tensors
   TA::TArrayD t2(world, trange_oovv);

--- a/examples/gemm/ta_cc_abcd.cpp
+++ b/examples/gemm/ta_cc_abcd.cpp
@@ -72,7 +72,7 @@ int main(int argc, char** argv) {
 
     // Get command line arguments
     if (argc < 5) {
-      std::cout << "Mocks t2(i,a,j,b) * v(a,b,c,d) term in CC amplitude eqs"
+      std::cout << "Mocks t2(i,j,a,b) * v(a,b,c,d) term in CC amplitude eqs"
                 << std::endl
                 << "Usage: " << argv[0]
                 << " occ_size occ_nblocks uocc_size "

--- a/examples/gemm/ta_cc_abcd.cpp
+++ b/examples/gemm/ta_cc_abcd.cpp
@@ -256,6 +256,7 @@ void cc_abcd(TA::World& world, const TA::TiledRange1& trange_occ,
                   << error("i,j,a,b").squared_norm().get() << std::endl;
       }
     }
+    t2_v.world().gop.fence();
     TiledArray::record_duration_since(tp_start);
 
     const double time = TiledArray::durations().back();

--- a/examples/gemm/ta_dense_asymm.cpp
+++ b/examples/gemm/ta_dense_asymm.cpp
@@ -50,11 +50,6 @@ int main(int argc, char** argv) {
     std::cerr << "Error: block sizes must be greater than zero.\n";
     return 1;
   }
-  if ((Nm % Bm) != 0ul || Nn % Bn != 0ul || Nk % Bk != 0ul) {
-    std::cerr
-        << "Error: dimension size must be evenly divisible by block size.\n";
-    return 1;
-  }
   const long repeat = (argc >= 8 ? atol(argv[7]) : 5);
   if (repeat <= 0) {
     std::cerr << "Error: number of repetitions must be greater than zero.\n";
@@ -72,22 +67,22 @@ int main(int argc, char** argv) {
 
   const bool do_memtrace = (argc >= 10 ? std::atol(argv[9]) : false);
 
-  const std::size_t Tm = Nm / Bm;
-  const std::size_t Tn = Nn / Bn;
-  const std::size_t Tk = Nk / Bk;
-
   // Construct TiledRange
   std::vector<unsigned int> blocking_m;
-  blocking_m.reserve(Tm + 1);
   for (long i = 0l; i <= Nm; i += Bm) blocking_m.push_back(i);
+  if (blocking_m.back() != Nm) blocking_m.push_back(Nm);
 
   std::vector<unsigned int> blocking_n;
-  blocking_n.reserve(Tn + 1);
   for (long i = 0l; i <= Nn; i += Bn) blocking_n.push_back(i);
+  if (blocking_n.back() != Nn) blocking_n.push_back(Nn);
 
   std::vector<unsigned int> blocking_k;
-  blocking_k.reserve(Tk + 1);
   for (long i = 0l; i <= Nk; i += Bk) blocking_k.push_back(i);
+  if (blocking_k.back() != Nk) blocking_k.push_back(Nk);
+
+  const std::size_t Tm = blocking_m.size() - 1;
+  const std::size_t Tn = blocking_n.size() - 1;
+  const std::size_t Tk = blocking_k.size() - 1;
 
   // Structure of c
   std::vector<TiledArray::TiledRange1> blocking_C;
@@ -138,13 +133,13 @@ int main(int argc, char** argv) {
                 << "\nScalar type       = " << scalar_type_str
                 << "\nSize of A         = " << Nm << "x" << Nk << " ("
                 << double(Nm * Nk * sizeof(T)) / 1.0e9 << " GB)"
-                << "\nSize of A block   = " << Bm << "x" << Bk
+                << "\nSize of (largest) A block   = " << Bm << "x" << Bk
                 << "\nSize of B         = " << Nk << "x" << Nn << " ("
                 << double(Nk * Nn * sizeof(T)) / 1.0e9 << " GB)"
-                << "\nSize of B block   = " << Bk << "x" << Bn
+                << "\nSize of (largest) B block   = " << Bk << "x" << Bn
                 << "\nSize of C         = " << Nm << "x" << Nn << " ("
                 << double(Nm * Nn * sizeof(T)) / 1.0e9 << " GB)"
-                << "\nSize of C block   = " << Bm << "x" << Bn
+                << "\nSize of (largest) C block   = " << Bm << "x" << Bn
                 << "\n# of blocks of C  = " << Tm * Tn
                 << "\nAverage # of blocks of C/node = "
                 << double(Tm * Tn) / double(world.size()) << "\n";

--- a/examples/gemm/ta_dense_asymm.cpp
+++ b/examples/gemm/ta_dense_asymm.cpp
@@ -148,10 +148,11 @@ int main(int argc, char** argv) {
       if (do_memtrace) {
         world.gop.fence();
         madness::print_meminfo(world.rank(), str);
+      } else {
+        world.gop.fence();
       }
 #ifdef TA_TENSOR_MEM_PROFILE
       {
-        world.gop.fence();
         std::cout
             << str << ": TA::Tensor allocated "
             << TA::hostEnv::instance()->host_allocator_getActualHighWatermark()


### PR DESCRIPTION
{`ta_dense_asymm`,`ta_cc_abcd`,`ta_dense_device`} support nonuniform tiling. `ta_cc_abcd` also supports non-`double` scalar types.