### PR TITLE
singleToDoublePrecPerfRatio hip device property does not exist before…

### DIFF
--- a/examples/device/ta_dense_device.cpp
+++ b/examples/device/ta_dense_device.cpp
@@ -315,9 +315,7 @@ int try_main(int argc, char **argv) {
           std::cout << "error(GetDeviceProperties) = " << error << std::endl;
         }
         std::cout << "Device #" << device_id << ": " << prop.name << std::endl
-                  << "  managedMemory = " << prop.managedMemory << std::endl
-                  << "  singleToDoublePrecisionPerfRatio = "
-                  << prop.singleToDoublePrecisionPerfRatio << std::endl;
+                  << "  managedMemory = " << prop.managedMemory << std::endl;
         int result;
         error = TiledArray::device::deviceGetAttribute(
             &result, TiledArray::device::DevAttrUnifiedAddressing, device_id);


### PR DESCRIPTION
singleToDoublePrecPerfRatio hip device property does not exist before hip 6.0.0, and is depreciated in latest hip