### PR TITLE
Fix block-sparse sub-block assignment when RHS threshold is looser than dest

### DIFF
--- a/src/TiledArray/expressions/expr.h
+++ b/src/TiledArray/expressions/expr.h
@@ -537,9 +537,22 @@ class Expr {
           std::make_shared<op_type>(shift_op_type(shift));
 
       for (const auto index : *dist_eval.pmap()) {
-        if (!dist_eval.is_zero(index))
-          set_tile(result, blk_range.ordinal(index), dist_eval.get(index),
-                   shift_op);
+        if (!dist_eval.is_zero(index)) {
+          // N.B. always consume the tile from dist_eval: it schedules every
+          // non-zero tile and a stranded (never-got) producer would deadlock
+          // dist_eval.wait() below.
+          auto tile = dist_eval.get(index);
+          // `result`'s block shape was formed by SparseShape::update_block
+          // (above), which screens the updated region with the DESTINATION
+          // array's threshold. That threshold may be stricter than the RHS
+          // (`dist_eval`) shape's threshold, so a tile the RHS kept can be
+          // screened to zero in `result`. Writing it would violate the
+          // result's shape (ArrayImpl::set asserts !is_zero). Let the
+          // destination shape be authoritative: drop such sub-threshold tiles
+          // rather than force them into a shape-zero slot.
+          const auto ord = blk_range.ordinal(index);
+          if (!result.is_zero(ord)) set_tile(result, ord, tile, shift_op);
+        }
       }
     }
 

--- a/tests/expressions_sparse.cpp
+++ b/tests/expressions_sparse.cpp
@@ -47,6 +47,14 @@ BOOST_AUTO_TEST_CASE(block_assign_threshold_mismatch) {
   auto& world = *GlobalFixture::world;
   const float saved_threshold = Shape::threshold();
 
+  // The global (static) sparse threshold must be changed consistently on all
+  // ranks; use the documented gop.serial_invoke idiom (see
+  // SparseShape::threshold and conversions/truncate.h) rather than a bare
+  // setter call.
+  auto set_threshold = [&world](float t) {
+    world.gop.serial_invoke([t] { Shape::threshold(t); });
+  };
+
   // dest: 4x2 tiles; the assigned sub-block is tiles [2,4) x [0,2).
   TiledRange dest_tr{{0, 2, 4, 6, 8}, {0, 3, 6}};
   TiledRange blk_tr{{4, 6, 8}, {0, 3, 6}};  // sub-block, lobounds preserved
@@ -54,7 +62,7 @@ BOOST_AUTO_TEST_CASE(block_assign_threshold_mismatch) {
   // src (built under a LOW threshold) keeps two tiles: a small-norm one that
   // the destination's higher threshold will screen, and a large-norm one it
   // will not.
-  Shape::threshold(1.0e-8f);
+  set_threshold(1.0e-8f);
   Tensor<float> src_norms(blk_tr.tiles_range(), 0.0f);
   src_norms(0, 0) = 1.0e-3f;  // below dest threshold -> must be dropped
   src_norms(1, 1) = 1.0f;     // above dest threshold -> must be kept
@@ -65,7 +73,7 @@ BOOST_AUTO_TEST_CASE(block_assign_threshold_mismatch) {
   world.gop.fence();
 
   // dest: all-ones sparse array pre-sized under a HIGHER threshold.
-  Shape::threshold(1.0e-2f);
+  set_threshold(1.0e-2f);
   TSpArrayD dest(world, dest_tr);  // SparseShape(1, trange): every tile nonzero
   dest.fill(0.0);
   world.gop.fence();
@@ -81,7 +89,7 @@ BOOST_AUTO_TEST_CASE(block_assign_threshold_mismatch) {
   BOOST_CHECK(dest.is_zero({2, 0}));   // 1e-3 < 1e-2 -> screened out
   BOOST_CHECK(!dest.is_zero({3, 1}));  // 1.0  >= 1e-2 -> kept
 
-  Shape::threshold(saved_threshold);  // restore global (static) threshold
+  set_threshold(saved_threshold);  // restore global (static) threshold
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/expressions_sparse.cpp
+++ b/tests/expressions_sparse.cpp
@@ -31,3 +31,57 @@ typedef boost::mpl::vector<EF_TAspTensorI> Fixtures;
 
 BOOST_AUTO_TEST_SUITE(expressions_sparse_suite)
 #include "expressions_impl.h"
+
+BOOST_AUTO_TEST_SUITE(expressions_sparse_block_assign_suite)
+
+// Regression: sub-block assignment `dest.block(lo,hi) = src` must not abort
+// when the RHS (`src`) shape carries a LOWER screening threshold than the
+// destination. Expr::eval_to(BlkTsrExpr) forms the result block shape via
+// SparseShape::update_block, which keeps the DESTINATION's threshold, but
+// writes every tile the RHS shape kept. A tile the RHS keeps yet the (stricter)
+// destination threshold screens to zero must be DROPPED -- letting the
+// destination shape be authoritative -- rather than forced into a shape-zero
+// slot (which trips ArrayImpl::set's !is_zero assertion).
+BOOST_AUTO_TEST_CASE(block_assign_threshold_mismatch) {
+  using Shape = SparseShape<float>;
+  auto& world = *GlobalFixture::world;
+  const float saved_threshold = Shape::threshold();
+
+  // dest: 4x2 tiles; the assigned sub-block is tiles [2,4) x [0,2).
+  TiledRange dest_tr{{0, 2, 4, 6, 8}, {0, 3, 6}};
+  TiledRange blk_tr{{4, 6, 8}, {0, 3, 6}};  // sub-block, lobounds preserved
+
+  // src (built under a LOW threshold) keeps two tiles: a small-norm one that
+  // the destination's higher threshold will screen, and a large-norm one it
+  // will not.
+  Shape::threshold(1.0e-8f);
+  Tensor<float> src_norms(blk_tr.tiles_range(), 0.0f);
+  src_norms(0, 0) = 1.0e-3f;  // below dest threshold -> must be dropped
+  src_norms(1, 1) = 1.0f;     // above dest threshold -> must be kept
+  Shape src_shape(src_norms, blk_tr, /*do_not_scale=*/true);
+  TSpArrayD src(world, blk_tr, src_shape);
+  src.fill(1.0);
+  BOOST_CHECK(!src.is_zero({0, 0}));  // src keeps the small-norm tile
+  world.gop.fence();
+
+  // dest: all-ones sparse array pre-sized under a HIGHER threshold.
+  Shape::threshold(1.0e-2f);
+  TSpArrayD dest(world, dest_tr);  // SparseShape(1, trange): every tile nonzero
+  dest.fill(0.0);
+  world.gop.fence();
+
+  // The offending assignment: must not throw/abort with the fix in place.
+  BOOST_CHECK_NO_THROW({
+    dest("i,j").block({2, 0}, {4, 2}, preserve_lobound) = src("i,j");
+    world.gop.fence();
+  });
+
+  // Destination threshold is authoritative: the small-norm tile is dropped, the
+  // large-norm tile survives.
+  BOOST_CHECK(dest.is_zero({2, 0}));   // 1e-3 < 1e-2 -> screened out
+  BOOST_CHECK(!dest.is_zero({3, 1}));  // 1.0  >= 1e-2 -> kept
+
+  Shape::threshold(saved_threshold);  // restore global (static) threshold
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Problem

`a("i,j").block(lo,hi) = rhs("i,j")` aborts with `TA_ASSERT(!is_zero(i))` in `ArrayImpl<..., SparsePolicy>::set` (or hangs, under the throwing assert policy inside a task) when the RHS expression's shape carries a **looser** screening threshold than the destination array.

`Expr::eval_to(BlkTsrExpr)` builds the assigned sub-block's shape via `SparseShape::update_block`, which screens the updated region with the **destination** array's `my_threshold_`. The tile-write loop, however, wrote every tile the **RHS** (`dist_eval`) shape kept. A tile the RHS keeps but the merged `result` shape screens to zero was then written into a shape-zero slot, tripping the `!is_zero` assertion.

This surfaces downstream (e.g. a sub-block *scatter* that reconstructs a sparse result from independently-screened partials, where the partials were screened at a lower threshold than the pre-sized destination).

## Fix

Make the destination shape authoritative in the block-write loop: only `set` tiles the merged `result` shape keeps. The RHS tile is still `get()`-consumed **unconditionally** — skipping the `get()` would strand the scheduled producer and deadlock `dist_eval.wait()`.

`DensePolicy` is unaffected: `DenseShape::is_zero` is always false, so the added guard is inert and behavior is byte-identical.

## Test

Adds `expressions_sparse_block_assign_suite/block_assign_threshold_mismatch`: a real `TSpArrayD` sub-block assignment whose source keeps a small-norm tile that the stricter destination threshold screens out. It asserts the assignment does not throw and that the destination threshold decides which tiles survive. The case fails (assertion) without the fix.

Verified locally: new case + `expressions_sparse` (52), dense `expressions` (52), and ToT expression suites all pass.