### PR TITLE
Powellsr/fix/debug attach handling

### DIFF
--- a/src/TiledArray/util/bug.cpp
+++ b/src/TiledArray/util/bug.cpp
@@ -77,7 +77,6 @@ Debugger::~Debugger() {
   for (int i = 0; i < NSIG; i++) {
     if (mysigs_[i]) signals[i] = nullptr;
   }
-  delete[] mysigs_;
 }
 
 void Debugger::init() {
@@ -91,7 +90,7 @@ void Debugger::init() {
   debug_ = 1;
   wait_for_debugger_ = 1;
 
-  mysigs_ = new int[NSIG];
+  mysigs_ = std::make_unique<int[]>(NSIG);
   for (int i = 0; i < NSIG; i++) {
     mysigs_[i] = 0;
   }
@@ -187,13 +186,9 @@ const std::string Debugger::lldb_cmd_ =
 
 void Debugger::resolve_cmd_alias() {
   if (cmd_ == "gdb_xterm") {
-    cmd_ =
-        "xterm -title \"$(PREFIX)$(EXEC)\" -e gdb -ex \"set variable "
-        "debugger_ready_=1\" --pid=$(PID) $(EXEC) &";
+    cmd_ = "xterm -title \"$(PREFIX)$(EXEC)\" -e " + gdb_cmd_ + " &";
   } else if (cmd_ == "lldb_xterm") {
-    cmd_ =
-        "xterm -title \"$(PREFIX)$(EXEC)\" -e lldb -p $(PID) -o \"expr "
-        "debugger_ready_=1\" &";
+    cmd_ = "xterm -title \"$(PREFIX)$(EXEC)\" -e " + lldb_cmd_ + " &";
   }
 }
 
@@ -222,10 +217,10 @@ std::string Debugger::replace_macros(std::string str) {
 void Debugger::set_cmd(const char *cmd) {
   if (cmd) {
     cmd_ = cmd;
-    resolve_cmd_alias();
   } else {
     cmd_.resize(0);
   }
+  this->resolve_cmd_alias();
 }
 
 void Debugger::debug(const char *reason) {
@@ -236,80 +231,50 @@ void Debugger::debug(const char *reason) {
     std::cout << "no reason given";
   std::cout << std::endl;
 
-  if (!cmd_.empty()) {
-    int pid = getpid();
-    // contruct the command name
-    std::string cmd = cmd_;
-    std::string::size_type pos;
-    std::string pidvar("$(PID)");
-    while ((pos = cmd.find(pidvar)) != std::string::npos) {
-      std::string pidstr;
-      pidstr += std::to_string(pid);
-      cmd.replace(pos, pidvar.size(), pidstr);
-    }
-    std::string execvar("$(EXEC)");
-    while ((pos = cmd.find(execvar)) != std::string::npos) {
-      cmd.replace(pos, execvar.size(), exec_);
-    }
-    std::string prefixvar("$(PREFIX)");
-    while ((pos = cmd.find(prefixvar)) != std::string::npos) {
-      cmd.replace(pos, prefixvar.size(), prefix_);
-    }
 
-    // start the debugger
-    // before starting the debugger de-register signal handler for SIGTRAP to
-    // let the debugger take over
-    release(SIGTRAP);
+  const std::string cmd = replace_macros(cmd_);
+  // start the debugger
+  // before starting the debugger de-register signal handler for SIGTRAP to
+  // let the debugger take over
+  release(SIGTRAP);
+  int system_retvalue = 0;
+  if (!cmd.empty()) {
     std::cout << prefix_ << "Debugger: starting \"" << cmd << "\"" << std::endl;
-    debugger_ready_ = 0;
-    const auto system_retvalue = system(cmd.c_str());
-    if (system_retvalue != 0) {  // call to system() failed
-      std::cout << prefix_
-                << "Failed debugger launch: system() did not succeed ..."
-                << std::endl;
-    } else {  // call to system() succeeded
-      // wait until the debugger is ready
-      if (sleep_) {
-        std::cout << prefix_ << "Sleeping " << sleep_
-                  << " seconds to wait for debugger ..." << std::endl;
-        sleep(sleep_);
-      }
-      if (wait_for_debugger_) {
-        std::string make_ready_message;
-        if (cmd_.find(" gdb ") != std::string::npos ||
-            cmd_.find(" lldb ") != std::string::npos) {
-          make_ready_message =
-              " configure debugging session (set breakpoints/watchpoints, "
-              "etc.) then type 'c' to continue running";
-        }
-
-        std::cout << prefix_ << ": waiting for the user ..."
-                  << make_ready_message << std::endl;
-        while (!debugger_ready_)
-          ;
-      }
-    }
-  } // Here, need handling of cmd_ empty
-  if (sleep_) {
-    std::cout << prefix_ << "Debugger: sleeping " << sleep_
-                  << " seconds to wait for debugger ..." << std::endl;
-    sleep(sleep_);
+    system_retvalue = system(cmd.c_str());
   }
-  if (wait_for_debugger_) {
-    std::cout << prefix_ << "Debugger: waiting for the user ...";
-    if (cmd_.empty()) {
-      std::cout << " attach debugger to process "
-                    << std::to_string(getpid())
-                    << " as follows:" << std::endl
-                    << prefix_ << "Debugger: - if using  gdb: "
-                    << replace_macros(gdb_cmd_) << std::endl
-                    << prefix_ << "Debugger: - if using lldb: "
-                    << replace_macros(lldb_cmd_);
+  if (system_retvalue != 0) {
+    ExEnv::outn() << prefix_
+                  << "Failed debugger launch: system() did not succeed ..."
+                  << std::endl;
+  } else { // call to system() succeeded
+    // wait until the debugger is ready
+    if (sleep_) {
+      std::cout << prefix_ << "Debugger: sleeping " << sleep_
+                << " seconds to wait for debugger ..." << std::endl;
+      sleep(sleep_);
     }
+    if (wait_for_debugger_) {
+      std::cout << prefix_ << "Debugger: waiting for the user ...";
+      if (cmd_.find(" gdb ") != std::string::npos ||
+          cmd_.find(" lldb ") != std::string::npos) {
+        std::cout <<
+            " configure debugging session (set breakpoints/watchpoints, "
+            "etc.) then type 'c' to continue running";
+      } else if (cmd.empty()) {
+        std::cout << " attach debugger to process "
+                  << std::to_string(getpid())
+                  << " as follows:" << std::endl
+                  << prefix_ << "Debugger: - if using  gdb: "
+                  << replace_macros(gdb_cmd_) << std::endl
+                  << prefix_ << "Debugger: - if using lldb: "
+                  << replace_macros(lldb_cmd_);
+      }
+      std::cout << std::endl;
 
-    std::cout << prefix_ << ": waiting for the user ..." << std::endl;
-    while (!debugger_ready_)
-      ;
+      debugger_ready_ = 0;
+      while (!debugger_ready_)
+        ;
+    }
   }
 }
 
@@ -334,6 +299,10 @@ void Debugger::got_signal(int sig) {
   else
     signame = "UNKNOWN SIGNAL";
 
+  for (auto const &action: actions_) {
+    action();
+  }
+  actions_.clear();
   if (traceback_) {
     traceback(signame);
   }
@@ -401,6 +370,10 @@ void Debugger::__traceback(const std::string &prefix, const char *reason) {
               << std::endl;
   else
     std::cout << result.str(nframes_to_skip) << std::endl;
+}
+
+void Debugger::register_prelaunch_action(std::function<void()> action) {
+  actions_.push_back(action);
 }
 
 void create_debugger(const char *cmd, const char *exec, std::int64_t rank) {

--- a/src/TiledArray/util/bug.cpp
+++ b/src/TiledArray/util/bug.cpp
@@ -105,14 +105,14 @@ static void handler(int sig) {
 void Debugger::handle(int sig) {
   if (sig >= NSIG) return;
   typedef void (*handler_type)(int);
-  signal(sig, (handler_type)handler);
+  std::signal(sig, (handler_type)handler);
   signals[sig] = this;
   mysigs_[sig] = 1;
 }
 
 void Debugger::release(int sig) {
   if (sig >= NSIG) return;
-  signal(sig, SIG_DFL);
+  std::signal(sig, SIG_DFL);
   signals[sig] = nullptr;
   mysigs_[sig] = 0;
 }
@@ -231,7 +231,6 @@ void Debugger::debug(const char *reason) {
     std::cout << "no reason given";
   std::cout << std::endl;
 
-
   const std::string cmd = replace_macros(cmd_);
   // start the debugger
   // before starting the debugger de-register signal handler for SIGTRAP to
@@ -240,13 +239,13 @@ void Debugger::debug(const char *reason) {
   int system_retvalue = 0;
   if (!cmd.empty()) {
     std::cout << prefix_ << "Debugger: starting \"" << cmd << "\"" << std::endl;
-    system_retvalue = system(cmd.c_str());
+    system_retvalue = std::system(cmd.c_str());
   }
   if (system_retvalue != 0) {
     std::cout << prefix_
-                  << "Failed debugger launch: system() did not succeed ..."
-                  << std::endl;
-  } else { // call to system() succeeded
+              << "Failed debugger launch: system() did not succeed ..."
+              << std::endl;
+  } else {  // call to system() succeeded
     // wait until the debugger is ready
     if (sleep_) {
       std::cout << prefix_ << "Debugger: sleeping " << sleep_
@@ -257,17 +256,17 @@ void Debugger::debug(const char *reason) {
       std::cout << prefix_ << "Debugger: waiting for the user ...";
       if (cmd_.find(" gdb ") != std::string::npos ||
           cmd_.find(" lldb ") != std::string::npos) {
-        std::cout <<
-            " configure debugging session (set breakpoints/watchpoints, "
-            "etc.) then type 'c' to continue running";
+        std::cout
+            << " configure debugging session (set breakpoints/watchpoints, "
+               "etc.) then type 'c' to continue running";
       } else if (cmd.empty()) {
-        std::cout << " attach debugger to process "
-                  << std::to_string(getpid())
+        std::cout << " attach debugger to process " << std::to_string(getpid())
                   << " as follows:" << std::endl
-                  << prefix_ << "Debugger: - if using  gdb: "
-                  << replace_macros(gdb_cmd_) << std::endl
-                  << prefix_ << "Debugger: - if using lldb: "
-                  << replace_macros(lldb_cmd_);
+                  << prefix_
+                  << "Debugger: - if using  gdb: " << replace_macros(gdb_cmd_)
+                  << std::endl
+                  << prefix_
+                  << "Debugger: - if using lldb: " << replace_macros(lldb_cmd_);
       }
       std::cout << std::endl;
 
@@ -299,7 +298,7 @@ void Debugger::got_signal(int sig) {
   else
     signame = "UNKNOWN SIGNAL";
 
-  for (auto const &action: actions_) {
+  for (auto const &action : actions_) {
     action();
   }
   actions_.clear();

--- a/src/TiledArray/util/bug.cpp
+++ b/src/TiledArray/util/bug.cpp
@@ -243,7 +243,7 @@ void Debugger::debug(const char *reason) {
     system_retvalue = system(cmd.c_str());
   }
   if (system_retvalue != 0) {
-    ExEnv::outn() << prefix_
+    std::cout << prefix_
                   << "Failed debugger launch: system() did not succeed ..."
                   << std::endl;
   } else { // call to system() succeeded

--- a/src/TiledArray/util/bug.h
+++ b/src/TiledArray/util/bug.h
@@ -395,9 +395,10 @@ class Debugger {
   /// \param cmd a string
   /// \return processed str
   std::string replace_macros(std::string cmd);
+
   static const std::string gdb_cmd_;
   static const std::string lldb_cmd_;
-  std::vector<std::function<void()>> actions_; // prelaunch actions
+  std::vector<std::function<void()>> actions_;  // prelaunch actions
 };
 
 /// Use this to create a Debugger object and make it the default

--- a/src/TiledArray/util/bug.h
+++ b/src/TiledArray/util/bug.h
@@ -30,6 +30,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/src/TiledArray/util/bug.h
+++ b/src/TiledArray/util/bug.h
@@ -384,6 +384,9 @@ class Debugger {
  private:
   /// Replaces alias in cmd_ with its full form
   void resolve_cmd_alias();
+  std::string replace_macros(std::string cmd);
+  static const std::string gdb_cmd_;
+  static const std::string lldb_cmd_;
 };
 
 /// Use this to create a Debugger object and make it the default


### PR DESCRIPTION
Mostly followed MPQC version, didn't use HAVE_SYSTEM macro, as it doesn't appear to be defined in TA code. 
system_retvalue, ~ bug.cpp:240 may not be used correctly in MPQC. It's defined as zero and never changed; the system call return value is assigned to another var, which is cast to void (which I learned silences compiler warnings, is there a reason for this?