### PR TITLE
Make sure namespace device is always closed

### DIFF
--- a/src/TiledArray/external/device.h
+++ b/src/TiledArray/external/device.h
@@ -915,9 +915,9 @@ inline umpire::Allocator& get_pinned_allocator::operator()() {
   return deviceEnv::instance()->pinned_allocator();
 }
 
-}  // namespace detail
-
 #endif  // TILEDARRAY_HAS_DEVICE
+
+}  // namespace detail
 
 #ifdef TILEDARRAY_HAS_CUDA
 namespace nvidia {


### PR DESCRIPTION
Even if TILEDARRAY_HAS_DEVICE is not defined