### PR TITLE
"namespace" `ENABLE_{CUDA,HIP,SCALAPACK,WFN91_LINALG_DISCOVERY_KIT}` CMake variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         -DMPIEXEC_PREFLAGS='--bind-to;none;--allow-run-as-root'
         -DCMAKE_PREFIX_PATH="/usr/local/opt/bison;/usr/local/opt/scalapack;/usr/local/opt/boost"
         -DTA_ASSERT_POLICY=TA_ASSERT_THROW
-        -DENABLE_SCALAPACK=ON
+        -DTA_SCALAPACK=ON
 
     steps:
     - uses: actions/checkout@v4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ variables:
     CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda
     ${BLA_VENDOR}
     ${BLA_THREADS}
-    ${ENABLE_SCALAPACK}
+    ${TA_SCALAPACK}
 
 before_script:
   # NB: if CMAKE_BUILD_PARALLEL_LEVEL is not set (i.e. using shared runner), use 1 to ensure we have enough memory
@@ -42,7 +42,7 @@ ubuntu:
   image: valeevgroup/${IMAGE}
   variables:
     TA_PYTHON : "TA_PYTHON=ON"
-    ENABLE_SCALAPACK : "ENABLE_SCALAPACK=OFF"
+    TA_SCALAPACK : "TA_SCALAPACK=OFF"
   script:
     - ./ci/.build-project
         --build ./build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ variables:
     TA_ASSERT_POLICY=TA_ASSERT_THROW
     TA_UT_CTEST_TIMEOUT=3000
     ${TA_PYTHON}
-    ${ENABLE_CUDA}
+    ${TA_CUDA}
     CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda
     ${BLA_VENDOR}
     ${BLA_THREADS}
@@ -69,7 +69,7 @@ ubuntu:
         CXX: [ g++ ]
         BUILD_TYPE : [ "RelWithDebInfo" ]
         TA_PYTHON : [ "TA_PYTHON=OFF" ]
-        ENABLE_CUDA : [ "ENABLE_CUDA=ON" ]
+        TA_CUDA : [ "TA_CUDA=ON" ]
         TA_TARGETS : [ "tiledarray examples-tiledarray check_serial-tiledarray" ]
         RUNNER_TAGS: [ cuda ]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,20 +117,17 @@ set(MPI_CXX_SKIP_MPICXX TRUE CACHE BOOL "MPI_CXX_SKIP_MPICXX")
 option(ENABLE_MPI "Enable MPI" ON)
 add_feature_info(MPI ENABLE_MPI "Message-Passing Interface supports distributed-memory parallel programs")
 
-option(ENABLE_SCALAPACK "Enable ScaLAPACK Bindings in TiledArray" OFF)
-add_feature_info(ScaLAPACK ENABLE_SCALAPACK "ScaLAPACK provides distributed linear algebra")
+option(TA_SCALAPACK "Enable ScaLAPACK Bindings in TiledArray" OFF)
+add_feature_info(ScaLAPACK TA_SCALAPACK "ScaLAPACK provides distributed linear algebra")
 
-option(ENABLE_WFN91_LINALG_DISCOVERY_KIT "Use linear algebra discovery kit from github.com/wavefunction91 [recommended]" ON)
-add_feature_info(WFN91LinearAlgebraDiscoveryKit ENABLE_WFN91_LINALG_DISCOVERY_KIT "Linear algebra discovery kit from github.com/wavefunction91 supports many more corner cases than the default CMake modules and/or ICL's BLAS++/LAPACK++ modules")
+option(TA_LINALG_DISCOVERY_KIT "Use linear algebra discovery kit from github.com/wavefunction91 [recommended]" ON)
+add_feature_info(WFN91LinearAlgebraDiscoveryKit TA_LINALG_DISCOVERY_KIT "Linear algebra discovery kit from github.com/wavefunction91 supports many more corner cases than the default CMake modules and/or ICL's BLAS++/LAPACK++ modules")
 
-redefaultable_option(ENABLE_TBB "Enable use of TBB with MADNESS" OFF)
-add_feature_info(TBB ENABLE_TBB "Intel Thread-Building Blocks (TBB) supports programming shared-memory systems")
+option(TA_CUDA "Enables use of NVIDIA CUDA-supported hardware (such as NVIDIA GPUs) by TiledArray" OFF)
+add_feature_info(CUDA TA_CUDA "Use of NVIDIA CUDA-supported hardware by TiledArray")
 
-option(ENABLE_CUDA "Enable use of CUDA with TiledArray" OFF)
-add_feature_info(CUDA ENABLE_CUDA "NVIDIA CUDA support for GPU")
-
-option(ENABLE_HIP "Enable use of HIP with TiledArray" OFF)
-add_feature_info(HIP ENABLE_HIP "AMD HIP/ROCm support for GPU")
+option(TA_HIP "Enables use of AMD HIP-supported hardware (such as AMD GPUs) by TiledArray" OFF)
+add_feature_info(HIP TA_HIP "Use of AMD HIP-supported hardware by TiledArray")
 
 option(ENABLE_GPERFTOOLS "Enable linking with Gperftools" OFF)
 add_feature_info(GPERFTOOLS ENABLE_GPERFTOOLS "Google Performance Tools provide fast memory allocation and performance profiling")
@@ -310,10 +307,10 @@ endif(CCACHE)
 
 # required deps:
 # 1. derive runtime (CUDA/HIP/...) first since others may depend on it
-if(ENABLE_CUDA)
+if(TA_CUDA)
   include(external/cuda.cmake)
 endif()
-if(ENABLE_HIP)
+if(TA_HIP)
   include(external/hip.cmake)
 endif()
 include(${PROJECT_SOURCE_DIR}/cmake/modules/FindOrFetchRangeV3.cmake)
@@ -334,14 +331,14 @@ include(external/umpire.cmake)
 # - yes => Invoke first to configure the correct libraries config and run modules to find BLAS/LAPACK/ScaLAPACK(if needed)
 # - no  => BLAS/LAPACK will be discovered by BLAS++/LAPACK++ (loaded by BTAS) which use standard CMake modules or
 #          their custom modules; if needed, ScaLAPACK will be discovered by BLACS++
-if (ENABLE_WFN91_LINALG_DISCOVERY_KIT)
+if (TA_LINALG_DISCOVERY_KIT)
   include(FetchWfn91LinAlgModules)
   include(FindLinalg)
-endif(ENABLE_WFN91_LINALG_DISCOVERY_KIT)
+endif(TA_LINALG_DISCOVERY_KIT)
 # Boost is to be discovered by the top cmake project, and every (sub)project needs to make sure it has all of its targets
 include(external/boost.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/modules/FindOrFetchBTAS.cmake)
-if(ENABLE_SCALAPACK)
+if(TA_SCALAPACK)
   include(external/scalapackpp.cmake)
 endif()
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -200,8 +200,8 @@ ASLR is a standard technique for increasing platform security implemented by the
 * `CMAKE_POSITION_INDEPENDENT_CODE` -- This standard CMake variable controls whether targets are compiled by default as position-independent code or not. If `BUILD_SHARED_LIBS=OFF` need to set this to `ON` if want to use the TiledArray libraries to build shared libraries or position-independent executables.
 
 To make things more concrete, consider the following 2 scenarios:
-* Platform with ASLR disabled -- set `TA_ASSUMES_ASLR_DISABLED=ON` to set the defaults correctly and enable the ASLR check. `BUILD_SHARED_LIBS` can be set to `ON` (to produce shared TA/MADworld libraries, e.g., to minimize the executable size) or to `OFF` to produce static libraries. If the TA+MADworld static libraries will be linked into shared libraries set `CMAKE_POSITION_INDEPENDENT_CODE=ON`, otherwise `CMAKE_POSITION_INDEPENDENT_CODE` will be set to OFF for maximum efficiency of function calls.
-* Platform with ASLR enabled -- this is the default. Setting `BUILD_SHARED_LIBS=ON` in this scenario will produce executables that can only be safely used with 1 MPI rank, thus `BUILD_SHARED_LIBS` will be defaulted to OFF (i.e. TA+MADworld libraries will be built as static libraries). `CMAKE_POSITION_INDEPENDENT_CODE` is by default set to `ON`, thus TA+MADworld libraries can be linked into position-independent executables safely. TA+MADworld libraries can also be linked into a shared library, provided that *ALL* code using TA+MADworld is part of the *SAME* shared library. E.g. to link TA+MADworld into a Python module compile TA+MADworld libraries and their dependents as static libraries (with `CMAKE_POSITION_INDEPENDENT_CODE=ON`) and link them all together into a single module (same logic applies to shared libraries using TA+MADworld).
+* Platform with ASLR disabled -- set `TA_ASSUMES_ASLR_DISABLED=ON` to set the defaults correctly and enable the ASLR check. `BUILD_SHARED_LIBS` can be set to `ON` (to produce shared TA/MADworld libraries, e.g., to minimize the executable size) or to `OFF` to produce static libraries. If the TA+MADworld static libraries will be linked into shared libraries set `CMAKE_POSITION_INDEPENDENT_CODE=ON`, otherwise `CMAKE_POSITION_INDEPENDENT_CODE` will be set to `OFF` for maximum efficiency of function calls.
+* Platform with ASLR enabled -- this is the default. Setting `BUILD_SHARED_LIBS=ON` in this scenario will produce executables that can only be safely used with 1 MPI rank, thus `BUILD_SHARED_LIBS` will be defaulted to `OFF` (i.e. TA+MADworld libraries will be built as static libraries). `CMAKE_POSITION_INDEPENDENT_CODE` is by default set to `ON`, thus TA+MADworld libraries can be linked into position-independent executables safely. TA+MADworld libraries can also be linked into a shared library, provided that *ALL* code using TA+MADworld is part of the *SAME* shared library. E.g. to link TA+MADworld into a Python module compile TA+MADworld libraries and their dependents as static libraries (with `CMAKE_POSITION_INDEPENDENT_CODE=ON`) and link them all together into a single module (same logic applies to shared libraries using TA+MADworld).
 
 ## MPI
 
@@ -212,7 +212,7 @@ following CMake cache variables:
 * MPI_C_COMPILER -- The MPI C compiler wrapper
 * MPI_CXX_COMPILER -- The MPI C++ compiler wrapper
 
-You can build TiledArray without MPI support by setting ENABLE_MPI to OFF.
+You can build TiledArray without MPI support by setting `ENABLE_MPI` to `OFF`.
 Though we strongly recommend compiling with MPI even if you do not intend
 to use TiledArray in a distributed memory environment. Note, if you
 build MADNESS yourself, you must also configure MADNESS with `ENABLE_MPI=OFF`
@@ -236,7 +236,7 @@ as needed.
 As of version 1.0 TiledArray also provides a direct (non-iterative) linear solvers API
 implemented using LAPACK and (optionally) ScaLAPACK. Therefore LAPACK is now a mandatory
 prerequisite of TiledArray. The use of ScaLAPACK can be enabled by setting CMake cache
-variable `ENABLE_SCALAPACK` to `ON`.
+variable `TA_SCALAPACK` to `ON`.
 
 Robust discovery of linear algebra libraries, and _especially_ their distributed-memory
 variants, is a complex process. Unfortunately even for serial/shared-memory linear
@@ -245,7 +245,7 @@ algebra libraries only basic scenarios are supported by the standard CMake modul
 [LAPACK](https://cmake.org/cmake/help/latest/module/FindLAPACK.html)).
 There are several discovery mechanisms available for robust discovery of linear
 algebra in TA:
-- By specifying the `BLAS_LIBRARIES`, `LAPACK_LIBRARIES`, and (if `ENABLE_SCALAPACK` is on)
+- By specifying the `BLAS_LIBRARIES`, `LAPACK_LIBRARIES`, and (if `TA_SCALAPACK` is on)
   `ScaLAPACK_LIBRARIES` CMake cache variables via CMake command line or via a toolchain.
   Doing this overrides all other mechanisms of discovery described below and is recommended
   if the discovery fails for some reason. To help with setting these variables for specific
@@ -270,7 +270,7 @@ algebra in TA:
     - `Accelerate`: Apple's Accelerate framework
     - `FLAME`: (LAPACK-only) [libFLAME](https://www.cs.utexas.edu/~flame/web/libFLAME.html)
     *N.B.* These differ from the recognized values of the `BLA_VENDOR` variable used by the [BLAS+LAPACK CMake modules](https://cmake.org/cmake/help/latest/module/FindBLAS.html).
-- If the use of the NWChemEx kit is disabled by setting CMake cache variable `ENABLE_WFN91_LINALG_DISCOVERY_KIT` to `OFF`
+- If the use of the NWChemEx kit is disabled by setting CMake cache variable `TA_LINALG_DISCOVERY_KIT` to `OFF`
   BLAS/LAPACK are imported transitively via the BLAS++/LAPACK++ libraries (which are themselves
   imported transitively via the BTAS library). Under the most common scenario, where TiledArray
   will configure and compile BTAS dependency and its BLAS++/LAPACK++ prerequisites from source
@@ -329,9 +329,9 @@ Also note that even if OpenMP or TBB backends are used, TiledArray will be defau
 
 Support for execution on NVIDIA and AMD GPGPUs is controlled by the following variables:
 
-* `ENABLE_CUDA`  -- Set to `ON` to turn on CUDA support. [Default=OFF].
+* `TA_CUDA`  -- Set to `ON` to turn on CUDA support. [Default=OFF].
 * `CMAKE_CUDA_HOST_COMPILER`  -- Set to the path to the host C++ compiler to be used by CUDA compiler. CUDA compilers used to be notorious for only being able to use specific C++ host compilers, but support for more recent C++ host compilers has improved. The default is determined by the CUDA compiler and the user environment variables (`PATH` etc.).
-* `ENABLE_HIP`  -- Set to `ON` to turn on HIP/ROCm support. [Default=OFF].
+* `TA_HIP`  -- Set to `ON` to turn on HIP/ROCm support. [Default=OFF].
 * `LIBRETT_INSTALL_DIR` -- the installation prefix of the pre-installed LibreTT library. This should not be normally needed; it is strongly recommended to let TiledArray build and install LibreTT.
 * `UMPIRE_INSTALL_DIR` -- the installation prefix of the pre-installed Umpire library. This should not be normally needed; it is strongly recommended to let TiledArray build and install Umpire.
 
@@ -367,12 +367,10 @@ the correct revision of MADNESS.
 The following CMake options may be used to modify build behavior or find MADNESS:
 
 * `ENABLE_MPI` -- Enable MPI [Default=ON]
-* `ENABLE_SCALAPACK` -- Enable the use of ScaLAPACK bindings [Default=OFF]
 * `ENABLE_TBB` -- Enable the use of TBB when building MADNESS [Default=ON]
 * `ENABLE_GPERFTOOLS` -- Enable the use of gperftools when building MADNESS [Default=OFF]
 * `ENABLE_TCMALLOC_MINIMAL` -- Enable the use of gperftool's tcmalloc_minimal library only (the rest of gperftools is skipped) when building MADNESS [Default=OFF]
 * `ENABLE_LIBUNWIND` -- Force the discovery of libunwind library when building MADNESS [Default=OFF]
-* `ENABLE_WFN91_LINALG_DISCOVERY_KIT` -- Enable the use of NWChemEx's linear algebra discovery [Default=ON]
 * `MADNESS_SOURCE_DIR` -- Path to the MADNESS source directory
 * `MADNESS_BINARY_DIR` -- Path to the MADNESS build directory
 * `MADNESS_URL` -- Path to the MADNESS repository [Default=MADNESS git repository]

--- a/bin/docker-cuda-build.sh
+++ b/bin/docker-cuda-build.sh
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y python3 python3-pip python3-test python
 RUN CMAKE_URL="https://cmake.org/files/v${CMAKE_VERSION%.[0-9]}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" && wget --no-check-certificate -O - \$CMAKE_URL | tar --strip-components=1 -xz -C /usr/local
 ENV CMAKE=/usr/local/bin/cmake
 # 3. download and build TiledArray
-RUN cd /usr/local/src && git clone --depth=1 https://github.com/ValeevGroup/tiledarray.git && cd /usr/local/src/tiledarray && mkdir build && cd build && \$CMAKE .. -G Ninja -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DCMAKE_INSTALL_PREFIX=/usr/local -DENABLE_CUDA=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo && \$CMAKE --build . --target tiledarray && \$CMAKE --build . --target examples && \$CMAKE --build . --target install
+RUN cd /usr/local/src && git clone --depth=1 https://github.com/ValeevGroup/tiledarray.git && cd /usr/local/src/tiledarray && mkdir build && cd build && \$CMAKE .. -G Ninja -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DCMAKE_INSTALL_PREFIX=/usr/local -DTA_CUDA=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo && \$CMAKE --build . --target tiledarray && \$CMAKE --build . --target examples && \$CMAKE --build . --target install
 
 # Clean up APT when done.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/ci/.build-project
+++ b/ci/.build-project
@@ -89,7 +89,7 @@ if [[ "$vars" =~ \"-DBLAS_PREFERENCE_LIST=IntelMKL ]]; then
   cmd "source /opt/intel/oneapi/tbb/latest/env/vars.sh"
   cmd "echo TBBROOT=\$TBBROOT"
 fi
-if [[ "$vars" =~ \"-D([a-zA-Z]+_)?ENABLE_CUDA=(ON|TRUE|1|YES)\" ]]; then
+if [[ "$vars" =~ \"-D([a-zA-Z]+_)?TA_CUDA=(ON|TRUE|1|YES)\" ]]; then
   cmd "make -C /home/ValeevGroup install/cuda"
   cmd "rm -fr /usr/local/bin/nvcc"
   cmd "export CUDACXX=/usr/local/cuda/bin/nvcc"

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,7 +1,7 @@
 To run CI in docker use `docker-run-ci` and give build parameters, eg:
 
 ```
-$ ./ci/docker-run-ci TA_PYTHON=OFF ENABLE_CUDA=ON all check
+$ ./ci/docker-run-ci TA_PYTHON=OFF TA_CUDA=ON all check
 Removing previous build container: andrey.tiledarray.build
 
 Running new build of /home/andrey/github/tiledarray on andrey.tiledarray.build

--- a/ci/docker-run-ci
+++ b/ci/docker-run-ci
@@ -2,7 +2,7 @@
 
 # build project via docker run, eg
 # usage: docker-run-ci [ VAR=VALUE ... ] [ target ... ]
-# example: ./ci/docker-run-ci TA_PYTHON=OFF ENABLE_CUDA=ON all check
+# example: ./ci/docker-run-ci TA_PYTHON=OFF TA_CUDA=ON all check
 
 project=$(basename $PWD)
 image=valeevgroup/ubuntu:${VALEEVGROUP_UBUNTU_TAG:-latest}

--- a/cmake/toolchains/README.md
+++ b/cmake/toolchains/README.md
@@ -27,7 +27,7 @@ export CUDA_GCC_DIR=/sw/summit/gcc/7.4.0
 
 cmake ../../tiledarray \
 -DCMAKE_TOOLCHAIN_FILE=cmake/vg/toolchains/olcf-summit-gcc-essl.cmake \
--DENABLE_CUDA=ON \
+-DTA_CUDA=ON \
 -DCMAKE_CUDA_HOST_COMPILER=${CUDA_GCC_DIR}/bin/g++ \
 -DCUDAToolkit_ROOT=/sw/summit/cuda/10.1.243 \
 -DENABLE_TBB=OFF \

--- a/examples/scalapack/CMakeLists.txt
+++ b/examples/scalapack/CMakeLists.txt
@@ -24,7 +24,7 @@
 
 # Create example executable
 
-if(ENABLE_SCALAPACK)
+if(TA_SCALAPACK)
 
 foreach(_exec conversion evp)
 
@@ -35,4 +35,4 @@ foreach(_exec conversion evp)
 
 endforeach()
 
-endif(ENABLE_SCALAPACK)
+endif(TA_SCALAPACK)

--- a/external/eigen.cmake
+++ b/external/eigen.cmake
@@ -6,11 +6,11 @@ include(AppendFlags)
 
 # if CUDA is enabled (assuming CUDA version is 9 or 10) need Eigen 3.3.7
 # see https://gitlab.com/libeigen/eigen/issues/1491
-if (ENABLE_CUDA)
+if (TA_CUDA)
   set(_tiledarray_required_eigen_version 3.3.7)
-else(ENABLE_CUDA)
+else(TA_CUDA)
   set(_tiledarray_required_eigen_version ${TA_TRACKED_EIGEN_VERSION})
-endif(ENABLE_CUDA)
+endif(TA_CUDA)
 
 # Check for existing Eigen
 # prefer CMake-configured-and-installed instance

--- a/external/librett.cmake
+++ b/external/librett.cmake
@@ -69,7 +69,7 @@ else()
         -DCMAKE_PREFIX_PATH=${LIBRETT_CMAKE_PREFIX_PATH}
         -DENABLE_NO_ALIGNED_ALLOC=ON
         )
-    if (ENABLE_CUDA)
+    if (TA_CUDA)
         list(APPEND LIBRETT_CMAKE_ARGS
                 -DENABLE_CUDA=ON
                 -DCMAKE_CUDA_COMPILER=${CMAKE_CUDA_COMPILER}
@@ -82,7 +82,7 @@ else()
             list(APPEND LIBRETT_CMAKE_ARGS "-DCMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}")
         endif(DEFINED CMAKE_CUDA_ARCHITECTURES)
     endif()
-    if (ENABLE_HIP)
+    if (TA_HIP)
         list(APPEND LIBRETT_CMAKE_ARGS
                 -DENABLE_HIP=ON
                 -DCMAKE_HIP_COMPILER=${CMAKE_HIP_COMPILER}
@@ -178,14 +178,14 @@ set_target_properties(TiledArray_LIBRETT
         INTERFACE_LINK_LIBRARIES
         "$<BUILD_INTERFACE:${LIBRETT_BUILD_BYPRODUCTS}>;$<INSTALL_INTERFACE:${_LIBRETT_INSTALL_DIR}/lib/librett.${LIBRETT_DEFAULT_LIBRARY_SUFFIX}>"
         )
-if (ENABLE_CUDA)
+if (TA_CUDA)
     set_target_properties(TiledArray_LIBRETT
             PROPERTIES
             INTERFACE_COMPILE_DEFINITIONS
             "LIBRETT_USES_CUDA=1"
     )
 endif()
-if (ENABLE_HIP)
+if (TA_HIP)
     set_target_properties(TiledArray_LIBRETT
             PROPERTIES
             INTERFACE_COMPILE_DEFINITIONS

--- a/external/umpire.cmake
+++ b/external/umpire.cmake
@@ -113,7 +113,7 @@ else()
              -DUMPIRE_ENABLE_FILESYSTEM=OFF)
     endif()
 
-    if (ENABLE_CUDA)
+    if (TA_CUDA)
         list(APPEND UMPIRE_CMAKE_ARGS
                 -DENABLE_CUDA=ON
                 -DCMAKE_CUDA_COMPILER=${CMAKE_CUDA_COMPILER}
@@ -134,8 +134,8 @@ else()
         if (DEFINED CUDA_TOOLKIT_ROOT_DIR)
             list(APPEND UMPIRE_CMAKE_ARGS "-DCUDA_TOOLKIT_ROOT_DIR=${CUDA_TOOLKIT_ROOT_DIR}")
         endif()
-    endif(ENABLE_CUDA)
-    if (ENABLE_HIP)
+    endif(TA_CUDA)
+    if (TA_HIP)
         list(APPEND UMPIRE_CMAKE_ARGS
                 -DENABLE_HIP=ON
                 -DCMAKE_HIP_COMPILER=${CMAKE_HIP_COMPILER}
@@ -145,7 +145,7 @@ else()
         if (DEFINED CMAKE_HIP_ARCHITECTURES)
             list(APPEND UMPIRE_CMAKE_ARGS "-DCMAKE_HIP_ARCHITECTURES=${CMAKE_HIP_ARCHITECTURES}")
         endif(DEFINED CMAKE_HIP_ARCHITECTURES)
-    endif(ENABLE_HIP)
+    endif(TA_HIP)
     if (CMAKE_TOOLCHAIN_FILE)
         set(UMPIRE_CMAKE_ARGS "${UMPIRE_CMAKE_ARGS}"
             "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}"

--- a/src/TiledArray/initialize.h
+++ b/src/TiledArray/initialize.h
@@ -44,7 +44,7 @@ bool initialized_to_be_quiet();
 ///       initialization:
 ///       | Environment Variable | Default| Description |
 ///       |----------------------|--------|-------------|
-///       | `TA_LINALG_BACKEND`  | none   | If set, chooses the linear algebra backend to use; valid values are `scalapack` (distributed library ScaLAPACK, only available if configured with `ENABLE_SCALAPACK=ON`), `lapack` (non-distributed library LAPACK, always available), and `ttg` (experimental [TTG](https://github.com/TESSEorg/TTG) backend, only implements Cholesky); the default is to choose best available backend automatically (recommended) |
+///       | `TA_LINALG_BACKEND`  | none   | If set, chooses the linear algebra backend to use; valid values are `scalapack` (distributed library ScaLAPACK, only available if configured with `TA_SCALAPACK=ON`), `lapack` (non-distributed library LAPACK, always available), and `ttg` (experimental [TTG](https://github.com/TESSEorg/TTG) backend, only implements Cholesky); the default is to choose best available backend automatically (recommended) |
 ///       | `TA_LINALG_DISTRIBUTED_MINSIZE`  | 4194304 | Unless `TA_LINALG_BACKEND` is set, this controls the minimum matrix size (#rows times #columns) for which the distributed backend if chosen when selecting the best available backend |
 /// @warning MADWorld can only be initialized/finalized once, hence if
 ///          TiledArray initializes MADWorld


### PR DESCRIPTION
by renaming to `TA_{CUDA,HIP,SCALAPACK,LINALG_DISCOVERY_KIT}`

includes misc dox fixes