### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -225,7 +225,7 @@ if(HIP_FOUND OR CUDA_FOUND)
        TiledArray/external/cuda.h
        TiledArray/device/cpu_cuda_vector.h)
   endif(CUDA_FOUND)
-endif(CUDA_FOUND OR HIP_FOUND)
+endif(HIP_FOUND OR CUDA_FOUND)
 
 set(TILEDARRAY_SOURCE_FILES
 TiledArray/tiledarray.cpp


### PR DESCRIPTION
Silences a CMake warning.

```
CMake Warning (dev) in cmake-build-release/_deps/tiledarray-src/src/CMakeLists.txt:
  A logical block opening on the line

    /Users/jonathonmisiewicz/Downloads/mpqc4/cmake-build-release/_deps/tiledarray-src/src/CMakeLists.txt:207 (if)

  closes on the line

    /Users/jonathonmisiewicz/Downloads/mpqc4/cmake-build-release/_deps/tiledarray-src/src/CMakeLists.txt:228 (endif)

  with mis-matching arguments.
```