### PR TITLE
ToT: strided arena kernels for complex inner cells; complex ToT scaling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,11 +147,11 @@ add_feature_info(TENSOR_MEM_PROFILE TA_TENSOR_MEM_PROFILE "instrumented profilin
 option(TA_TENSOR_ASSERT_NO_MUTABLE_OPS_WHILE_SHARED "Turn on TA_ASSERT that no mutable operations occur on TA::{Tensor,Tile} objects that share data" OFF)
 add_feature_info(TENSOR_ASSERT_NO_MUTABLE_OPS_WHILE_SHARED TA_TENSOR_ASSERT_NO_MUTABLE_OPS_WHILE_SHARED "TA_ASSERT that no mutable operations occur on TA::{Tensor,Tile} objects that share data")
 
-option(TA_STRIDED_DGEMM_COUNT
-       "Compile-in atomic counters that witness strided-DGEMM firing (tests/benches)"
+option(TA_STRIDED_GEMM_COUNT
+       "Compile-in atomic counters that witness strided-GEMM firing (tests/benches)"
        OFF)
-if (TA_STRIDED_DGEMM_COUNT)
-  add_compile_definitions(TA_STRIDED_DGEMM_COUNT)
+if (TA_STRIDED_GEMM_COUNT)
+  add_compile_definitions(TA_STRIDED_GEMM_COUNT)
 endif()
 
 option(TA_EXPERT "TiledArray Expert mode: disables automatically downloading or building dependencies" OFF)

--- a/examples/tot_bench/CMakeLists.txt
+++ b/examples/tot_bench/CMakeLists.txt
@@ -18,7 +18,7 @@
 #  CMakeLists.txt
 #
 
-# Strided-DGEMM ToT throughput benches (strided-vs-current arena DGEMM).
+# Strided-GEMM ToT throughput benches (strided-vs-current arena GEMM).
 
 foreach(_exec opa_strided_arena_dgemm opb_strided_arena_dgemm regime_a_hce_e_strided_bench ce_ce_segmented_strided_bench)
   add_ta_executable(${_exec} "${_exec}.cpp" "tiledarray")

--- a/examples/tot_bench/ce_ce_segmented_strided_bench.cpp
+++ b/examples/tot_bench/ce_ce_segmented_strided_bench.cpp
@@ -1,7 +1,7 @@
 // ce_ce_segmented_strided_bench.cpp
 // ---------------------------------------------------------------------------
-// Tile/BLAS-level benchmark for the hce+ce per-k SEGMENTED strided DGEMM
-// (arena_strided_dgemm_ce_ce_right). It times the SAME kernel on the SAME
+// Tile/BLAS-level benchmark for the hce+ce per-k SEGMENTED strided GEMM
+// (arena_strided_gemm_ce_ce_right). It times the SAME kernel on the SAME
 // hole-containing arena operands under the two states of the runtime kill
 // switch TiledArray::detail::ce_ce_strided_disabled():
 //
@@ -13,10 +13,10 @@
 //
 // The ONLY variable between the two timings is that toggle, so the ratio
 // isolates the kernel strategy swap. Operands model the measured CSV-CCk
-// fallback regime: present cells are CLUSTERED (mean segment length ~ --cluster)
-// and per-k MISALIGNED (each k shifts its hole phase), the pattern the old
-// all-or-nothing gate fell back to scalar on. The right-kernel walker is
-// identical to the left's, so this speedup represents hce+ce overall.
+// fallback regime: present cells are CLUSTERED (mean segment length ~
+// --cluster) and per-k MISALIGNED (each k shifts its hole phase), the pattern
+// the old all-or-nothing gate fell back to scalar on. The right-kernel walker
+// is identical to the left's, so this speedup represents hce+ce overall.
 // ---------------------------------------------------------------------------
 
 #include <tiledarray.h>
@@ -169,7 +169,7 @@ int main(int argc, char** argv) {
   for (std::size_t o = 0; o < R.range().volume(); ++o)
     if (R.data()[o]) ++present_R;
 
-  std::printf("=== hce+ce segmented-vs-per-cell strided DGEMM bench ===\n");
+  std::printf("=== hce+ce segmented-vs-per-cell strided GEMM bench ===\n");
   std::printf("Mmu=%zu nK=%zu P=%ld Q=%ld cluster=%ld  "
               "present C=%zu/%zu  present R=%zu/%zu\n",
               Mmu, nK, P, Q, cl, present_C, Ctemplate.range().volume(),
@@ -210,27 +210,28 @@ int main(int argc, char** argv) {
     Outer C = make_C();
     TA::detail::ce_ce_strided_disabled() = disabled;
     for (int w = 0; w < cli.warmup; ++w) { zero_C(C);
-      TA::detail::arena_strided_dgemm_ce_ce_right(
-          C, L, R, Mo, Mmu, nK, tablas::NoTranspose, tablas::Transpose, 1.0); }
+      TA::detail::arena_strided_gemm_ce_ce_right(
+          C, L, R, Mo, Mmu, nK, tablas::NoTranspose, tablas::Transpose, 1.0);
+    }
     std::vector<double> ms;
     ms.reserve(cli.reps);
     for (int r = 0; r < cli.reps; ++r) {
       zero_C(C);  // untimed
       auto t0 = clock_type::now();
-      TA::detail::arena_strided_dgemm_ce_ce_right(
+      TA::detail::arena_strided_gemm_ce_ce_right(
           C, L, R, Mo, Mmu, nK, tablas::NoTranspose, tablas::Transpose, 1.0);
       ms.push_back(ms_since(t0));
     }
     return ms;
   };
 
-#ifdef TA_STRIDED_DGEMM_COUNT
-  TA::detail::g_strided_dgemm_ce_ce_right_calls.store(0);
+#ifdef TA_STRIDED_GEMM_COUNT
+  TA::detail::g_strided_gemm_ce_ce_right_calls.store(0);
 #endif
   auto seg_ms = time_path(/*disabled=*/false);
-#ifdef TA_STRIDED_DGEMM_COUNT
+#ifdef TA_STRIDED_GEMM_COUNT
   const std::size_t seg_calls =
-      TA::detail::g_strided_dgemm_ce_ce_right_calls.load();
+      TA::detail::g_strided_gemm_ce_ce_right_calls.load();
 #endif
   auto pc_ms = time_path(/*disabled=*/true);
   TA::detail::ce_ce_strided_disabled() = false;  // restore production default
@@ -249,8 +250,8 @@ int main(int argc, char** argv) {
               seg_min > 0 ? pc_min / seg_min : 0.0,
               seg_med > 0 ? pc_med / seg_med : 0.0);
 
-#ifdef TA_STRIDED_DGEMM_COUNT
-  std::printf("\n--- firing witness (TA_STRIDED_DGEMM_COUNT) ---\n");
+#ifdef TA_STRIDED_GEMM_COUNT
+  std::printf("\n--- firing witness (TA_STRIDED_GEMM_COUNT) ---\n");
   std::printf("segment GEMMs over %d+%d (warmup+timed) reps = %zu  "
               "(mean %.1f per rep)\n",
               cli.warmup, cli.reps, seg_calls,

--- a/examples/tot_bench/regime_a_hce_e_strided_bench.cpp
+++ b/examples/tot_bench/regime_a_hce_e_strided_bench.cpp
@@ -8,11 +8,11 @@
 // `TiledArray::detail::regime_a_strided_disabled()`:
 //
 //   strided   (disabled=false): the ce+e core fuses the outer-contraction k
-//             into ONE strided DGEMM per result cell (M=N=1, K=tile-volume).
+//             into ONE strided GEMM per result cell (M=N=1, K=tile-volume).
 //   per-cell  (disabled=true) : the legacy per-cell rank-1 `dger` loop.
 //
 // The ONLY variable between the two timings is that toggle, so the measured
-// ratio isolates the kernel swap (rank-1 dger loop -> one strided DGEMM). It
+// ratio isolates the kernel swap (rank-1 dger loop -> one strided GEMM). It
 // is NOT an arena-vs-owning comparison: both paths read the identical arena
 // data and pay the identical einsum driver / scheduling overhead (which
 // compresses the ratio -- that is honest and expected).
@@ -210,8 +210,8 @@ int main(int argc, char** argv) {
 
   // ---- Timed: strided path (disabled = false) ----
   TA::detail::regime_a_strided_disabled() = false;
-#ifdef TA_STRIDED_DGEMM_COUNT
-  TA::detail::g_strided_dgemm_ce_e_calls.store(0);
+#ifdef TA_STRIDED_GEMM_COUNT
+  TA::detail::g_strided_gemm_ce_e_calls.store(0);
 #endif
   std::vector<double> strided_ms;
   strided_ms.reserve(cli.reps);
@@ -221,9 +221,9 @@ int main(int argc, char** argv) {
     c.world().gop.fence();
     strided_ms.push_back(ms_since(t0));
   }
-#ifdef TA_STRIDED_DGEMM_COUNT
+#ifdef TA_STRIDED_GEMM_COUNT
   const std::size_t strided_calls =
-      TA::detail::g_strided_dgemm_ce_e_calls.load();
+      TA::detail::g_strided_gemm_ce_e_calls.load();
 #endif
   const double t_strided_min =
       *std::min_element(strided_ms.begin(), strided_ms.end());
@@ -259,17 +259,17 @@ int main(int argc, char** argv) {
   std::printf("speedup   : min=%6.3fx  median=%6.3fx  (t_percell / t_strided)\n",
               speedup_min, speedup_med);
 
-#ifdef TA_STRIDED_DGEMM_COUNT
-  std::printf("\n--- firing witness (TA_STRIDED_DGEMM_COUNT) ---\n");
-  std::printf("g_strided_dgemm_ce_e_calls = %zu  (over %d strided reps)\n",
+#ifdef TA_STRIDED_GEMM_COUNT
+  std::printf("\n--- firing witness (TA_STRIDED_GEMM_COUNT) ---\n");
+  std::printf("g_strided_gemm_ce_e_calls = %zu  (over %d strided reps)\n",
               strided_calls, cli.reps);
   if (strided_calls == 0) {
     std::fprintf(stderr,
-                 "ERROR: strided DGEMM never fired -- reported numbers would "
+                 "ERROR: strided GEMM never fired -- reported numbers would "
                  "reflect a silent fallback, not the strided path.\n");
     std::abort();
   }
-  std::printf("OK: strided DGEMM fired (counter > 0).\n");
+  std::printf("OK: strided GEMM fired (counter > 0).\n");
 #endif
 
   return 0;

--- a/src/TiledArray/expressions/cont_engine.h
+++ b/src/TiledArray/expressions/cont_engine.h
@@ -1366,26 +1366,27 @@ class ContEngine : public BinaryEngine<Derived> {
                 // non-identity inner result perm is applied downstream and left
                 // to the per-cell path here.
                 // The strided kernel is specialized to view (arena) inner cells
-                // with double storage, and its static_assert requires that of
-                // ALL THREE operands (result, left, right). Gate on the same
-                // 3-operand predicate so a mixed-operand contraction (e.g. a
-                // view/double result with a non-view or non-double operand, or
-                // float/complex inner) stays on the generic per-cell path and
-                // never instantiates the double-view-only kernel (which would
-                // be a hard compile error rather than a graceful fallback).
+                // whose numeric type is one of the four BLAS gemm element types
+                // (is_strided_dgemm_numeric_v), shared by ALL THREE operands
+                // (result, left, right). Gate on the same 3-operand predicate
+                // so a mixed-operand contraction (e.g. a view result with a
+                // non-view operand, a non-BLAS inner numeric type, or a
+                // real-ToT x complex-ToT product) stays on the generic
+                // per-cell path and never instantiates the view-only kernel
+                // (which would be a hard compile error rather than a graceful
+                // fallback).
                 if constexpr (
                     TiledArray::is_tensor_view_v<result_tile_element_type> &&
                     TiledArray::is_tensor_view_v<left_tile_element_type> &&
                     TiledArray::is_tensor_view_v<right_tile_element_type> &&
-                    std::is_same_v<
-                        typename result_tile_element_type::numeric_type,
-                        double> &&
+                    TiledArray::detail::is_strided_dgemm_numeric_v<
+                        typename result_tile_element_type::numeric_type> &&
                     std::is_same_v<
                         typename left_tile_element_type::numeric_type,
-                        double> &&
+                        typename result_tile_element_type::numeric_type> &&
                     std::is_same_v<
                         typename right_tile_element_type::numeric_type,
-                        double>) {
+                        typename result_tile_element_type::numeric_type>) {
                   if (contrreduce_op.gemm_helper().num_contract_ranks() == 0 &&
                       !bool(inner(this->perm_))) {
                     const scalar_type factor = this->factor_;
@@ -1401,7 +1402,9 @@ class ContEngine : public BinaryEngine<Derived> {
                               Cc, Lt, Rt, static_cast<std::size_t>(M),
                               static_cast<std::size_t>(N),
                               static_cast<std::size_t>(K), gh.left_op(),
-                              gh.right_op(), double(factor));
+                              gh.right_op(),
+                              static_cast<typename result_tile_element_type::
+                                              numeric_type>(factor));
                         };
                   }
                   // ce+ce (hce+ce): inner CONTRACTION (num_contract_ranks() >=
@@ -1517,7 +1520,10 @@ class ContEngine : public BinaryEngine<Derived> {
                               Cc, Lt, Rt, static_cast<std::size_t>(Mo),
                               static_cast<std::size_t>(No),
                               static_cast<std::size_t>(Ko), gh.left_op(),
-                              gh.right_op(), double(factor), left_inner_T);
+                              gh.right_op(),
+                              static_cast<typename result_tile_element_type::
+                                              numeric_type>(factor),
+                              left_inner_T);
                         };
                   } else if (left_arm_ok) {
                     const scalar_type factor = this->factor_;
@@ -1537,11 +1543,14 @@ class ContEngine : public BinaryEngine<Derived> {
                               Cc, Lt, Rt, static_cast<std::size_t>(Mo),
                               static_cast<std::size_t>(No),
                               static_cast<std::size_t>(Ko), gh.left_op(),
-                              gh.right_op(), double(factor), right_inner_T);
+                              gh.right_op(),
+                              static_cast<typename result_tile_element_type::
+                                              numeric_type>(factor),
+                              right_inner_T);
                         };
                   }
                   // [strided-dgemm] install-decision instrumentation. For each
-                  // ToT contraction reaching this double-view path, report
+                  // ToT contraction reaching this view-cell path, report
                   // whether a strided-DGEMM regime (hce+e / hc+e / hce+ce)
                   // FIRED or the contraction REVERTED to the generic by-cell
                   // evaluation path (with the blocking guard). Gated by

--- a/src/TiledArray/expressions/cont_engine.h
+++ b/src/TiledArray/expressions/cont_engine.h
@@ -154,34 +154,34 @@ class ContEngine : public BinaryEngine<Derived> {
                                 ///< used; null otherwise
   std::function<void(result_tile_type&, const left_tile_type&,
                      const right_tile_type&, const math::GemmHelper&)>
-      arena_strided_dgemm_ce_e_tile_op_;  ///< whole-tile ce+e strided DGEMM op
-                                          ///< (arena inner OUTER-PRODUCT under
-                                          ///< an outer contraction); null
-                                          ///< otherwise
+      arena_strided_gemm_ce_e_tile_op_;  ///< whole-tile ce+e strided GEMM op
+                                         ///< (arena inner OUTER-PRODUCT under
+                                         ///< an outer contraction); null
+                                         ///< otherwise
   std::function<void(result_tile_type&, const left_tile_type&,
                      const right_tile_type&, const math::GemmHelper&)>
-      arena_strided_dgemm_ce_ce_right_tile_op_;  ///< whole-tile ce+ce strided
-                                                 ///< DGEMM op (arena inner
-                                                 ///< CONTRACTION under an outer
-                                                 ///< contraction;
-                                                 ///< right-external rides BLAS
-                                                 ///< M, left-external rides an
-                                                 ///< outer loop); null
-                                                 ///< otherwise. Mutually
-                                                 ///< exclusive with
-                                                 ///< arena_strided_dgemm_ce_e_tile_op_
-                                                 ///< (disjoint
-                                                 ///< num_contract_ranks()
-                                                 ///< gates)
+      arena_strided_gemm_ce_ce_right_tile_op_;  ///< whole-tile ce+ce strided
+                                                ///< GEMM op (arena inner
+                                                ///< CONTRACTION under an outer
+                                                ///< contraction;
+                                                ///< right-external rides BLAS
+                                                ///< M, left-external rides an
+                                                ///< outer loop); null
+                                                ///< otherwise. Mutually
+                                                ///< exclusive with
+                                                ///< arena_strided_gemm_ce_e_tile_op_
+                                                ///< (disjoint
+                                                ///< num_contract_ranks()
+                                                ///< gates)
   std::function<void(result_tile_type&, const left_tile_type&,
                      const right_tile_type&, const math::GemmHelper&)>
-      arena_strided_dgemm_ce_ce_left_tile_op_;  ///< whole-tile ce+ce strided
-                                                ///< DGEMM op, LEFT-clean
-                                                ///< mirror: left-external rides
-                                                ///< BLAS M, right-external
-                                                ///< rides an outer loop.
-                                                ///< Mutually exclusive with the
-                                                ///< ce_e and ce_ce_right ops.
+      arena_strided_gemm_ce_ce_left_tile_op_;  ///< whole-tile ce+ce strided
+                                               ///< GEMM op, LEFT-clean
+                                               ///< mirror: left-external rides
+                                               ///< BLAS M, right-external
+                                               ///< rides an outer loop.
+                                               ///< Mutually exclusive with the
+                                               ///< ce_e and ce_ce_right ops.
   using arena_plan_storage_t =
       TiledArray::detail::arena_plan_storage_t<result_tile_type, left_tile_type,
                                                right_tile_type>;
@@ -441,14 +441,14 @@ class ContEngine : public BinaryEngine<Derived> {
           // on num_contract_ranks()==0; the two ce+ce orientations on disjoint
           // right-/left-clean inner structure), so at most one is non-null and
           // only one install fires.
-          if (this->arena_strided_dgemm_ce_e_tile_op_)
-            op_.set_strided_oprod_op(this->arena_strided_dgemm_ce_e_tile_op_);
-          if (this->arena_strided_dgemm_ce_ce_right_tile_op_)
+          if (this->arena_strided_gemm_ce_e_tile_op_)
+            op_.set_strided_oprod_op(this->arena_strided_gemm_ce_e_tile_op_);
+          if (this->arena_strided_gemm_ce_ce_right_tile_op_)
             op_.set_strided_oprod_op(
-                this->arena_strided_dgemm_ce_ce_right_tile_op_);
-          if (this->arena_strided_dgemm_ce_ce_left_tile_op_)
+                this->arena_strided_gemm_ce_ce_right_tile_op_);
+          if (this->arena_strided_gemm_ce_ce_left_tile_op_)
             op_.set_strided_oprod_op(
-                this->arena_strided_dgemm_ce_ce_left_tile_op_);
+                this->arena_strided_gemm_ce_ce_left_tile_op_);
         }
         // Plan ownership transferred to op_; mark carrier slot empty so any
         // later use of arena_plan_ reads as "no plan" rather than moved-from.
@@ -504,14 +504,14 @@ class ContEngine : public BinaryEngine<Derived> {
           // on num_contract_ranks()==0; the two ce+ce orientations on disjoint
           // right-/left-clean inner structure), so at most one is non-null and
           // only one install fires.
-          if (this->arena_strided_dgemm_ce_e_tile_op_)
-            op_.set_strided_oprod_op(this->arena_strided_dgemm_ce_e_tile_op_);
-          if (this->arena_strided_dgemm_ce_ce_right_tile_op_)
+          if (this->arena_strided_gemm_ce_e_tile_op_)
+            op_.set_strided_oprod_op(this->arena_strided_gemm_ce_e_tile_op_);
+          if (this->arena_strided_gemm_ce_ce_right_tile_op_)
             op_.set_strided_oprod_op(
-                this->arena_strided_dgemm_ce_ce_right_tile_op_);
-          if (this->arena_strided_dgemm_ce_ce_left_tile_op_)
+                this->arena_strided_gemm_ce_ce_right_tile_op_);
+          if (this->arena_strided_gemm_ce_ce_left_tile_op_)
             op_.set_strided_oprod_op(
-                this->arena_strided_dgemm_ce_ce_left_tile_op_);
+                this->arena_strided_gemm_ce_ce_left_tile_op_);
         }
         // Plan ownership transferred to op_; mark carrier slot empty so any
         // later use of arena_plan_ reads as "no plan" rather than moved-from.
@@ -789,14 +789,14 @@ class ContEngine : public BinaryEngine<Derived> {
       // ce+e, ce+ce_right and ce+ce_left are mutually exclusive; at most one
       // is non-null and only one install fires (see init_struct)
       if constexpr (TiledArray::detail::is_tensor_of_tensor_v<value_type>) {
-        if (this->arena_strided_dgemm_ce_e_tile_op_)
-          op_.set_strided_oprod_op(this->arena_strided_dgemm_ce_e_tile_op_);
-        if (this->arena_strided_dgemm_ce_ce_right_tile_op_)
+        if (this->arena_strided_gemm_ce_e_tile_op_)
+          op_.set_strided_oprod_op(this->arena_strided_gemm_ce_e_tile_op_);
+        if (this->arena_strided_gemm_ce_ce_right_tile_op_)
           op_.set_strided_oprod_op(
-              this->arena_strided_dgemm_ce_ce_right_tile_op_);
-        if (this->arena_strided_dgemm_ce_ce_left_tile_op_)
+              this->arena_strided_gemm_ce_ce_right_tile_op_);
+        if (this->arena_strided_gemm_ce_ce_left_tile_op_)
           op_.set_strided_oprod_op(
-              this->arena_strided_dgemm_ce_ce_left_tile_op_);
+              this->arena_strided_gemm_ce_ce_left_tile_op_);
       }
       // Plan ownership transferred to op_; mark carrier slot empty so any
       // later use of arena_plan_ reads as "no plan" rather than moved-from.
@@ -1361,13 +1361,13 @@ class ContEngine : public BinaryEngine<Derived> {
                       "path was inactive (arena disabled)");
                 // ce+e (hce+e): inner OUTER product (no inner contraction)
                 // under outer contraction on arena view cells -> one strided
-                // DGEMM per result cell (ride the contracted index into BLAS
+                // GEMM per result cell (ride the contracted index into BLAS
                 // K). Only the canonical perm-free layout is fused; a
                 // non-identity inner result perm is applied downstream and left
                 // to the per-cell path here.
                 // The strided kernel is specialized to view (arena) inner cells
                 // whose numeric type is one of the four BLAS gemm element types
-                // (is_strided_dgemm_numeric_v), shared by ALL THREE operands
+                // (is_strided_gemm_numeric_v), shared by ALL THREE operands
                 // (result, left, right). Gate on the same 3-operand predicate
                 // so a mixed-operand contraction (e.g. a view result with a
                 // non-view operand, a non-BLAS inner numeric type, or a
@@ -1379,7 +1379,7 @@ class ContEngine : public BinaryEngine<Derived> {
                     TiledArray::is_tensor_view_v<result_tile_element_type> &&
                     TiledArray::is_tensor_view_v<left_tile_element_type> &&
                     TiledArray::is_tensor_view_v<right_tile_element_type> &&
-                    TiledArray::detail::is_strided_dgemm_numeric_v<
+                    TiledArray::detail::is_strided_gemm_numeric_v<
                         typename result_tile_element_type::numeric_type> &&
                     std::is_same_v<
                         typename left_tile_element_type::numeric_type,
@@ -1390,7 +1390,7 @@ class ContEngine : public BinaryEngine<Derived> {
                   if (contrreduce_op.gemm_helper().num_contract_ranks() == 0 &&
                       !bool(inner(this->perm_))) {
                     const scalar_type factor = this->factor_;
-                    this->arena_strided_dgemm_ce_e_tile_op_ =
+                    this->arena_strided_gemm_ce_e_tile_op_ =
                         [factor](result_tile_type& Cc, const left_tile_type& Lt,
                                  const right_tile_type& Rt,
                                  const math::GemmHelper& gh) {
@@ -1398,7 +1398,7 @@ class ContEngine : public BinaryEngine<Derived> {
                           integer M, N, K;
                           gh.compute_matrix_sizes(M, N, K, Lt.range(),
                                                   Rt.range());
-                          TiledArray::detail::arena_strided_dgemm_ce_e(
+                          TiledArray::detail::arena_strided_gemm_ce_e(
                               Cc, Lt, Rt, static_cast<std::size_t>(M),
                               static_cast<std::size_t>(N),
                               static_cast<std::size_t>(K), gh.left_op(),
@@ -1410,7 +1410,7 @@ class ContEngine : public BinaryEngine<Derived> {
                   // ce+ce (hce+ce): inner CONTRACTION (num_contract_ranks() >=
                   // 1) under outer contraction. One operand inner must be a
                   // pure contraction vector; that side's outer-external rides
-                  // BLAS M with one strided DGEMM per (batch, other-external,
+                  // BLAS M with one strided GEMM per (batch, other-external,
                   // outer-contraction) cell. Two orientations (right-clean ->
                   // ce_ce_right, left-clean -> ce_ce_left); see the either-side
                   // rule below. Sibling of the ce+e arm above (disjoint
@@ -1508,7 +1508,7 @@ class ContEngine : public BinaryEngine<Derived> {
                         this->left_inner_permtype_ ==
                         TiledArray::expressions::PermutationType::
                             matrix_transpose;
-                    this->arena_strided_dgemm_ce_ce_right_tile_op_ =
+                    this->arena_strided_gemm_ce_ce_right_tile_op_ =
                         [factor, left_inner_T](result_tile_type& Cc,
                                                const left_tile_type& Lt,
                                                const right_tile_type& Rt,
@@ -1516,7 +1516,7 @@ class ContEngine : public BinaryEngine<Derived> {
                           math::blas::integer Mo = 0, No = 0, Ko = 0;
                           gh.compute_matrix_sizes(Mo, No, Ko, Lt.range(),
                                                   Rt.range());
-                          TiledArray::detail::arena_strided_dgemm_ce_ce_right(
+                          TiledArray::detail::arena_strided_gemm_ce_ce_right(
                               Cc, Lt, Rt, static_cast<std::size_t>(Mo),
                               static_cast<std::size_t>(No),
                               static_cast<std::size_t>(Ko), gh.left_op(),
@@ -1531,7 +1531,7 @@ class ContEngine : public BinaryEngine<Derived> {
                         this->right_inner_permtype_ ==
                         TiledArray::expressions::PermutationType::
                             matrix_transpose;
-                    this->arena_strided_dgemm_ce_ce_left_tile_op_ =
+                    this->arena_strided_gemm_ce_ce_left_tile_op_ =
                         [factor, right_inner_T](result_tile_type& Cc,
                                                 const left_tile_type& Lt,
                                                 const right_tile_type& Rt,
@@ -1539,7 +1539,7 @@ class ContEngine : public BinaryEngine<Derived> {
                           math::blas::integer Mo = 0, No = 0, Ko = 0;
                           gh.compute_matrix_sizes(Mo, No, Ko, Lt.range(),
                                                   Rt.range());
-                          TiledArray::detail::arena_strided_dgemm_ce_ce_left(
+                          TiledArray::detail::arena_strided_gemm_ce_ce_left(
                               Cc, Lt, Rt, static_cast<std::size_t>(Mo),
                               static_cast<std::size_t>(No),
                               static_cast<std::size_t>(Ko), gh.left_op(),
@@ -1549,28 +1549,28 @@ class ContEngine : public BinaryEngine<Derived> {
                               right_inner_T);
                         };
                   }
-                  // [strided-dgemm] install-decision instrumentation. For each
+                  // [strided-gemm] install-decision instrumentation. For each
                   // ToT contraction reaching this view-cell path, report
-                  // whether a strided-DGEMM regime (hce+e / hc+e / hce+ce)
+                  // whether a strided-GEMM regime (hce+e / hc+e / hce+ce)
                   // FIRED or the contraction REVERTED to the generic by-cell
                   // evaluation path (with the blocking guard). Gated by
-                  // TA_STRIDED_DGEMM_VERBOSE; a no-op otherwise.
-                  if (TiledArray::detail::strided_dgemm_verbose()) {
-                    if (this->arena_strided_dgemm_ce_e_tile_op_) {
-                      TiledArray::detail::strided_dgemm_log(
+                  // TA_STRIDED_GEMM_VERBOSE; a no-op otherwise.
+                  if (TiledArray::detail::strided_gemm_verbose()) {
+                    if (this->arena_strided_gemm_ce_e_tile_op_) {
+                      TiledArray::detail::strided_gemm_log(
                           left_has_ext ? "hce+e  FIRES (ce+e)"
                                        : "hc+e   FIRES (ce+e)");
-                    } else if (this->arena_strided_dgemm_ce_ce_right_tile_op_) {
-                      TiledArray::detail::strided_dgemm_log(
+                    } else if (this->arena_strided_gemm_ce_ce_right_tile_op_) {
+                      TiledArray::detail::strided_gemm_log(
                           "hce+ce FIRES (ce+ce right)");
-                    } else if (this->arena_strided_dgemm_ce_ce_left_tile_op_) {
-                      TiledArray::detail::strided_dgemm_log(
+                    } else if (this->arena_strided_gemm_ce_ce_left_tile_op_) {
+                      TiledArray::detail::strided_gemm_log(
                           "hce+ce FIRES (ce+ce left)");
                     } else if (!inner_contraction) {
                       // ce+e candidate (no inner contraction); the only guard
                       // that can block its install is a non-identity inner
                       // result perm.
-                      TiledArray::detail::strided_dgemm_log(
+                      TiledArray::detail::strided_gemm_log(
                           left_has_ext
                               ? "hce+e  REVERTED -> by-cell (inner result perm)"
                               : "hc+e   REVERTED -> by-cell (inner result "
@@ -1611,11 +1611,11 @@ class ContEngine : public BinaryEngine<Derived> {
                       msg += "/";
                       msg += std::to_string(inner_gh.num_contract_ranks());
                       msg += ")";
-                      TiledArray::detail::strided_dgemm_log(msg.c_str());
+                      TiledArray::detail::strided_gemm_log(msg.c_str());
                     } else {
                       // ce+ce candidate, canonical inner, but no clean side /
                       // no outer external to ride.
-                      TiledArray::detail::strided_dgemm_log(
+                      TiledArray::detail::strided_gemm_log(
                           !(right_inner_clean || left_inner_clean)
                               ? "hce+ce REVERTED -> by-cell (matrix x matrix, "
                                 "no clean inner side)"

--- a/src/TiledArray/tensor/arena_einsum.h
+++ b/src/TiledArray/tensor/arena_einsum.h
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <complex>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
@@ -36,6 +37,18 @@
 #endif
 
 namespace TiledArray::detail {
+
+/// Numeric types the arena strided-DGEMM kernels (ce+e, ce+ce) are
+/// instantiated for: the four BLAS gemm element types (float, double,
+/// std::complex<float>, std::complex<double>). The kernels are layout/stride
+/// machinery over math::blas::gemm, so all four share one body; the ContEngine
+/// install gates and the hc+e reuse gate consult this trait so any other inner
+/// numeric type keeps the per-cell path.
+template <typename T>
+inline constexpr bool is_strided_dgemm_numeric_v =
+    std::is_same_v<T, float> || std::is_same_v<T, double> ||
+    std::is_same_v<T, std::complex<float>> ||
+    std::is_same_v<T, std::complex<double>>;
 
 /// Env-gated (TA_STRIDED_DGEMM_VERBOSE) toggle for the strided-DGEMM install
 /// logger. Reads the environment once. Set TA_STRIDED_DGEMM_VERBOSE=1 to have
@@ -282,7 +295,7 @@ template <typename GetCell>
 inline int classify_run(GetCell getcell, std::size_t n) {
   if (n == 0) return 0;
   long s0 = -1;
-  const double* base = nullptr;
+  decltype(getcell(std::size_t{0}).data()) base = nullptr;
   for (std::size_t i = 0; i < n; ++i) {
     const auto& c = getcell(i);
     if (!c) return 1;  // absent
@@ -320,7 +333,7 @@ inline int classify_operand(GetR getR, GetL getL, std::size_t nrun,
     const auto& lk = getL(k);
     if (!lk || static_cast<long>(lk.size()) != P * Q) return 13;  // single-cell
     long s0 = -1;
-    const double* base = nullptr;
+    decltype(getR(std::size_t{0}, std::size_t{0}).data()) base = nullptr;
     for (std::size_t i = 0; i < nrun; ++i) {
       const auto& c = getR(k, i);
       if (!c) return 13;
@@ -397,7 +410,7 @@ inline int gather_rescuable(GetC getC, GetR getR, GetL getL, std::size_t nrun,
   if (nrun == 0 || nrun > 1024) return 0;
   std::size_t pres[1024];
   std::size_t np = 0;
-  const double* rbase = nullptr;
+  decltype(getC(std::size_t{0}).data()) rbase = nullptr;
   for (std::size_t i = 0; i < nrun; ++i) {
     const auto& c = getC(i);
     if (!c) continue;
@@ -418,7 +431,7 @@ inline int gather_rescuable(GetC getC, GetR getR, GetL getL, std::size_t nrun,
   bool any_k = false;
   for (std::size_t k = 0; k < nK; ++k) {
     if (!getL(k)) continue;  // absent single-cell -> skip k (β=1)
-    const double* ob = nullptr;
+    decltype(getR(std::size_t{0}, std::size_t{0}).data()) ob = nullptr;
     long os = -1;
     for (std::size_t j = 0; j < np; ++j) {
       const auto& oc = getR(k, pres[j]);
@@ -472,8 +485,8 @@ inline void measure_segments(GetC getC, GetR getR, GetL getL, std::size_t nrun,
         ++mu;
         continue;
       }
-      const double* cb = c0.data();
-      const double* rb = r0.data();
+      const auto* cb = c0.data();
+      const auto* rb = r0.data();
       std::size_t end = mu + 1;
       long sC = -1, sR = -1;
       while (end < nrun) {
@@ -1166,11 +1179,12 @@ inline std::atomic<std::size_t> g_strided_dgemm_ce_e_calls{0};
 /// present, uniform inner size, single constant stride); else an inline per-k
 /// rank-1 fallback for THAT cell only. Orientation-aware (left_op/right_op pick
 /// per-(m,n,k) offsets). M=left-external, N=right-external, K=outer-contracted.
-template <typename ResultOuter, typename LeftOuter, typename RightOuter>
+template <typename ResultOuter, typename LeftOuter, typename RightOuter,
+          typename T = typename ResultOuter::value_type::numeric_type>
 void arena_strided_dgemm_ce_e(ResultOuter& C, const LeftOuter& L,
                               const RightOuter& R, std::size_t M, std::size_t N,
                               std::size_t K, math::blas::Op left_op,
-                              math::blas::Op right_op, double factor) {
+                              math::blas::Op right_op, T factor) {
   namespace blas = TiledArray::math::blas;
   using integer = blas::integer;
   static_assert(is_tensor_view_v<typename ResultOuter::value_type> &&
@@ -1178,10 +1192,13 @@ void arena_strided_dgemm_ce_e(ResultOuter& C, const LeftOuter& L,
                     is_tensor_view_v<typename RightOuter::value_type>,
                 "arena_strided_dgemm_ce_e: arena (view) inner cells only");
   static_assert(
-      std::is_same_v<typename ResultOuter::value_type::numeric_type, double> &&
-          std::is_same_v<typename LeftOuter::value_type::numeric_type, double> &&
-          std::is_same_v<typename RightOuter::value_type::numeric_type, double>,
-      "arena_strided_dgemm_ce_e: double inner storage only");
+      std::is_same_v<typename ResultOuter::value_type::numeric_type, T> &&
+          std::is_same_v<typename LeftOuter::value_type::numeric_type, T> &&
+          std::is_same_v<typename RightOuter::value_type::numeric_type, T>,
+      "arena_strided_dgemm_ce_e: inner storages must share numeric type T");
+  static_assert(is_strided_dgemm_numeric_v<T>,
+                "arena_strided_dgemm_ce_e: float/double/complex<float>/"
+                "complex<double> inner storage only");
   if (M == 0 || N == 0 || K == 0) return;
   const std::size_t nbatch = static_cast<std::size_t>(C.nbatch());
   if (nbatch == 0) return;
@@ -1253,7 +1270,7 @@ void arena_strided_dgemm_ce_e(ResultOuter& C, const LeftOuter& L,
                        /*K=*/static_cast<integer>(K), factor,
                        /*A=*/l0.data(), /*lda=*/static_cast<integer>(ldA),
                        /*B=*/r0.data(), /*ldb=*/static_cast<integer>(ldB),
-                       /*beta=*/1.0,
+                       /*beta=*/T(1),
                        /*C=*/Cc.data(), /*ldc=*/static_cast<integer>(Q));
           }
 #ifdef TA_STRIDED_DGEMM_COUNT
@@ -1278,7 +1295,7 @@ void arena_strided_dgemm_ce_e(ResultOuter& C, const LeftOuter& L,
             record_ce_e_fallback(why);
           }
           // inline per-k rank-1 fallback for THIS cell (computed once)
-          double* c = Cc.data();
+          T* c = Cc.data();
           std::uint64_t _fl = 0;
           for (std::size_t k = 0; k < K; ++k) {
             const auto& lk = lc[lbase + a_off(m, k)];
@@ -1287,8 +1304,8 @@ void arena_strided_dgemm_ce_e(ResultOuter& C, const LeftOuter& L,
             const std::size_t pp = lk.size(), qq = rk.size();
             if (static_cast<long>(Cc.size()) != static_cast<long>(pp * qq))
               continue;
-            const double* lp = lk.data();
-            const double* rp = rk.data();
+            const T* lp = lk.data();
+            const T* rp = rk.data();
             _fl += 2ull * pp * qq;
             for (std::size_t p = 0; p < pp; ++p)
               for (std::size_t q = 0; q < qq; ++q)
@@ -1335,12 +1352,13 @@ inline bool& ce_ce_strided_disabled() {
 /// (each cell once -> no double-count). C must be pre-shaped (a_1-major); the
 /// result outer is (m, μ̃) row-major (left-then-right concatenation, matching
 /// make_result_range). Accumulates into C (beta=1).
-template <typename ResultOuter, typename LeftOuter, typename RightOuter>
+template <typename ResultOuter, typename LeftOuter, typename RightOuter,
+          typename T = typename ResultOuter::value_type::numeric_type>
 void arena_strided_dgemm_ce_ce_right(ResultOuter& C, const LeftOuter& L,
                                const RightOuter& R, std::size_t Mo,
                                std::size_t No, std::size_t Ko,
                                math::blas::Op left_op, math::blas::Op right_op,
-                               double factor,
+                               T factor,
                                bool left_inner_transposed = false) {
   // left_inner_transposed: the external-carrying LEFT inner cell is stored
   // (a4,a1)=Q x P (matrix_transpose) instead of canonical (a1,a4)=P x Q. Folded
@@ -1353,10 +1371,13 @@ void arena_strided_dgemm_ce_ce_right(ResultOuter& C, const LeftOuter& L,
                     is_tensor_view_v<typename RightOuter::value_type>,
                 "arena_strided_dgemm_ce_ce_right: arena (view) inner cells only");
   static_assert(
-      std::is_same_v<typename ResultOuter::value_type::numeric_type, double> &&
-          std::is_same_v<typename LeftOuter::value_type::numeric_type, double> &&
-          std::is_same_v<typename RightOuter::value_type::numeric_type, double>,
-      "arena_strided_dgemm_ce_ce_right: double inner storage only");
+      std::is_same_v<typename ResultOuter::value_type::numeric_type, T> &&
+          std::is_same_v<typename LeftOuter::value_type::numeric_type, T> &&
+          std::is_same_v<typename RightOuter::value_type::numeric_type, T>,
+      "arena_strided_dgemm_ce_ce_right: inner storages must share numeric type T");
+  static_assert(is_strided_dgemm_numeric_v<T>,
+                "arena_strided_dgemm_ce_ce_right: float/double/complex<float>/"
+                "complex<double> inner storage only");
   const std::size_t Mmu = No;  // right outer-external rides BLAS M
   const std::size_t nK = Ko;   // outer-contracted is looped with beta=1
   const std::size_t nbatch = static_cast<std::size_t>(C.nbatch());
@@ -1444,7 +1465,7 @@ void arena_strided_dgemm_ce_ce_right(ResultOuter& C, const LeftOuter& L,
                            const typename LeftOuter::value_type& lk) {
         ScopedPhaseTimer _fb_timer(g_fallback_ns_ce_ce);
         std::uint64_t _fl = 0;
-        const double* l = lk.data();
+        const T* l = lk.data();
         for (std::size_t mu = 0; mu < Mmu; ++mu) {
           auto& Cc = cc[cbase + c_off(m, mu)];
           const auto& rk = rc[rbase + r_off(k, mu)];
@@ -1453,14 +1474,14 @@ void arena_strided_dgemm_ce_ce_right(ResultOuter& C, const LeftOuter& L,
           const long Ql = static_cast<long>(rk.size());
           if (Ql == 0 || static_cast<long>(lk.size()) != Pl * Ql) continue;
           _fl += 2ull * static_cast<std::uint64_t>(Pl) * Ql;
-          double* c = Cc.data();
-          const double* rr = rk.data();
+          T* c = Cc.data();
+          const T* rr = rk.data();
           for (long a1 = 0; a1 < Pl; ++a1) {
-            double acc = 0;
+            T acc = 0;
             if (left_inner_transposed) {
               for (long a4 = 0; a4 < Ql; ++a4) acc += l[a4 * Pl + a1] * rr[a4];
             } else {
-              const double* lr = l + a1 * Ql;
+              const T* lr = l + a1 * Ql;
               for (long a4 = 0; a4 < Ql; ++a4) acc += lr[a4] * rr[a4];
             }
             c[a1] += factor * acc;
@@ -1492,7 +1513,7 @@ void arena_strided_dgemm_ce_ce_right(ResultOuter& C, const LeftOuter& L,
           continue;
         }
 
-        const double* Lk = lk.data();  // P x Q (or Q x P if transposed)
+        const T* Lk = lk.data();  // P x Q (or Q x P if transposed)
         std::size_t mu = 0;
         while (mu < Mmu) {
           const auto& rc0 = rc[rbase + r_off(k, mu)];
@@ -1503,8 +1524,8 @@ void arena_strided_dgemm_ce_ce_right(ResultOuter& C, const LeftOuter& L,
             ++mu;
             continue;
           }
-          const double* rstart = rc0.data();  // segment μ̃-run base on R, stride sR
-          double* cstart = cc0.data();        // segment μ̃-run base on C, stride sC
+          const T* rstart = rc0.data();  // segment μ̃-run base on R, stride sR
+          T* cstart = cc0.data();        // segment μ̃-run base on C, stride sC
           // Grow the maximal segment, recomputing the strides locally (never
           // reuse a run-wide stale stride).
           std::size_t end = mu + 1;
@@ -1548,7 +1569,7 @@ void arena_strided_dgemm_ce_ce_right(ResultOuter& C, const LeftOuter& L,
                 /*A=*/rstart, /*lda=*/static_cast<integer>(ldR),
                 /*B=*/Lk,
                 /*ldb=*/static_cast<integer>(left_inner_transposed ? P : Q),
-                /*beta=*/1.0,
+                /*beta=*/T(1),
                 /*C=*/cstart, /*ldc=*/static_cast<integer>(ldC));
           }
 #ifdef TA_STRIDED_DGEMM_COUNT
@@ -1581,12 +1602,13 @@ inline std::atomic<std::size_t> g_strided_dgemm_ce_ce_left_calls{0};
 /// only (each cell once -> no double-count). Orientation-aware (l_off/r_off from
 /// left_op/right_op of the OUTER GemmHelper, exactly as the right core). C must
 /// be pre-shaped; the result outer is (m, n) row-major. Accumulates (beta=1).
-template <typename ResultOuter, typename LeftOuter, typename RightOuter>
+template <typename ResultOuter, typename LeftOuter, typename RightOuter,
+          typename T = typename ResultOuter::value_type::numeric_type>
 void arena_strided_dgemm_ce_ce_left(ResultOuter& C, const LeftOuter& L,
                                     const RightOuter& R, std::size_t Mo,
                                     std::size_t No, std::size_t Ko,
                                     math::blas::Op left_op,
-                                    math::blas::Op right_op, double factor,
+                                    math::blas::Op right_op, T factor,
                                     bool right_inner_transposed = false) {
   // right_inner_transposed: the external-carrying RIGHT inner cell is stored
   // (b1,a4)=P x Q (matrix_transpose) instead of canonical (a4,b1)=Q x P. Folded
@@ -1599,10 +1621,13 @@ void arena_strided_dgemm_ce_ce_left(ResultOuter& C, const LeftOuter& L,
                     is_tensor_view_v<typename RightOuter::value_type>,
                 "arena_strided_dgemm_ce_ce_left: arena (view) inner cells only");
   static_assert(
-      std::is_same_v<typename ResultOuter::value_type::numeric_type, double> &&
-          std::is_same_v<typename LeftOuter::value_type::numeric_type, double> &&
-          std::is_same_v<typename RightOuter::value_type::numeric_type, double>,
-      "arena_strided_dgemm_ce_ce_left: double inner storage only");
+      std::is_same_v<typename ResultOuter::value_type::numeric_type, T> &&
+          std::is_same_v<typename LeftOuter::value_type::numeric_type, T> &&
+          std::is_same_v<typename RightOuter::value_type::numeric_type, T>,
+      "arena_strided_dgemm_ce_ce_left: inner storages must share numeric type T");
+  static_assert(is_strided_dgemm_numeric_v<T>,
+                "arena_strided_dgemm_ce_ce_left: float/double/complex<float>/"
+                "complex<double> inner storage only");
   const std::size_t nK = Ko;  // outer-contracted, looped with beta=1
   const std::size_t nbatch = static_cast<std::size_t>(C.nbatch());
   if (nbatch == 0 || Mo == 0 || nK == 0 || No == 0) return;
@@ -1681,7 +1706,7 @@ void arena_strided_dgemm_ce_ce_left(ResultOuter& C, const LeftOuter& L,
                            const typename RightOuter::value_type& rk) {
         ScopedPhaseTimer _fb_timer(g_fallback_ns_ce_ce);
         std::uint64_t _fl = 0;
-        const double* bd = rk.data();  // canonical Q x P row-major
+        const T* bd = rk.data();  // canonical Q x P row-major
         for (std::size_t m = 0; m < Mo; ++m) {
           auto& Cc = cc[cbase + c_off(m, n)];
           const auto& lk = lc[lbase + l_off(m, k)];
@@ -1690,14 +1715,14 @@ void arena_strided_dgemm_ce_ce_left(ResultOuter& C, const LeftOuter& L,
           const long Ql = static_cast<long>(lk.size());
           if (Ql == 0 || static_cast<long>(rk.size()) != Ql * Pl) continue;
           _fl += 2ull * static_cast<std::uint64_t>(Pl) * Ql;
-          double* c = Cc.data();
-          const double* a = lk.data();  // Ql vector
+          T* c = Cc.data();
+          const T* a = lk.data();  // Ql vector
           for (long a4 = 0; a4 < Ql; ++a4) {
-            const double av = a[a4];
+            const T av = a[a4];
             if (right_inner_transposed) {
               for (long p = 0; p < Pl; ++p) c[p] += factor * av * bd[p * Ql + a4];
             } else {
-              const double* br = bd + a4 * Pl;
+              const T* br = bd + a4 * Pl;
               for (long p = 0; p < Pl; ++p) c[p] += factor * av * br[p];
             }
           }
@@ -1728,7 +1753,7 @@ void arena_strided_dgemm_ce_ce_left(ResultOuter& C, const LeftOuter& L,
           continue;
         }
 
-        const double* Rk = rk.data();  // Q x P (or P x Q if transposed)
+        const T* Rk = rk.data();  // Q x P (or P x Q if transposed)
         std::size_t m = 0;
         while (m < Mo) {
           const auto& lc0 = lc[lbase + l_off(m, k)];
@@ -1739,8 +1764,8 @@ void arena_strided_dgemm_ce_ce_left(ResultOuter& C, const LeftOuter& L,
             ++m;
             continue;
           }
-          const double* lstart = lc0.data();  // segment m-run base on L, stride sA
-          double* cstart = cc0.data();        // segment m-run base on C, stride sC
+          const T* lstart = lc0.data();  // segment m-run base on L, stride sA
+          T* cstart = cc0.data();        // segment m-run base on C, stride sC
           // Grow the maximal segment, recomputing the strides locally (never
           // reuse a run-wide stale stride).
           std::size_t end = m + 1;
@@ -1784,7 +1809,7 @@ void arena_strided_dgemm_ce_ce_left(ResultOuter& C, const LeftOuter& L,
                 /*A=*/lstart, /*lda=*/static_cast<integer>(ldA),
                 /*B=*/Rk,
                 /*ldb=*/static_cast<integer>(right_inner_transposed ? Q : P),
-                /*beta=*/1.0,
+                /*beta=*/T(1),
                 /*C=*/cstart, /*ldc=*/static_cast<integer>(ldC));
           }
 #ifdef TA_STRIDED_DGEMM_COUNT
@@ -2196,16 +2221,19 @@ bool run_regime_a_arena(const Plan& plan, const HIndex& h, std::size_t batch,
     if constexpr (a_is_tot && b_is_tot) {
       using IIndex = ::Einsum::index::Index<std::size_t>;
       // hc+e reuse gate: the result/operand inner cells must be the kernel's
-      // (view + double) inner type; mirror arena_strided_dgemm_ce_e's
-      // static_assert so non-view / non-double ToT keep the per-cell path.
+      // (view + BLAS numeric) inner type; mirror arena_strided_dgemm_ce_e's
+      // static_assert so non-view / non-BLAS-numeric / mixed-type ToT keep the
+      // per-cell path.
       using LInnerT = typename ArrayA_t::value_type::value_type;
       using RInnerT = typename ArrayB_t::value_type::value_type;
       constexpr bool ce_e_kernel_ok =
           is_tensor_view_v<InnerT> && is_tensor_view_v<LInnerT> &&
           is_tensor_view_v<RInnerT> &&
-          std::is_same_v<typename InnerT::numeric_type, double> &&
-          std::is_same_v<typename LInnerT::numeric_type, double> &&
-          std::is_same_v<typename RInnerT::numeric_type, double>;
+          is_strided_dgemm_numeric_v<typename InnerT::numeric_type> &&
+          std::is_same_v<typename LInnerT::numeric_type,
+                         typename InnerT::numeric_type> &&
+          std::is_same_v<typename RInnerT::numeric_type,
+                         typename InnerT::numeric_type>;
       // Inner OUTER-PRODUCT (K_inner==0) is the strided-reusable shape; any
       // inner contraction (hc+ce) stays per-cell (two-level stride). The
       // runtime toggle lets tests/benches force the per-cell path.
@@ -2285,7 +2313,7 @@ bool run_regime_a_arena(const Plan& plan, const HIndex& h, std::size_t batch,
             arena_strided_dgemm_ce_e(cview, ai, bi, /*M=*/std::size_t{1},
                                      /*N=*/std::size_t{1}, /*K=*/Kvol,
                                      blas::NoTranspose, blas::NoTranspose,
-                                     /*factor=*/1.0);
+                                     /*factor=*/typename InnerT::numeric_type(1));
             continue;  // tile-i contribution complete
           }
         }

--- a/src/TiledArray/tensor/arena_einsum.h
+++ b/src/TiledArray/tensor/arena_einsum.h
@@ -14,8 +14,8 @@
 
 #include <algorithm>
 #include <atomic>
-#include <complex>
 #include <chrono>
+#include <complex>
 #include <cstdint>
 #include <cstdlib>
 #include <iomanip>
@@ -23,12 +23,12 @@
 #include <map>
 #include <mutex>
 #include <optional>
-#include <unordered_map>
-#include <vector>
 #include <string>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #if defined(_MSC_VER) && _MSC_VER < 1937  // VS 2022 < 17.7
 #define TA_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
@@ -1184,7 +1184,8 @@ template <typename ResultOuter, typename LeftOuter, typename RightOuter,
 void arena_strided_dgemm_ce_e(ResultOuter& C, const LeftOuter& L,
                               const RightOuter& R, std::size_t M, std::size_t N,
                               std::size_t K, math::blas::Op left_op,
-                              math::blas::Op right_op, T factor) {
+                              math::blas::Op right_op,
+                              std::type_identity_t<T> factor) {
   namespace blas = TiledArray::math::blas;
   using integer = blas::integer;
   static_assert(is_tensor_view_v<typename ResultOuter::value_type> &&
@@ -1355,11 +1356,12 @@ inline bool& ce_ce_strided_disabled() {
 template <typename ResultOuter, typename LeftOuter, typename RightOuter,
           typename T = typename ResultOuter::value_type::numeric_type>
 void arena_strided_dgemm_ce_ce_right(ResultOuter& C, const LeftOuter& L,
-                               const RightOuter& R, std::size_t Mo,
-                               std::size_t No, std::size_t Ko,
-                               math::blas::Op left_op, math::blas::Op right_op,
-                               T factor,
-                               bool left_inner_transposed = false) {
+                                     const RightOuter& R, std::size_t Mo,
+                                     std::size_t No, std::size_t Ko,
+                                     math::blas::Op left_op,
+                                     math::blas::Op right_op,
+                                     std::type_identity_t<T> factor,
+                                     bool left_inner_transposed = false) {
   // left_inner_transposed: the external-carrying LEFT inner cell is stored
   // (a4,a1)=Q x P (matrix_transpose) instead of canonical (a1,a4)=P x Q. Folded
   // into the inner GEMM via transb (zero-copy); the right contraction-vector
@@ -1608,7 +1610,8 @@ void arena_strided_dgemm_ce_ce_left(ResultOuter& C, const LeftOuter& L,
                                     const RightOuter& R, std::size_t Mo,
                                     std::size_t No, std::size_t Ko,
                                     math::blas::Op left_op,
-                                    math::blas::Op right_op, T factor,
+                                    math::blas::Op right_op,
+                                    std::type_identity_t<T> factor,
                                     bool right_inner_transposed = false) {
   // right_inner_transposed: the external-carrying RIGHT inner cell is stored
   // (b1,a4)=P x Q (matrix_transpose) instead of canonical (a4,b1)=Q x P. Folded

--- a/src/TiledArray/tensor/arena_einsum.h
+++ b/src/TiledArray/tensor/arena_einsum.h
@@ -38,41 +38,41 @@
 
 namespace TiledArray::detail {
 
-/// Numeric types the arena strided-DGEMM kernels (ce+e, ce+ce) are
+/// Numeric types the arena strided-GEMM kernels (ce+e, ce+ce) are
 /// instantiated for: the four BLAS gemm element types (float, double,
 /// std::complex<float>, std::complex<double>). The kernels are layout/stride
 /// machinery over math::blas::gemm, so all four share one body; the ContEngine
 /// install gates and the hc+e reuse gate consult this trait so any other inner
 /// numeric type keeps the per-cell path.
 template <typename T>
-inline constexpr bool is_strided_dgemm_numeric_v =
+inline constexpr bool is_strided_gemm_numeric_v =
     std::is_same_v<T, float> || std::is_same_v<T, double> ||
     std::is_same_v<T, std::complex<float>> ||
     std::is_same_v<T, std::complex<double>>;
 
-/// Env-gated (TA_STRIDED_DGEMM_VERBOSE) toggle for the strided-DGEMM install
-/// logger. Reads the environment once. Set TA_STRIDED_DGEMM_VERBOSE=1 to have
-/// the ContEngine print, per ToT contraction, whether a strided-DGEMM regime
+/// Env-gated (TA_STRIDED_GEMM_VERBOSE) toggle for the strided-GEMM install
+/// logger. Reads the environment once. Set TA_STRIDED_GEMM_VERBOSE=1 to have
+/// the ContEngine print, per ToT contraction, whether a strided-GEMM regime
 /// (hce+e / hc+e / hce+ce) FIRES or REVERTS to the generic by-cell path.
-inline bool strided_dgemm_verbose() {
+inline bool strided_gemm_verbose() {
   static const bool enabled = [] {
-    const char* e = std::getenv("TA_STRIDED_DGEMM_VERBOSE");
+    const char* e = std::getenv("TA_STRIDED_GEMM_VERBOSE");
     return e != nullptr && e[0] != '\0' && !(e[0] == '0' && e[1] == '\0');
   }();
   return enabled;
 }
 
-/// One-line install-decision logger for the strided-DGEMM regimes. No-op unless
-/// strided_dgemm_verbose() (i.e. TA_STRIDED_DGEMM_VERBOSE) is set.
-inline void strided_dgemm_log(const char* msg) {
-  if (strided_dgemm_verbose()) std::cerr << "[strided-dgemm] " << msg << '\n';
+/// One-line install-decision logger for the strided-GEMM regimes. No-op unless
+/// strided_gemm_verbose() (i.e. TA_STRIDED_GEMM_VERBOSE) is set.
+inline void strided_gemm_log(const char* msg) {
+  if (strided_gemm_verbose()) std::cerr << "[strided-gemm] " << msg << '\n';
 }
 
 /// ===========================================================================
 /// GEMM-vs-op timing instrumentation (Amdahl profiling).
 ///
 /// Accumulates the wall-clock nanoseconds spent INSIDE blas::gemm in the
-/// strided-DGEMM regimes, separated by regime (ce+e = inner outer-product,
+/// strided-GEMM regimes, separated by regime (ce+e = inner outer-product,
 /// ce+ce = inner contraction). The inner-cell loops in each kernel are serial
 /// within a single Product op, so summing per-call durations across all ops is
 /// directly comparable to the summed per-op "Eval | Product | <ns>ns" trace
@@ -127,7 +127,7 @@ class ScopedGemmTimer {
 /// Each ce+e strided GEMM is a (P x Q) result accumulated over K, i.e.
 /// gemm dims M=P, N=Q, K=K. We bucket calls by the exact (P,Q,K) triple and
 /// tally count + wall ns per bucket, so we can see whether the inner extents
-/// in a given molecule are large enough to feed an efficient DGEMM (the bench
+/// in a given molecule are large enough to feed an efficient GEMM (the bench
 /// used K~256; CSV/PNO domains in small molecules may be far smaller).
 ///
 /// To stay lock-free in the hot loop, each thread accumulates into its own
@@ -220,7 +220,7 @@ class ScopedShapedGemmTimer {
 /// ---------------------------------------------------------------------------
 /// Phase decomposition of the ce+ce kernel time (where does the non-GEMM
 /// overhead go?). All gated by TA_GEMM_TIMING; printed at exit.
-///   kernel_total = whole arena_strided_dgemm_ce_ce_{right,left} body
+///   kernel_total = whole arena_strided_gemm_ce_ce_{right,left} body
 ///   gemm         = g_gemm_ns_ce_ce (the blas::gemm calls, timed elsewhere)
 ///   check        = the per-(b,m/n) presence+stride cleanliness verification
 ///   fallback     = the per-cell GEMV scalar path taken when a run is not clean
@@ -278,7 +278,7 @@ inline void phase_stop(std::atomic<std::uint64_t>& acc,
 ///   1 = absent   : a cell in the run is missing (sparsity / screened out)
 ///   2 = nonuniform: present, but inner-cell sizes differ along the run
 ///   3 = stride    : present + uniform, but cells are NOT at a constant
-///                   page-jump-free stride (the strided-DGEMM precondition)
+///                   page-jump-free stride (the strided-GEMM precondition)
 ///   0 = run looks clean (so the rejection came from the OTHER operand run)
 inline std::atomic<std::uint64_t> g_fall_runs_ce_ce{0};
 inline std::atomic<std::uint64_t> g_fall_res_absent_ce_ce{0};      // 1
@@ -1167,38 +1167,38 @@ void fused_scale_t_x_tot_inplace(Result& result, const Scalar& s,
       result, right);
 }
 
-#ifdef TA_STRIDED_DGEMM_COUNT
-inline std::atomic<std::size_t> g_strided_dgemm_ce_e_calls{0};
+#ifdef TA_STRIDED_GEMM_COUNT
+inline std::atomic<std::size_t> g_strided_gemm_ce_e_calls{0};
 #endif
 
-/// ce+e strided-DGEMM core (inner OUTER-PRODUCT), looped over the Hadamard-
+/// ce+e strided-GEMM core (inner OUTER-PRODUCT), looped over the Hadamard-
 /// folded nbatch. For each batch b and result cell (m,n):
 ///   C[m,n](p,q) += factor * sum_k L[m,k](p) * R[k,n](q)
-/// as ONE P x Q DGEMM riding the outer-contracted k into BLAS K via the
+/// as ONE P x Q GEMM riding the outer-contracted k into BLAS K via the
 /// inter-cell slab stride (zero-copy) when the k-run is "clean" (all cells
 /// present, uniform inner size, single constant stride); else an inline per-k
 /// rank-1 fallback for THAT cell only. Orientation-aware (left_op/right_op pick
 /// per-(m,n,k) offsets). M=left-external, N=right-external, K=outer-contracted.
 template <typename ResultOuter, typename LeftOuter, typename RightOuter,
           typename T = typename ResultOuter::value_type::numeric_type>
-void arena_strided_dgemm_ce_e(ResultOuter& C, const LeftOuter& L,
-                              const RightOuter& R, std::size_t M, std::size_t N,
-                              std::size_t K, math::blas::Op left_op,
-                              math::blas::Op right_op,
-                              std::type_identity_t<T> factor) {
+void arena_strided_gemm_ce_e(ResultOuter& C, const LeftOuter& L,
+                             const RightOuter& R, std::size_t M, std::size_t N,
+                             std::size_t K, math::blas::Op left_op,
+                             math::blas::Op right_op,
+                             std::type_identity_t<T> factor) {
   namespace blas = TiledArray::math::blas;
   using integer = blas::integer;
   static_assert(is_tensor_view_v<typename ResultOuter::value_type> &&
                     is_tensor_view_v<typename LeftOuter::value_type> &&
                     is_tensor_view_v<typename RightOuter::value_type>,
-                "arena_strided_dgemm_ce_e: arena (view) inner cells only");
+                "arena_strided_gemm_ce_e: arena (view) inner cells only");
   static_assert(
       std::is_same_v<typename ResultOuter::value_type::numeric_type, T> &&
           std::is_same_v<typename LeftOuter::value_type::numeric_type, T> &&
           std::is_same_v<typename RightOuter::value_type::numeric_type, T>,
-      "arena_strided_dgemm_ce_e: inner storages must share numeric type T");
-  static_assert(is_strided_dgemm_numeric_v<T>,
-                "arena_strided_dgemm_ce_e: float/double/complex<float>/"
+      "arena_strided_gemm_ce_e: inner storages must share numeric type T");
+  static_assert(is_strided_gemm_numeric_v<T>,
+                "arena_strided_gemm_ce_e: float/double/complex<float>/"
                 "complex<double> inner storage only");
   if (M == 0 || N == 0 || K == 0) return;
   const std::size_t nbatch = static_cast<std::size_t>(C.nbatch());
@@ -1274,8 +1274,8 @@ void arena_strided_dgemm_ce_e(ResultOuter& C, const LeftOuter& L,
                        /*beta=*/T(1),
                        /*C=*/Cc.data(), /*ldc=*/static_cast<integer>(Q));
           }
-#ifdef TA_STRIDED_DGEMM_COUNT
-          g_strided_dgemm_ce_e_calls.fetch_add(1, std::memory_order_relaxed);
+#ifdef TA_STRIDED_GEMM_COUNT
+          g_strided_gemm_ce_e_calls.fetch_add(1, std::memory_order_relaxed);
 #endif
         } else {
           ScopedPhaseTimer _fb_timer(g_fallback_ns_ce_e);
@@ -1320,12 +1320,12 @@ void arena_strided_dgemm_ce_e(ResultOuter& C, const LeftOuter& L,
   }
 }
 
-#ifdef TA_STRIDED_DGEMM_COUNT
-inline std::atomic<std::size_t> g_strided_dgemm_ce_ce_right_calls{0};
+#ifdef TA_STRIDED_GEMM_COUNT
+inline std::atomic<std::size_t> g_strided_gemm_ce_ce_right_calls{0};
 #endif
 
-/// Kill switch for the ce+ce (hce+ce) per-k segmented strided-DGEMM path: when
-/// true, arena_strided_dgemm_ce_ce_right/_left route EVERY present cell through
+/// Kill switch for the ce+ce (hce+ce) per-k segmented strided-GEMM path: when
+/// true, arena_strided_gemm_ce_ce_right/_left route EVERY present cell through
 /// the per-cell scalar GEMV loop (the legacy "revert to per-cell" behavior)
 /// instead of the segment walker. Test/bench hook only -- production default is
 /// false (segmented on). Mirrors regime_a_strided_disabled().
@@ -1334,19 +1334,20 @@ inline bool& ce_ce_strided_disabled() {
   return flag;
 }
 
-/// ce+ce strided-DGEMM core (inner CONTRACTION; ride right-external μ̃ into BLAS
+/// ce+ce strided-GEMM core (inner CONTRACTION; ride right-external μ̃ into BLAS
 /// M). ORIENTATION-AWARE (offsets derived from left_op/right_op of the OUTER
-/// GemmHelper, exactly as arena_strided_dgemm_ce_e) and Hadamard-agnostic:
+/// GemmHelper, exactly as arena_strided_gemm_ce_e) and Hadamard-agnostic:
 /// Hadamard is carried as nbatch by the einsum driver, so a thin nbatch loop
 /// wraps a fixed-Hadamard ce+ce core and serves both hce+ce (nbatch>1) and the
 /// no-Hadamard ce+ce (nbatch==1). Do NOT assert nbatch==1.
 ///
-/// Outer GemmHelper mapping: Mo = left outer-external, No = right outer-external
-/// = Mμ, Ko = outer-contracted = nK. The left-external `m` (Mo) is an OUTER loop
-/// around the per-(b) body; R (a function of k,μ̃ only) is reused across m.
-/// For each batch b, each left-external m, and each outer-contraction cell Κ=k:
+/// Outer GemmHelper mapping: Mo = left outer-external, No = right
+/// outer-external = Mμ, Ko = outer-contracted = nK. The left-external `m` (Mo)
+/// is an OUTER loop around the per-(b) body; R (a function of k,μ̃ only) is
+/// reused across m. For each batch b, each left-external m, and each
+/// outer-contraction cell Κ=k:
 ///   C̃[m,μ̃, a_1] += factor * Σ_{a_4} R[k,μ̃](a_4) · L[m,k](a_1,a_4)
-/// realized as ONE M=μ̃ × N=a_1 × K=a_4 DGEMM riding μ̃ into BLAS M via the
+/// realized as ONE M=μ̃ × N=a_1 × K=a_4 GEMM riding μ̃ into BLAS M via the
 /// (empirically measured) inter-μ̃-cell slab stride (zero-copy), looping k with
 /// beta=1. Mo==1 reduces to the original ce+ce kernel exactly. If a per-(b,m)
 /// run is not clean, an inline per-cell GEMV fallback handles THAT (b,m) only
@@ -1355,30 +1356,32 @@ inline bool& ce_ce_strided_disabled() {
 /// make_result_range). Accumulates into C (beta=1).
 template <typename ResultOuter, typename LeftOuter, typename RightOuter,
           typename T = typename ResultOuter::value_type::numeric_type>
-void arena_strided_dgemm_ce_ce_right(ResultOuter& C, const LeftOuter& L,
-                                     const RightOuter& R, std::size_t Mo,
-                                     std::size_t No, std::size_t Ko,
-                                     math::blas::Op left_op,
-                                     math::blas::Op right_op,
-                                     std::type_identity_t<T> factor,
-                                     bool left_inner_transposed = false) {
+void arena_strided_gemm_ce_ce_right(ResultOuter& C, const LeftOuter& L,
+                                    const RightOuter& R, std::size_t Mo,
+                                    std::size_t No, std::size_t Ko,
+                                    math::blas::Op left_op,
+                                    math::blas::Op right_op,
+                                    std::type_identity_t<T> factor,
+                                    bool left_inner_transposed = false) {
   // left_inner_transposed: the external-carrying LEFT inner cell is stored
   // (a4,a1)=Q x P (matrix_transpose) instead of canonical (a1,a4)=P x Q. Folded
   // into the inner GEMM via transb (zero-copy); the right contraction-vector
   // side must remain canonical (gated upstream).
   namespace blas = TiledArray::math::blas;
   using integer = blas::integer;
-  static_assert(is_tensor_view_v<typename ResultOuter::value_type> &&
-                    is_tensor_view_v<typename LeftOuter::value_type> &&
-                    is_tensor_view_v<typename RightOuter::value_type>,
-                "arena_strided_dgemm_ce_ce_right: arena (view) inner cells only");
+  static_assert(
+      is_tensor_view_v<typename ResultOuter::value_type> &&
+          is_tensor_view_v<typename LeftOuter::value_type> &&
+          is_tensor_view_v<typename RightOuter::value_type>,
+      "arena_strided_gemm_ce_ce_right: arena (view) inner cells only");
   static_assert(
       std::is_same_v<typename ResultOuter::value_type::numeric_type, T> &&
           std::is_same_v<typename LeftOuter::value_type::numeric_type, T> &&
           std::is_same_v<typename RightOuter::value_type::numeric_type, T>,
-      "arena_strided_dgemm_ce_ce_right: inner storages must share numeric type T");
-  static_assert(is_strided_dgemm_numeric_v<T>,
-                "arena_strided_dgemm_ce_ce_right: float/double/complex<float>/"
+      "arena_strided_gemm_ce_ce_right: inner storages must share numeric type "
+      "T");
+  static_assert(is_strided_gemm_numeric_v<T>,
+                "arena_strided_gemm_ce_ce_right: float/double/complex<float>/"
                 "complex<double> inner storage only");
   const std::size_t Mmu = No;  // right outer-external rides BLAS M
   const std::size_t nK = Ko;   // outer-contracted is looped with beta=1
@@ -1396,7 +1399,8 @@ void arena_strided_dgemm_ce_ce_right(ResultOuter& C, const LeftOuter& L,
   TA_ASSERT(shape_ok);
   if (!shape_ok) return;
   ScopedPhaseTimer _kernel_timer(g_kernel_ns_ce_ce);
-  // orientation-aware outer offsets (mirror arena_strided_dgemm_ce_e a_off/b_off)
+  // orientation-aware outer offsets (mirror arena_strided_gemm_ce_e
+  // a_off/b_off)
   const std::size_t ldb_o = (right_op == blas::NoTranspose) ? No : Ko;
   auto r_off = [&](std::size_t k, std::size_t mu) {
     return (right_op == blas::NoTranspose) ? k * ldb_o + mu : mu * ldb_o + k;
@@ -1574,9 +1578,9 @@ void arena_strided_dgemm_ce_ce_right(ResultOuter& C, const LeftOuter& L,
                 /*beta=*/T(1),
                 /*C=*/cstart, /*ldc=*/static_cast<integer>(ldC));
           }
-#ifdef TA_STRIDED_DGEMM_COUNT
-          g_strided_dgemm_ce_ce_right_calls.fetch_add(1,
-                                                      std::memory_order_relaxed);
+#ifdef TA_STRIDED_GEMM_COUNT
+          g_strided_gemm_ce_ce_right_calls.fetch_add(1,
+                                                     std::memory_order_relaxed);
 #endif
           mu = end;
         }
@@ -1585,12 +1589,12 @@ void arena_strided_dgemm_ce_ce_right(ResultOuter& C, const LeftOuter& L,
   }
 }
 
-#ifdef TA_STRIDED_DGEMM_COUNT
-inline std::atomic<std::size_t> g_strided_dgemm_ce_ce_left_calls{0};
+#ifdef TA_STRIDED_GEMM_COUNT
+inline std::atomic<std::size_t> g_strided_gemm_ce_ce_left_calls{0};
 #endif
 
-/// ce+ce strided-DGEMM core, LEFT-clean mirror of
-/// arena_strided_dgemm_ce_ce_right. Here the LEFT operand inner cell is the pure
+/// ce+ce strided-GEMM core, LEFT-clean mirror of
+/// arena_strided_gemm_ce_ce_right. Here the LEFT operand inner cell is the pure
 /// contraction vector L[m,k](a4) (no inner external) and the RIGHT operand
 /// carries the inner external R[k,n](a4,b1); the result inner is the right
 /// inner-external b1. Rides the LEFT outer-external `m` (Mo) into BLAS M and
@@ -1598,21 +1602,22 @@ inline std::atomic<std::size_t> g_strided_dgemm_ce_ce_left_calls{0};
 /// m,k) supplies the strided BLAS-M rows. For each batch b, each right-external
 /// n, and each outer-contraction cell k:
 ///   C[m,n](b1) += factor * Σ_{a4} L[m,k](a4) · R[k,n](a4,b1)
-/// realized as ONE M=Mo × N=P(=b1) × K=Q(=a4) DGEMM riding `m` into BLAS M via
+/// realized as ONE M=Mo × N=P(=b1) × K=Q(=a4) GEMM riding `m` into BLAS M via
 /// the inter-m-cell slab stride (zero-copy), looping k with beta=1. If a
 /// per-(b,n) run is not clean, an inline per-cell fallback handles THAT (b,n)
-/// only (each cell once -> no double-count). Orientation-aware (l_off/r_off from
-/// left_op/right_op of the OUTER GemmHelper, exactly as the right core). C must
-/// be pre-shaped; the result outer is (m, n) row-major. Accumulates (beta=1).
+/// only (each cell once -> no double-count). Orientation-aware (l_off/r_off
+/// from left_op/right_op of the OUTER GemmHelper, exactly as the right core). C
+/// must be pre-shaped; the result outer is (m, n) row-major. Accumulates
+/// (beta=1).
 template <typename ResultOuter, typename LeftOuter, typename RightOuter,
           typename T = typename ResultOuter::value_type::numeric_type>
-void arena_strided_dgemm_ce_ce_left(ResultOuter& C, const LeftOuter& L,
-                                    const RightOuter& R, std::size_t Mo,
-                                    std::size_t No, std::size_t Ko,
-                                    math::blas::Op left_op,
-                                    math::blas::Op right_op,
-                                    std::type_identity_t<T> factor,
-                                    bool right_inner_transposed = false) {
+void arena_strided_gemm_ce_ce_left(ResultOuter& C, const LeftOuter& L,
+                                   const RightOuter& R, std::size_t Mo,
+                                   std::size_t No, std::size_t Ko,
+                                   math::blas::Op left_op,
+                                   math::blas::Op right_op,
+                                   std::type_identity_t<T> factor,
+                                   bool right_inner_transposed = false) {
   // right_inner_transposed: the external-carrying RIGHT inner cell is stored
   // (b1,a4)=P x Q (matrix_transpose) instead of canonical (a4,b1)=Q x P. Folded
   // into the inner GEMM via transb (zero-copy); the left contraction-vector
@@ -1622,14 +1627,15 @@ void arena_strided_dgemm_ce_ce_left(ResultOuter& C, const LeftOuter& L,
   static_assert(is_tensor_view_v<typename ResultOuter::value_type> &&
                     is_tensor_view_v<typename LeftOuter::value_type> &&
                     is_tensor_view_v<typename RightOuter::value_type>,
-                "arena_strided_dgemm_ce_ce_left: arena (view) inner cells only");
+                "arena_strided_gemm_ce_ce_left: arena (view) inner cells only");
   static_assert(
       std::is_same_v<typename ResultOuter::value_type::numeric_type, T> &&
           std::is_same_v<typename LeftOuter::value_type::numeric_type, T> &&
           std::is_same_v<typename RightOuter::value_type::numeric_type, T>,
-      "arena_strided_dgemm_ce_ce_left: inner storages must share numeric type T");
-  static_assert(is_strided_dgemm_numeric_v<T>,
-                "arena_strided_dgemm_ce_ce_left: float/double/complex<float>/"
+      "arena_strided_gemm_ce_ce_left: inner storages must share numeric type "
+      "T");
+  static_assert(is_strided_gemm_numeric_v<T>,
+                "arena_strided_gemm_ce_ce_left: float/double/complex<float>/"
                 "complex<double> inner storage only");
   const std::size_t nK = Ko;  // outer-contracted, looped with beta=1
   const std::size_t nbatch = static_cast<std::size_t>(C.nbatch());
@@ -1642,7 +1648,7 @@ void arena_strided_dgemm_ce_ce_left(ResultOuter& C, const LeftOuter& L,
   TA_ASSERT(shape_ok);
   if (!shape_ok) return;
   ScopedPhaseTimer _kernel_timer(g_kernel_ns_ce_ce);
-  // orientation-aware outer offsets (mirror arena_strided_dgemm_ce_ce_right)
+  // orientation-aware outer offsets (mirror arena_strided_gemm_ce_ce_right)
   const std::size_t lda_o = (left_op == blas::NoTranspose) ? Ko : Mo;
   auto l_off = [&](std::size_t m, std::size_t k) {
     return (left_op == blas::NoTranspose) ? m * lda_o + k : k * lda_o + m;
@@ -1661,14 +1667,14 @@ void arena_strided_dgemm_ce_ce_left(ResultOuter& C, const LeftOuter& L,
     const std::size_t lbase = b * Mo * nK;
     const std::size_t rbase = b * No * nK;
     for (std::size_t n = 0; n < No; ++n) {  // right-external outer loop
-      // Per-k segment walker (mirror of arena_strided_dgemm_ce_ce_right; strided
+      // Per-k segment walker (mirror of arena_strided_gemm_ce_ce_right; strided
       // axis is m, single-cell operand is R[k,n], strided operands are L[m,k]
       // (the BLAS-M rows) and C[m,n]). For each present R[k,n], walk the m axis
       // and emit one strided GEMM per maximal contiguous segment of present,
-      // size-matched (C.size==P, L.size==Q), uniformly-strided cells; skip holes.
-      // beta=1 accumulates across k AND segments. A fully-dense run yields one
-      // full-run segment == the old clean GEMM. A genuine size mismatch
-      // R[k,n] != P*Q drops to a tiny scalar path for that k only.
+      // size-matched (C.size==P, L.size==Q), uniformly-strided cells; skip
+      // holes. beta=1 accumulates across k AND segments. A fully-dense run
+      // yields one full-run segment == the old clean GEMM. A genuine size
+      // mismatch R[k,n] != P*Q drops to a tiny scalar path for that k only.
       const auto _check_t0 = phase_start();
       // Result inner free index P(=b1) from the FIRST PRESENT C[m,n].
       long P = -1;
@@ -1815,9 +1821,9 @@ void arena_strided_dgemm_ce_ce_left(ResultOuter& C, const LeftOuter& L,
                 /*beta=*/T(1),
                 /*C=*/cstart, /*ldc=*/static_cast<integer>(ldC));
           }
-#ifdef TA_STRIDED_DGEMM_COUNT
-          g_strided_dgemm_ce_ce_left_calls.fetch_add(1,
-                                                     std::memory_order_relaxed);
+#ifdef TA_STRIDED_GEMM_COUNT
+          g_strided_gemm_ce_ce_left_calls.fetch_add(1,
+                                                    std::memory_order_relaxed);
 #endif
           m = end;
         }
@@ -2172,7 +2178,7 @@ auto make_regime_a_arena_plan(const A& a, const B& b, const Inner& inner,
   }
 }
 
-/// Kill switch for the regime-A hc+e strided-DGEMM reuse path: when true,
+/// Kill switch for the regime-A hc+e strided-GEMM reuse path: when true,
 /// run_regime_a_arena keeps the legacy per-cell accumulate. Test/bench hook
 /// for the strided-vs-per-cell differential (correctness) and the perf
 /// measurement; production default is false (strided on). Mirrors
@@ -2224,7 +2230,7 @@ bool run_regime_a_arena(const Plan& plan, const HIndex& h, std::size_t batch,
     if constexpr (a_is_tot && b_is_tot) {
       using IIndex = ::Einsum::index::Index<std::size_t>;
       // hc+e reuse gate: the result/operand inner cells must be the kernel's
-      // (view + BLAS numeric) inner type; mirror arena_strided_dgemm_ce_e's
+      // (view + BLAS numeric) inner type; mirror arena_strided_gemm_ce_e's
       // static_assert so non-view / non-BLAS-numeric / mixed-type ToT keep the
       // per-cell path.
       using LInnerT = typename ArrayA_t::value_type::value_type;
@@ -2232,7 +2238,7 @@ bool run_regime_a_arena(const Plan& plan, const HIndex& h, std::size_t batch,
       constexpr bool ce_e_kernel_ok =
           is_tensor_view_v<InnerT> && is_tensor_view_v<LInnerT> &&
           is_tensor_view_v<RInnerT> &&
-          is_strided_dgemm_numeric_v<typename InnerT::numeric_type> &&
+          is_strided_gemm_numeric_v<typename InnerT::numeric_type> &&
           std::is_same_v<typename LInnerT::numeric_type,
                          typename InnerT::numeric_type> &&
           std::is_same_v<typename RInnerT::numeric_type,
@@ -2313,10 +2319,11 @@ bool run_regime_a_arena(const Plan& plan, const HIndex& h, std::size_t batch,
             const std::size_t Kvol =
                 static_cast<std::size_t>(trange.tile(i).volume());
             auto cview = tile.reshape(TiledArray::Range{1}, batch);
-            arena_strided_dgemm_ce_e(cview, ai, bi, /*M=*/std::size_t{1},
-                                     /*N=*/std::size_t{1}, /*K=*/Kvol,
-                                     blas::NoTranspose, blas::NoTranspose,
-                                     /*factor=*/typename InnerT::numeric_type(1));
+            arena_strided_gemm_ce_e(
+                cview, ai, bi, /*M=*/std::size_t{1},
+                /*N=*/std::size_t{1}, /*K=*/Kvol, blas::NoTranspose,
+                blas::NoTranspose,
+                /*factor=*/typename InnerT::numeric_type(1));
             continue;  // tile-i contribution complete
           }
         }

--- a/src/TiledArray/tensor/arena_tensor.h
+++ b/src/TiledArray/tensor/arena_tensor.h
@@ -445,14 +445,10 @@ void scale_to(ArenaTensor<T, R>& dst, Scalar factor) {
   if (!dst) return;
   auto* d = dst.data();
   const auto n = dst.size();
-  if constexpr (requires(T& x) { x *= factor; }) {
-    for (std::size_t i = 0; i < n; ++i) d[i] *= factor;
-  } else {
-    // no compound operator for this element/factor pair (e.g. complex<double>
-    // *= int): use detail's mixed complex x scalar operator*
-    using namespace TiledArray::detail;
-    for (std::size_t i = 0; i < n; ++i) d[i] = d[i] * factor;
-  }
+  // operator*= is the permissive one (std::complex<T>::operator*=(const T&)
+  // accepts any arithmetic factor), so no mixed-scalar detail operator is
+  // needed here
+  for (std::size_t i = 0; i < n; ++i) d[i] *= factor;
 }
 
 /// `dst += src`. Asserts shape compatibility.

--- a/src/TiledArray/tensor/arena_tensor.h
+++ b/src/TiledArray/tensor/arena_tensor.h
@@ -445,7 +445,14 @@ void scale_to(ArenaTensor<T, R>& dst, Scalar factor) {
   if (!dst) return;
   auto* d = dst.data();
   const auto n = dst.size();
-  for (std::size_t i = 0; i < n; ++i) d[i] *= factor;
+  if constexpr (requires(T& x) { x *= factor; }) {
+    for (std::size_t i = 0; i < n; ++i) d[i] *= factor;
+  } else {
+    // no compound operator for this element/factor pair (e.g. complex<double>
+    // *= int): use detail's mixed complex x scalar operator*
+    using namespace TiledArray::detail;
+    for (std::size_t i = 0; i < n; ++i) d[i] = d[i] * factor;
+  }
 }
 
 /// `dst += src`. Asserts shape compatibility.

--- a/src/TiledArray/tensor/tensor.h
+++ b/src/TiledArray/tensor/tensor.h
@@ -1972,6 +1972,9 @@ class Tensor {
       auto fill = [factor](typename value_type::value_type* dst,
                            const typename value_type::value_type* src,
                            std::size_t n) {
+        // detail's mixed complex x scalar operator* (e.g. complex<double> *
+        // int), as in the non-nested branch below
+        using namespace TiledArray::detail;
         for (std::size_t i = 0; i < n; ++i) dst[i] = src[i] * factor;
       };
       return detail::arena_trivial_unary<Tensor>(*this, fill);
@@ -1979,6 +1982,9 @@ class Tensor {
       auto fill = [factor](typename value_type::value_type* dst,
                            const typename value_type::value_type* src,
                            std::size_t n) {
+        // detail's mixed complex x scalar operator* (e.g. complex<double> *
+        // int), as in the non-nested branch below
+        using namespace TiledArray::detail;
         for (std::size_t i = 0; i < n; ++i) dst[i] = src[i] * factor;
       };
       return detail::arena_trivial_unary<Tensor>(*this, fill);

--- a/src/TiledArray/tile_op/contract_reduce.h
+++ b/src/TiledArray/tile_op/contract_reduce.h
@@ -138,7 +138,7 @@ class ContractReduceBase {
     /// \note the lifetime is managed by the callee!
     TiledArray::function_ref<elem_muladd_op_type> elem_muladd_op_;
 
-    /// whole-tile strided-DGEMM outer-contraction op for arena ToT. When set,
+    /// whole-tile strided-GEMM outer-contraction op for arena ToT. When set,
     /// ContractReduce::operator() delegates the (pre-shaped) result fill to it
     /// instead of the generic gemm. Carries factor itself (alpha_ is forced to
     /// 1 for ToT).
@@ -243,9 +243,9 @@ class ContractReduceBase {
     return pimpl_->arena_plan_;
   }
 
-  /// Strided-DGEMM op accessor/mutator
+  /// Strided-GEMM op accessor/mutator
 
-  /// \return A const reference to the strided-DGEMM op function_ref
+  /// \return A const reference to the strided-GEMM op function_ref
   const TiledArray::function_ref<typename Impl::strided_oprod_op_type>&
   strided_oprod_op() const {
     return pimpl_->strided_oprod_op_;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -106,7 +106,7 @@ set(ta_test_src_files  ta_test.cpp
     arena_sizeof_invariant_suite.cpp
     arena_tensor.cpp
     arena_tensor_kernels.cpp
-    arena_strided_dgemm.cpp
+    arena_strided_gemm.cpp
     tot_construction.cpp
 )
 

--- a/tests/arena_strided_dgemm.cpp
+++ b/tests/arena_strided_dgemm.cpp
@@ -5,6 +5,7 @@
 #include "TiledArray/math/blas.h"
 #include "tiledarray.h"
 #include "unit_test_config.h"
+#include <complex>
 #include <functional>
 #include <memory>
 #include <vector>
@@ -2107,6 +2108,124 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_killswitch_matches_left) {
     for (std::size_t a1 = 0; a1 < Cs.data()[o].size(); ++a1)
       BOOST_CHECK_CLOSE(Cs.data()[o].data()[a1], Cp.data()[o].data()[a1], 1e-12);
   }
+}
+
+
+// ---------------------------------------------------------------------------
+// std::complex<double> inner storage: the three strided kernels are templated
+// on the inner numeric type (is_strided_dgemm_numeric_v), so complex ToT
+// contractions (e.g. Kramers/relativistic CSV amplitudes) take the same
+// zero-copy strided path. Each case fabricates complex arena tiles inline and
+// checks against a naive complex reference, including a complex factor.
+using ZInner = TA::ArenaTensor<std::complex<double>, TA::Range>;
+using ZOuter = TA::Tensor<ZInner>;
+
+namespace {
+ZOuter make_filled_z(const TA::Range& r,
+                     const std::function<TA::Range(std::size_t)>& shape_fn,
+                     double base) {
+  ZOuter t = TA::detail::arena_outer_init<ZOuter>(r, 1, shape_fn);
+  for (std::size_t o = 0; o < t.range().volume(); ++o) {
+    ZInner& c = t.data()[o];
+    if (!c) continue;
+    for (std::size_t e = 0; e < c.size(); ++e)
+      c.data()[e] = std::complex<double>(base + 0.01 * o + e, 0.5 * e - 0.1 * o);
+  }
+  return t;
+}
+void check_close_z(const std::complex<double>& got,
+                   const std::complex<double>& ref) {
+  BOOST_CHECK_SMALL(std::abs(got - ref), 1e-10 * std::max(1.0, std::abs(ref)));
+}
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(ce_e_complex_matches_reference) {
+  namespace blas = TA::math::blas;
+  using Z = std::complex<double>;
+  const std::size_t M = 2, N = 3, K = 4, P = 3, Q = 5;
+  const Z factor(0.5, -1.25);
+  ZOuter L = make_filled_z(TA::Range{M, K}, [&](std::size_t) { return TA::Range{P}; }, 1.0);
+  ZOuter R = make_filled_z(TA::Range{N, K}, [&](std::size_t) { return TA::Range{Q}; }, 2.0);
+  ZOuter C = TA::detail::arena_outer_init<ZOuter>(
+      TA::Range{M, N}, 1, [&](std::size_t) { return TA::Range{P, Q}; });  // zero-init
+  TA::detail::arena_strided_dgemm_ce_e(C, L, R, M, N, K, blas::NoTranspose,
+                                       blas::Transpose, factor);
+  for (std::size_t m = 0; m < M; ++m)
+    for (std::size_t n = 0; n < N; ++n) {
+      std::vector<Z> ref(P * Q, Z{});
+      for (std::size_t k = 0; k < K; ++k) {
+        const Z* lp = L.data()[m * K + k].data();
+        const Z* rp = R.data()[n * K + k].data();
+        for (std::size_t p = 0; p < P; ++p)
+          for (std::size_t q = 0; q < Q; ++q) ref[p * Q + q] += factor * lp[p] * rp[q];
+      }
+      const Z* got = C.data()[m * N + n].data();
+      for (std::size_t e = 0; e < P * Q; ++e) check_close_z(got[e], ref[e]);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(ce_ce_right_complex_matches_reference) {
+  namespace blas = TA::math::blas;
+  using Z = std::complex<double>;
+  const std::size_t Mo = 2, Mmu = 3, nK = 2, P = 4, Q = 5;
+  const Z factor(-0.75, 0.3);
+  // L outer (Mo,nK) row-major (m slow, k fast), inner {P,Q}.
+  ZOuter L = make_filled_z(TA::Range{Mo, nK}, [&](std::size_t) { return TA::Range{P, Q}; }, 1.0);
+  // R outer (Mmu,nK) canonical (mu slow, k fast), inner {Q}.
+  ZOuter R = make_filled_z(TA::Range{Mmu, nK}, [&](std::size_t) { return TA::Range{Q}; }, 2.0);
+  // C outer (Mo,Mmu) row-major (m slow, mu fast), inner {P}.
+  ZOuter C = TA::detail::arena_outer_init<ZOuter>(
+      TA::Range{Mo, Mmu}, 1, [&](std::size_t) { return TA::Range{P}; });
+  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, /*Mo=*/Mo, /*No=*/Mmu,
+                                              /*Ko=*/nK, blas::NoTranspose,
+                                              blas::Transpose, factor);
+  for (std::size_t m = 0; m < Mo; ++m)
+    for (std::size_t mu = 0; mu < Mmu; ++mu) {
+      std::vector<Z> ref(P, Z{});
+      for (std::size_t k = 0; k < nK; ++k) {
+        const Z* l = L.data()[m * nK + k].data();   // P x Q row-major
+        const Z* r = R.data()[mu * nK + k].data();  // Q
+        for (std::size_t a1 = 0; a1 < P; ++a1) {
+          Z acc{};
+          for (std::size_t a4 = 0; a4 < Q; ++a4) acc += l[a1 * Q + a4] * r[a4];
+          ref[a1] += factor * acc;
+        }
+      }
+      const Z* got = C.data()[m * Mmu + mu].data();
+      for (std::size_t a1 = 0; a1 < P; ++a1) check_close_z(got[a1], ref[a1]);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(ce_ce_left_complex_matches_reference) {
+  namespace blas = TA::math::blas;
+  using Z = std::complex<double>;
+  const std::size_t Mo = 2, No = 3, nK = 2, P = 4, Q = 5;
+  const Z factor(1.5, 2.0);
+  // L (clean) outer (Mo,nK) row-major (m slow, k fast), inner {Q}.
+  ZOuter L = make_filled_z(TA::Range{Mo, nK}, [&](std::size_t) { return TA::Range{Q}; }, 1.0);
+  // R (matrix) outer (nK,No) canonical (k slow, n fast), inner {Q,P} row-major.
+  ZOuter R = make_filled_z(TA::Range{nK, No}, [&](std::size_t) { return TA::Range{Q, P}; }, 2.0);
+  // C outer (Mo,No) row-major (m slow, n fast), inner {P}.
+  ZOuter C = TA::detail::arena_outer_init<ZOuter>(
+      TA::Range{Mo, No}, 1, [&](std::size_t) { return TA::Range{P}; });
+  TA::detail::arena_strided_dgemm_ce_ce_left(C, L, R, /*Mo=*/Mo, /*No=*/No,
+                                             /*Ko=*/nK, blas::NoTranspose,
+                                             blas::NoTranspose, factor);
+  for (std::size_t m = 0; m < Mo; ++m)
+    for (std::size_t n = 0; n < No; ++n) {
+      std::vector<Z> ref(P, Z{});
+      for (std::size_t k = 0; k < nK; ++k) {
+        const Z* l = L.data()[m * nK + k].data();  // Q vector
+        const Z* r = R.data()[k * No + n].data();  // Q x P row-major
+        for (std::size_t p = 0; p < P; ++p) {
+          Z acc{};
+          for (std::size_t a4 = 0; a4 < Q; ++a4) acc += l[a4] * r[a4 * P + p];
+          ref[p] += factor * acc;
+        }
+      }
+      const Z* got = C.data()[m * No + n].data();
+      for (std::size_t p = 0; p < P; ++p) check_close_z(got[p], ref[p]);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/arena_strided_dgemm.cpp
+++ b/tests/arena_strided_dgemm.cpp
@@ -1,10 +1,14 @@
 // tests/arena_strided_dgemm.cpp
+#include <boost/mpl/list.hpp>
+#include "TiledArray/math/blas.h"
+#include "TiledArray/tensor.h"
 #include "TiledArray/tensor/arena_einsum.h"
 #include "TiledArray/tensor/arena_kernels.h"
-#include "TiledArray/tensor.h"
-#include "TiledArray/math/blas.h"
 #include "tiledarray.h"
 #include "unit_test_config.h"
+
+#include <algorithm>
+#include <cmath>
 #include <complex>
 #include <functional>
 #include <memory>
@@ -2110,122 +2114,208 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_killswitch_matches_left) {
   }
 }
 
-
 // ---------------------------------------------------------------------------
-// std::complex<double> inner storage: the three strided kernels are templated
-// on the inner numeric type (is_strided_dgemm_numeric_v), so complex ToT
-// contractions (e.g. Kramers/relativistic CSV amplitudes) take the same
-// zero-copy strided path. Each case fabricates complex arena tiles inline and
-// checks against a naive complex reference, including a complex factor.
-using ZInner = TA::ArenaTensor<std::complex<double>, TA::Range>;
-using ZOuter = TA::Tensor<ZInner>;
+// Every other BLAS GEMM element type admitted by is_strided_dgemm_numeric_v
+// (double is the type of the whole suite above): the three strided kernels
+// are templated on the inner numeric type, so float, complex<float> and
+// complex<double> ToT contractions (e.g. Kramers/relativistic CSV amplitudes)
+// take the same zero-copy strided path. Each case fabricates arena tiles
+// inline and checks against a naive reference, with a complex factor where
+// the type allows one.
+using strided_numeric_types =
+    boost::mpl::list<float, std::complex<float>, std::complex<double>>;
 
 namespace {
-ZOuter make_filled_z(const TA::Range& r,
-                     const std::function<TA::Range(std::size_t)>& shape_fn,
-                     double base) {
-  ZOuter t = TA::detail::arena_outer_init<ZOuter>(r, 1, shape_fn);
+template <typename T>
+using ArenaOuterOf = TA::Tensor<TA::ArenaTensor<T, TA::Range>>;
+
+template <typename T>
+T fill_value(double re, double im) {
+  if constexpr (TA::detail::is_complex_v<T>) {
+    using S = typename T::value_type;
+    return T(static_cast<S>(re), static_cast<S>(im));
+  } else {
+    return static_cast<T>(re);
+  }
+}
+
+template <typename T>
+ArenaOuterOf<T> make_filled_t(
+    const TA::Range& r, const std::function<TA::Range(std::size_t)>& shape_fn,
+    double base) {
+  auto t = TA::detail::arena_outer_init<ArenaOuterOf<T>>(r, 1, shape_fn);
   for (std::size_t o = 0; o < t.range().volume(); ++o) {
-    ZInner& c = t.data()[o];
+    auto& c = t.data()[o];
     if (!c) continue;
     for (std::size_t e = 0; e < c.size(); ++e)
-      c.data()[e] = std::complex<double>(base + 0.01 * o + e, 0.5 * e - 0.1 * o);
+      c.data()[e] = fill_value<T>(base + 0.01 * o + e, 0.5 * e - 0.1 * o);
   }
   return t;
 }
-void check_close_z(const std::complex<double>& got,
-                   const std::complex<double>& ref) {
-  BOOST_CHECK_SMALL(std::abs(got - ref), 1e-10 * std::max(1.0, std::abs(ref)));
+
+template <typename T>
+void check_close_t(const T& got, const T& ref) {
+  using S = TA::detail::scalar_t<T>;
+  const double tol = std::is_same_v<S, float> ? 1e-4 : 1e-10;
+  BOOST_CHECK_SMALL(static_cast<double>(std::abs(got - ref)),
+                    tol * std::max(1.0, static_cast<double>(std::abs(ref))));
 }
 }  // namespace
 
-BOOST_AUTO_TEST_CASE(ce_e_complex_matches_reference) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(ce_e_numeric_matches_reference, T,
+                              strided_numeric_types) {
   namespace blas = TA::math::blas;
-  using Z = std::complex<double>;
+  using Outer = ArenaOuterOf<T>;
   const std::size_t M = 2, N = 3, K = 4, P = 3, Q = 5;
-  const Z factor(0.5, -1.25);
-  ZOuter L = make_filled_z(TA::Range{M, K}, [&](std::size_t) { return TA::Range{P}; }, 1.0);
-  ZOuter R = make_filled_z(TA::Range{N, K}, [&](std::size_t) { return TA::Range{Q}; }, 2.0);
-  ZOuter C = TA::detail::arena_outer_init<ZOuter>(
-      TA::Range{M, N}, 1, [&](std::size_t) { return TA::Range{P, Q}; });  // zero-init
+  const T factor = fill_value<T>(0.5, -1.25);
+  Outer L = make_filled_t<T>(
+      TA::Range{M, K}, [&](std::size_t) { return TA::Range{P}; }, 1.0);
+  Outer R = make_filled_t<T>(
+      TA::Range{N, K}, [&](std::size_t) { return TA::Range{Q}; }, 2.0);
+  Outer C = TA::detail::arena_outer_init<Outer>(
+      TA::Range{M, N}, 1,
+      [&](std::size_t) { return TA::Range{P, Q}; });  // zero-init
   TA::detail::arena_strided_dgemm_ce_e(C, L, R, M, N, K, blas::NoTranspose,
                                        blas::Transpose, factor);
   for (std::size_t m = 0; m < M; ++m)
     for (std::size_t n = 0; n < N; ++n) {
-      std::vector<Z> ref(P * Q, Z{});
+      std::vector<T> ref(P * Q, T{});
       for (std::size_t k = 0; k < K; ++k) {
-        const Z* lp = L.data()[m * K + k].data();
-        const Z* rp = R.data()[n * K + k].data();
+        const T* lp = L.data()[m * K + k].data();
+        const T* rp = R.data()[n * K + k].data();
         for (std::size_t p = 0; p < P; ++p)
-          for (std::size_t q = 0; q < Q; ++q) ref[p * Q + q] += factor * lp[p] * rp[q];
+          for (std::size_t q = 0; q < Q; ++q)
+            ref[p * Q + q] += factor * lp[p] * rp[q];
       }
-      const Z* got = C.data()[m * N + n].data();
-      for (std::size_t e = 0; e < P * Q; ++e) check_close_z(got[e], ref[e]);
+      const T* got = C.data()[m * N + n].data();
+      for (std::size_t e = 0; e < P * Q; ++e) check_close_t(got[e], ref[e]);
     }
 }
 
-BOOST_AUTO_TEST_CASE(ce_ce_right_complex_matches_reference) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(ce_ce_right_numeric_matches_reference, T,
+                              strided_numeric_types) {
   namespace blas = TA::math::blas;
-  using Z = std::complex<double>;
+  using Outer = ArenaOuterOf<T>;
   const std::size_t Mo = 2, Mmu = 3, nK = 2, P = 4, Q = 5;
-  const Z factor(-0.75, 0.3);
+  const T factor = fill_value<T>(-0.75, 0.3);
   // L outer (Mo,nK) row-major (m slow, k fast), inner {P,Q}.
-  ZOuter L = make_filled_z(TA::Range{Mo, nK}, [&](std::size_t) { return TA::Range{P, Q}; }, 1.0);
+  Outer L = make_filled_t<T>(
+      TA::Range{Mo, nK}, [&](std::size_t) { return TA::Range{P, Q}; }, 1.0);
   // R outer (Mmu,nK) canonical (mu slow, k fast), inner {Q}.
-  ZOuter R = make_filled_z(TA::Range{Mmu, nK}, [&](std::size_t) { return TA::Range{Q}; }, 2.0);
+  Outer R = make_filled_t<T>(
+      TA::Range{Mmu, nK}, [&](std::size_t) { return TA::Range{Q}; }, 2.0);
   // C outer (Mo,Mmu) row-major (m slow, mu fast), inner {P}.
-  ZOuter C = TA::detail::arena_outer_init<ZOuter>(
+  Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mo, Mmu}, 1, [&](std::size_t) { return TA::Range{P}; });
   TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, /*Mo=*/Mo, /*No=*/Mmu,
                                               /*Ko=*/nK, blas::NoTranspose,
                                               blas::Transpose, factor);
   for (std::size_t m = 0; m < Mo; ++m)
     for (std::size_t mu = 0; mu < Mmu; ++mu) {
-      std::vector<Z> ref(P, Z{});
+      std::vector<T> ref(P, T{});
       for (std::size_t k = 0; k < nK; ++k) {
-        const Z* l = L.data()[m * nK + k].data();   // P x Q row-major
-        const Z* r = R.data()[mu * nK + k].data();  // Q
+        const T* l = L.data()[m * nK + k].data();   // P x Q row-major
+        const T* r = R.data()[mu * nK + k].data();  // Q
         for (std::size_t a1 = 0; a1 < P; ++a1) {
-          Z acc{};
+          T acc{};
           for (std::size_t a4 = 0; a4 < Q; ++a4) acc += l[a1 * Q + a4] * r[a4];
           ref[a1] += factor * acc;
         }
       }
-      const Z* got = C.data()[m * Mmu + mu].data();
-      for (std::size_t a1 = 0; a1 < P; ++a1) check_close_z(got[a1], ref[a1]);
+      const T* got = C.data()[m * Mmu + mu].data();
+      for (std::size_t a1 = 0; a1 < P; ++a1) check_close_t(got[a1], ref[a1]);
     }
 }
 
-BOOST_AUTO_TEST_CASE(ce_ce_left_complex_matches_reference) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(ce_ce_left_numeric_matches_reference, T,
+                              strided_numeric_types) {
   namespace blas = TA::math::blas;
-  using Z = std::complex<double>;
+  using Outer = ArenaOuterOf<T>;
   const std::size_t Mo = 2, No = 3, nK = 2, P = 4, Q = 5;
-  const Z factor(1.5, 2.0);
+  const T factor = fill_value<T>(1.5, 2.0);
   // L (clean) outer (Mo,nK) row-major (m slow, k fast), inner {Q}.
-  ZOuter L = make_filled_z(TA::Range{Mo, nK}, [&](std::size_t) { return TA::Range{Q}; }, 1.0);
+  Outer L = make_filled_t<T>(
+      TA::Range{Mo, nK}, [&](std::size_t) { return TA::Range{Q}; }, 1.0);
   // R (matrix) outer (nK,No) canonical (k slow, n fast), inner {Q,P} row-major.
-  ZOuter R = make_filled_z(TA::Range{nK, No}, [&](std::size_t) { return TA::Range{Q, P}; }, 2.0);
+  Outer R = make_filled_t<T>(
+      TA::Range{nK, No}, [&](std::size_t) { return TA::Range{Q, P}; }, 2.0);
   // C outer (Mo,No) row-major (m slow, n fast), inner {P}.
-  ZOuter C = TA::detail::arena_outer_init<ZOuter>(
+  Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mo, No}, 1, [&](std::size_t) { return TA::Range{P}; });
   TA::detail::arena_strided_dgemm_ce_ce_left(C, L, R, /*Mo=*/Mo, /*No=*/No,
                                              /*Ko=*/nK, blas::NoTranspose,
                                              blas::NoTranspose, factor);
   for (std::size_t m = 0; m < Mo; ++m)
     for (std::size_t n = 0; n < No; ++n) {
-      std::vector<Z> ref(P, Z{});
+      std::vector<T> ref(P, T{});
       for (std::size_t k = 0; k < nK; ++k) {
-        const Z* l = L.data()[m * nK + k].data();  // Q vector
-        const Z* r = R.data()[k * No + n].data();  // Q x P row-major
+        const T* l = L.data()[m * nK + k].data();  // Q vector
+        const T* r = R.data()[k * No + n].data();  // Q x P row-major
         for (std::size_t p = 0; p < P; ++p) {
-          Z acc{};
+          T acc{};
           for (std::size_t a4 = 0; a4 < Q; ++a4) acc += l[a4] * r[a4 * P + p];
           ref[p] += factor * acc;
         }
       }
-      const Z* got = C.data()[m * No + n].data();
-      for (std::size_t p = 0; p < P; ++p) check_close_z(got[p], ref[p]);
+      const T* got = C.data()[m * No + n].data();
+      for (std::size_t p = 0; p < P; ++p) check_close_t(got[p], ref[p]);
     }
+}
+
+// The arena-ToT (Tensor<ArenaTensor>) element-wise paths for complex cells
+// with integral/real factors: scale, add, subt, mult, the in-place scale_to
+// and axpy_to, and squared_norm (which must be Sum|z|^2 in the real scalar
+// type, not Sum z^2). These are the production paths of a complex arena ToT
+// DistArray; the owning-ToT fixture rows never reach them.
+BOOST_AUTO_TEST_CASE(arena_tot_complex_elementwise_and_norm) {
+  using Z = std::complex<double>;
+  using ZO = ArenaOuterOf<Z>;
+  const std::size_t M = 2, N = 3, P = 4;
+  auto shape = [&](std::size_t) { return TA::Range{P}; };
+  const ZO A = make_filled_t<Z>(TA::Range{M, N}, shape, 1.0);
+  const ZO B = make_filled_t<Z>(TA::Range{M, N}, shape, 2.0);
+  auto for_each_elem = [&](const ZO& got, auto&& ref_of) {
+    BOOST_REQUIRE_EQUAL(got.range().volume(), A.range().volume());
+    for (std::size_t o = 0; o < A.range().volume(); ++o) {
+      BOOST_REQUIRE(bool(got.data()[o]));
+      BOOST_REQUIRE_EQUAL(got.data()[o].size(), A.data()[o].size());
+      for (std::size_t e = 0; e < P; ++e)
+        check_close_t(got.data()[o].data()[e], ref_of(o, e));
+    }
+  };
+  auto a = [&](std::size_t o, std::size_t e) { return A.data()[o].data()[e]; };
+  auto b = [&](std::size_t o, std::size_t e) { return B.data()[o].data()[e]; };
+
+  // integral and real factors on complex cells
+  for_each_elem(A.scale(2), [&](auto o, auto e) { return a(o, e) * 2.0; });
+  for_each_elem(A.scale(2.5), [&](auto o, auto e) { return a(o, e) * 2.5; });
+  for_each_elem(A.add(B), [&](auto o, auto e) { return a(o, e) + b(o, e); });
+  for_each_elem(A.subt(B), [&](auto o, auto e) { return a(o, e) - b(o, e); });
+  for_each_elem(A.mult(B), [&](auto o, auto e) { return a(o, e) * b(o, e); });
+
+  // in-place, on a fresh copy each time
+  {
+    ZO C = make_filled_t<Z>(TA::Range{M, N}, shape, 1.0);
+    C.scale_to(3);
+    for_each_elem(C, [&](auto o, auto e) { return a(o, e) * 3.0; });
+  }
+  {
+    ZO C = make_filled_t<Z>(TA::Range{M, N}, shape, 1.0);
+    C.axpy_to(B, 2);
+    for_each_elem(C, [&](auto o, auto e) { return a(o, e) + 2.0 * b(o, e); });
+  }
+
+  // squared_norm: real scalar type, Sum |z|^2
+  static_assert(std::is_same_v<decltype(squared_norm(A.data()[0])), double>,
+                "arena squared_norm must return the real scalar type");
+  double ref_sq = 0.0;
+  for (std::size_t o = 0; o < A.range().volume(); ++o)
+    for (std::size_t e = 0; e < P; ++e) ref_sq += std::norm(a(o, e));
+  double cell_sq = 0.0;
+  for (std::size_t o = 0; o < A.range().volume(); ++o)
+    cell_sq += squared_norm(A.data()[o]);
+  BOOST_CHECK_CLOSE(cell_sq, ref_sq, 1e-10);
+  BOOST_CHECK_CLOSE(A.squared_norm(), ref_sq, 1e-10);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/arena_strided_gemm.cpp
+++ b/tests/arena_strided_gemm.cpp
@@ -1,4 +1,4 @@
-// tests/arena_strided_dgemm.cpp
+// tests/arena_strided_gemm.cpp
 #include <boost/mpl/list.hpp>
 #include "TiledArray/math/blas.h"
 #include "TiledArray/tensor.h"
@@ -68,7 +68,7 @@ std::vector<double> ref_ce_ce(const Outer& L, const Outer& R, std::size_t Mmu,
 }
 
 // ---------------------------------------------------------------------------
-// Sparsity-aware helpers for the per-k segmented strided-DGEMM tests (T1-T15).
+// Sparsity-aware helpers for the per-k segmented strided-GEMM tests (T1-T15).
 //
 // make_sparse: like make_filled, but a cell whose dense_shape(o) is selected by
 // is_hole(o) is built from a zero-volume TA::Range{}, which arena_outer_init
@@ -87,18 +87,18 @@ Outer make_sparse(const TA::Range& outer_range, std::size_t nbatch,
   return t;
 }
 
-// Sparsity-aware reference for arena_strided_dgemm_ce_ce_right in the SAME
-// canonical convention as ref_ce_ce (L=strided P x Q matrix, R=single Q-vector),
-// but generalized to Mo>=1 outer rows, NB batches, holes, and the left-inner
-// transpose. Per the kernel: for result cell C[m,mu] (length P),
+// Sparsity-aware reference for arena_strided_gemm_ce_ce_right in the SAME
+// canonical convention as ref_ce_ce (L=strided P x Q matrix, R=single
+// Q-vector), but generalized to Mo>=1 outer rows, NB batches, holes, and the
+// left-inner transpose. Per the kernel: for result cell C[m,mu] (length P),
 //   C[m,mu](a1) = factor * sum_k present L[m,k] (P x Q) * present R[mu,k] (Q),
 // skipping any k where L[m,k] or R[mu,k] is absent or size-mismatched.
 //   L outer (Mo x nK), canonical index b*Mo*nK + m*nK + k, inner {P,Q}
-//   R outer (Mmu x nK), canonical (mu slow, k fast) b*Mmu*nK + mu*nK + k, inner {Q}
-//   C outer (Mo x Mmu), index b*Mo*Mmu + m*Mmu + mu, inner {P}
-// out[(b*Mo+m)*Mmu+mu] is the expected length-P vector (empty == expect absent).
-// lt mirrors left_inner_transposed: lt=false L stored P x Q (l[a1*Q+a4]),
-// lt=true L stored Q x P (l[a4*P+a1]).
+//   R outer (Mmu x nK), canonical (mu slow, k fast) b*Mmu*nK + mu*nK + k, inner
+//   {Q} C outer (Mo x Mmu), index b*Mo*Mmu + m*Mmu + mu, inner {P}
+// out[(b*Mo+m)*Mmu+mu] is the expected length-P vector (empty == expect
+// absent). lt mirrors left_inner_transposed: lt=false L stored P x Q
+// (l[a1*Q+a4]), lt=true L stored Q x P (l[a4*P+a1]).
 std::vector<std::vector<double>> ref_ce_ce_right_sparse(
     const Outer& L, const Outer& R, std::size_t Mo, std::size_t Mmu,
     std::size_t nK, std::size_t P, double factor, std::size_t nbatch = 1,
@@ -130,16 +130,17 @@ std::vector<std::vector<double>> ref_ce_ce_right_sparse(
   return out;
 }
 
-// Sparsity-aware reference for arena_strided_dgemm_ce_ce_left. Here m (Mo) is
+// Sparsity-aware reference for arena_strided_gemm_ce_ce_left. Here m (Mo) is
 // the strided axis, n (No) the fixed result column; the RIGHT operand cell
 // R[k,n] (the P x Q matrix) is the single non-strided operand and L[m,k] (the
 // length-Q contraction vector) is the strided run. Per the kernel:
 //   C[m,n](b1) = factor * sum_k present L[m,k] (Q) * present R[k,n] (Q x P),
 // where result inner length P = b1. R canonical (a4,b1)=Q x P row-major
-// (rt=false: r[a4*P+b1]); rt mirrors right_inner_transposed (P x Q, r[b1*Q+a4]).
+// (rt=false: r[a4*P+b1]); rt mirrors right_inner_transposed (P x Q,
+// r[b1*Q+a4]).
 //   L outer (Mo x nK), index b*Mo*nK + m*nK + k, inner {Q}
-//   R outer (nK x No), canonical (k slow, n fast) b*nK*No + k*No + n, inner {Q,P}
-//   C outer (Mo x No), index b*Mo*No + m*No + n, inner {P}
+//   R outer (nK x No), canonical (k slow, n fast) b*nK*No + k*No + n, inner
+//   {Q,P} C outer (Mo x No), index b*Mo*No + m*No + n, inner {P}
 std::vector<std::vector<double>> ref_ce_ce_left_sparse(
     const Outer& L, const Outer& R, std::size_t Mo, std::size_t No,
     std::size_t nK, std::size_t P, double factor, std::size_t nbatch = 1,
@@ -195,7 +196,7 @@ Outer assemble_aliased(const Outer& src, const TA::Range& outer_range,
 }
 }  // namespace
 
-BOOST_AUTO_TEST_SUITE(arena_strided_dgemm_suite, TA_UT_LABEL_SERIAL)
+BOOST_AUTO_TEST_SUITE(arena_strided_gemm_suite, TA_UT_LABEL_SERIAL)
 
 // FACT A: uniform cells -> single constant inter-cell stride (>= cell size).
 BOOST_AUTO_TEST_CASE(fact_uniform_constant_stride) {
@@ -242,8 +243,8 @@ BOOST_AUTO_TEST_CASE(ce_e_matches_reference) {
   Outer R = make_filled(TA::Range{N, K}, [&](std::size_t){return TA::Range{Q};}, 2.0);
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{M, N}, 1, [&](std::size_t){return TA::Range{P, Q};});  // zero-init
-  TA::detail::arena_strided_dgemm_ce_e(C, L, R, M, N, K, blas::NoTranspose,
-                                       blas::Transpose, /*factor=*/1.0);
+  TA::detail::arena_strided_gemm_ce_e(C, L, R, M, N, K, blas::NoTranspose,
+                                      blas::Transpose, /*factor=*/1.0);
   for (std::size_t m = 0; m < M; ++m)
     for (std::size_t n = 0; n < N; ++n) {
       auto ref = ref_ce_e(L, R, m, n, K, P, Q, 1.0);
@@ -266,8 +267,8 @@ BOOST_AUTO_TEST_CASE(ce_e_ragged_cell_still_correct_inline) {
   // for the ragged row use P from k=0 (=3) so the fallback's pp*qq guard holds.
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{M, N}, 1, [&](std::size_t o){ return TA::Range{3, Q}; });
-  TA::detail::arena_strided_dgemm_ce_e(C, L, R, M, N, K, blas::NoTranspose,
-                                       blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_e(C, L, R, M, N, K, blas::NoTranspose,
+                                      blas::Transpose, 1.0);
   // (0,0): clean GEMM path
   {
     auto ref = ref_ce_e(L, R, 0, 0, K, 3, Q, 1.0);
@@ -298,8 +299,8 @@ BOOST_AUTO_TEST_CASE(ce_e_applies_factor) {
   Outer R = make_filled(TA::Range{N, K}, [&](std::size_t){return TA::Range{Q};}, 2.0);
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{M, N}, 1, [&](std::size_t){return TA::Range{P, Q};});
-  TA::detail::arena_strided_dgemm_ce_e(C, L, R, M, N, K, blas::NoTranspose,
-                                       blas::Transpose, 0.5);
+  TA::detail::arena_strided_gemm_ce_e(C, L, R, M, N, K, blas::NoTranspose,
+                                      blas::Transpose, 0.5);
   auto ref = ref_ce_e(L, R, 0, 0, K, P, Q, 0.5);
   const double* got = C.data()[0].data();
   for (std::size_t e = 0; e < P * Q; ++e) BOOST_CHECK_CLOSE(got[e], ref[e], 1e-12);
@@ -324,8 +325,8 @@ BOOST_AUTO_TEST_CASE(ce_e_multi_batch) {
     for (std::size_t e = 0; e < R.data()[o].size(); ++e)
       R.data()[o].data()[e] = 2.0 + 0.01 * o + e;
   // M=left-ext, N=right-ext, K=contracted; canonical orientation.
-  TA::detail::arena_strided_dgemm_ce_e(C, L, R, M, N, K,
-                                       blas::NoTranspose, blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_e(C, L, R, M, N, K, blas::NoTranspose,
+                                      blas::NoTranspose, 1.0);
   for (std::size_t b = 0; b < NB; ++b)
     for (std::size_t m = 0; m < M; ++m)
       for (std::size_t n = 0; n < N; ++n) {
@@ -345,7 +346,7 @@ BOOST_AUTO_TEST_CASE(ce_e_multi_batch) {
 // Addition A: multi-external inner indices on BOTH operands flatten into the
 // inner outer-product. Left inner {a1,a2} (P=a1*a2), right inner {a3,a4}
 // (Q=a3*a4), result inner {a1,a2,a3,a4} (P*Q). Single batch. Independent
-// outer-product reference; under TA_STRIDED_DGEMM_COUNT the per-cell DGEMM
+// outer-product reference; under TA_STRIDED_GEMM_COUNT the per-cell GEMM
 // fires once per result cell (= M*N).
 BOOST_AUTO_TEST_CASE(ce_e_multi_external_inner) {
   namespace blas = TiledArray::math::blas;
@@ -358,11 +359,11 @@ BOOST_AUTO_TEST_CASE(ce_e_multi_external_inner) {
                         [&](std::size_t){ return TA::Range{a3, a4}; }, 2.0);
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{M, N}, 1, [&](std::size_t){ return TA::Range{a1, a2, a3, a4}; });
-#ifdef TA_STRIDED_DGEMM_COUNT
-  TA::detail::g_strided_dgemm_ce_e_calls.store(0);
+#ifdef TA_STRIDED_GEMM_COUNT
+  TA::detail::g_strided_gemm_ce_e_calls.store(0);
 #endif
-  TA::detail::arena_strided_dgemm_ce_e(C, L, R, M, N, K, blas::NoTranspose,
-                                       blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_e(C, L, R, M, N, K, blas::NoTranspose,
+                                      blas::Transpose, 1.0);
   for (std::size_t m = 0; m < M; ++m)
     for (std::size_t n = 0; n < N; ++n) {
       auto ref = ref_ce_e(L, R, m, n, K, P, Q, 1.0);  // flat P*Q
@@ -370,16 +371,16 @@ BOOST_AUTO_TEST_CASE(ce_e_multi_external_inner) {
       for (std::size_t e = 0; e < P * Q; ++e)
         BOOST_CHECK_CLOSE(got[e], ref[e], 1e-12);
     }
-#ifdef TA_STRIDED_DGEMM_COUNT
-  BOOST_CHECK_EQUAL(TA::detail::g_strided_dgemm_ce_e_calls.load(), M * N);
+#ifdef TA_STRIDED_GEMM_COUNT
+  BOOST_CHECK_EQUAL(TA::detail::g_strided_gemm_ce_e_calls.load(), M * N);
 #endif
 }
 
-#ifdef TA_STRIDED_DGEMM_COUNT
+#ifdef TA_STRIDED_GEMM_COUNT
 BOOST_AUTO_TEST_CASE(ce_e_fires_clean_path) {
   namespace blas = TiledArray::math::blas;
   const std::size_t M = 2, N = 2, K = 3, P = 3, Q = 4, NB = 2;
-  // NB batches, all uniform sizes => every result cell clean => one DGEMM each.
+  // NB batches, all uniform sizes => every result cell clean => one GEMM each.
   Outer L = TA::detail::arena_outer_init<Outer>(
       TA::Range{M, K}, NB, [&](std::size_t){ return TA::Range{P}; });
   Outer R = TA::detail::arena_outer_init<Outer>(
@@ -392,11 +393,11 @@ BOOST_AUTO_TEST_CASE(ce_e_fires_clean_path) {
   for (std::size_t o = 0; o < NB * K * N; ++o)
     for (std::size_t e = 0; e < R.data()[o].size(); ++e)
       R.data()[o].data()[e] = 2.0 + 0.01 * o + e;
-  TA::detail::g_strided_dgemm_ce_e_calls.store(0);
-  TA::detail::arena_strided_dgemm_ce_e(C, L, R, M, N, K, blas::NoTranspose,
-                                       blas::NoTranspose, 1.0);
-  // one DGEMM per result cell per batch
-  BOOST_CHECK_EQUAL(TA::detail::g_strided_dgemm_ce_e_calls.load(), NB * M * N);
+  TA::detail::g_strided_gemm_ce_e_calls.store(0);
+  TA::detail::arena_strided_gemm_ce_e(C, L, R, M, N, K, blas::NoTranspose,
+                                      blas::NoTranspose, 1.0);
+  // one GEMM per result cell per batch
+  BOOST_CHECK_EQUAL(TA::detail::g_strided_gemm_ce_e_calls.load(), NB * M * N);
 }
 #endif
 
@@ -433,18 +434,20 @@ BOOST_AUTO_TEST_CASE(regime_a_oprod_mapping_two_tiles) {
   Outer L0 = make_L(VOL0, 1.0), R0 = make_R(VOL0, 2.0);
   Outer L1 = make_L(VOL1, 5.0), R1 = make_R(VOL1, 7.0);
 
-#ifdef TA_STRIDED_DGEMM_COUNT
-  TA::detail::g_strided_dgemm_ce_e_calls.store(0);
+#ifdef TA_STRIDED_GEMM_COUNT
+  TA::detail::g_strided_gemm_ce_e_calls.store(0);
 #endif
   // Regime-A call: present C as (Range{1}, nbatch=NB), M=N=1, K=vol, per tile.
   auto cview = C.reshape(TA::Range{1}, NB);
-  TA::detail::arena_strided_dgemm_ce_e(cview, L0, R0, /*M=*/std::size_t{1},
-                                       /*N=*/std::size_t{1}, /*K=*/VOL0,
-                                       blas::NoTranspose, blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_e(cview, L0, R0, /*M=*/std::size_t{1},
+                                      /*N=*/std::size_t{1}, /*K=*/VOL0,
+                                      blas::NoTranspose, blas::NoTranspose,
+                                      1.0);
   auto cview2 = C.reshape(TA::Range{1}, NB);
-  TA::detail::arena_strided_dgemm_ce_e(cview2, L1, R1, /*M=*/std::size_t{1},
-                                       /*N=*/std::size_t{1}, /*K=*/VOL1,
-                                       blas::NoTranspose, blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_e(cview2, L1, R1, /*M=*/std::size_t{1},
+                                      /*N=*/std::size_t{1}, /*K=*/VOL1,
+                                      blas::NoTranspose, blas::NoTranspose,
+                                      1.0);
 
   // Reference: for each batch b, sum the rank-1 outer products over BOTH tiles.
   for (std::size_t b = 0; b < NB; ++b) {
@@ -463,9 +466,9 @@ BOOST_AUTO_TEST_CASE(regime_a_oprod_mapping_two_tiles) {
     for (std::size_t e = 0; e < P * Q; ++e)
       BOOST_CHECK_CLOSE(got[e], ref[e], 1e-12);
   }
-#ifdef TA_STRIDED_DGEMM_COUNT
-  // clean operands => one DGEMM per (tile, batch); both tiles clean.
-  BOOST_CHECK_EQUAL(TA::detail::g_strided_dgemm_ce_e_calls.load(),
+#ifdef TA_STRIDED_GEMM_COUNT
+  // clean operands => one GEMM per (tile, batch); both tiles clean.
+  BOOST_CHECK_EQUAL(TA::detail::g_strided_gemm_ce_e_calls.load(),
                     std::size_t{2} * NB);
 #endif
 }
@@ -512,9 +515,10 @@ BOOST_AUTO_TEST_CASE(regime_a_oprod_mapping_scattered_falls_back) {
       TA::Range{NB}, /*batch=*/1, [&](std::size_t) { return TA::Range{P0, Q}; });
 
   auto cview = C.reshape(TA::Range{1}, NB);
-  TA::detail::arena_strided_dgemm_ce_e(cview, L, R, /*M=*/std::size_t{1},
-                                       /*N=*/std::size_t{1}, /*K=*/VOL,
-                                       blas::NoTranspose, blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_e(cview, L, R, /*M=*/std::size_t{1},
+                                      /*N=*/std::size_t{1}, /*K=*/VOL,
+                                      blas::NoTranspose, blas::NoTranspose,
+                                      1.0);
 
   // Reference: per batch b, sum rank-1 outer products over k, but ONLY for k
   // whose left inner size == P0 (the kernel's fallback guard skips the ragged k).
@@ -533,13 +537,13 @@ BOOST_AUTO_TEST_CASE(regime_a_oprod_mapping_scattered_falls_back) {
       BOOST_CHECK_CLOSE(got[e], ref[e], 1e-12);
   }
   // Counter intentionally NOT asserted: the ragged cell takes the inline
-  // fallback (no clean DGEMM), so firing is not the property under test --
+  // fallback (no clean GEMM), so firing is not the property under test --
   // correctness of the fallback is.
 }
 
 // Task 3.3 Step 2a: VOL=1 edge -> K=1, a single rank-1 outer product per batch.
 // One operand tile (one strided call). Hand reference + (count build) exactly
-// NB DGEMMs (one per batch, one tile, clean).
+// NB GEMMs (one per batch, one tile, clean).
 BOOST_AUTO_TEST_CASE(regime_a_oprod_mapping_vol1) {
   namespace blas = TiledArray::math::blas;
   const std::size_t NB = 2;
@@ -559,13 +563,14 @@ BOOST_AUTO_TEST_CASE(regime_a_oprod_mapping_vol1) {
     for (std::size_t e = 0; e < R.data()[o].size(); ++e)
       R.data()[o].data()[e] = 2.0 + 0.02 * o + e;
 
-#ifdef TA_STRIDED_DGEMM_COUNT
-  TA::detail::g_strided_dgemm_ce_e_calls.store(0);
+#ifdef TA_STRIDED_GEMM_COUNT
+  TA::detail::g_strided_gemm_ce_e_calls.store(0);
 #endif
   auto cview = C.reshape(TA::Range{1}, NB);
-  TA::detail::arena_strided_dgemm_ce_e(cview, L, R, /*M=*/std::size_t{1},
-                                       /*N=*/std::size_t{1}, /*K=*/VOL,
-                                       blas::NoTranspose, blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_e(cview, L, R, /*M=*/std::size_t{1},
+                                      /*N=*/std::size_t{1}, /*K=*/VOL,
+                                      blas::NoTranspose, blas::NoTranspose,
+                                      1.0);
   for (std::size_t b = 0; b < NB; ++b) {
     std::vector<double> ref(P * Q, 0.0);
     const double* l = L.data()[b * VOL + 0].data();  // P
@@ -576,15 +581,15 @@ BOOST_AUTO_TEST_CASE(regime_a_oprod_mapping_vol1) {
     for (std::size_t e = 0; e < P * Q; ++e)
       BOOST_CHECK_CLOSE(got[e], ref[e], 1e-12);
   }
-#ifdef TA_STRIDED_DGEMM_COUNT
-  // one DGEMM per batch, one (clean) tile.
-  BOOST_CHECK_EQUAL(TA::detail::g_strided_dgemm_ce_e_calls.load(), NB);
+#ifdef TA_STRIDED_GEMM_COUNT
+  // one GEMM per batch, one (clean) tile.
+  BOOST_CHECK_EQUAL(TA::detail::g_strided_gemm_ce_e_calls.load(), NB);
 #endif
 }
 
 // Task 3.3 Step 2b: P=1 and Q=1 inner-extent edges -> the rank-1 outer product
 // degenerates to a scalar*scalar per k. Two operand tiles (like R1), cross-tile
-// beta=1; (count build) == 2*NB DGEMMs (one per tile per batch, all clean).
+// beta=1; (count build) == 2*NB GEMMs (one per tile per batch, all clean).
 BOOST_AUTO_TEST_CASE(regime_a_oprod_mapping_p1_q1) {
   namespace blas = TiledArray::math::blas;
   const std::size_t NB = 2;
@@ -612,17 +617,19 @@ BOOST_AUTO_TEST_CASE(regime_a_oprod_mapping_p1_q1) {
   Outer L0 = make_L(VOL0, 1.0), R0 = make_R(VOL0, 2.0);
   Outer L1 = make_L(VOL1, 5.0), R1 = make_R(VOL1, 7.0);
 
-#ifdef TA_STRIDED_DGEMM_COUNT
-  TA::detail::g_strided_dgemm_ce_e_calls.store(0);
+#ifdef TA_STRIDED_GEMM_COUNT
+  TA::detail::g_strided_gemm_ce_e_calls.store(0);
 #endif
   auto cview = C.reshape(TA::Range{1}, NB);
-  TA::detail::arena_strided_dgemm_ce_e(cview, L0, R0, /*M=*/std::size_t{1},
-                                       /*N=*/std::size_t{1}, /*K=*/VOL0,
-                                       blas::NoTranspose, blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_e(cview, L0, R0, /*M=*/std::size_t{1},
+                                      /*N=*/std::size_t{1}, /*K=*/VOL0,
+                                      blas::NoTranspose, blas::NoTranspose,
+                                      1.0);
   auto cview2 = C.reshape(TA::Range{1}, NB);
-  TA::detail::arena_strided_dgemm_ce_e(cview2, L1, R1, /*M=*/std::size_t{1},
-                                       /*N=*/std::size_t{1}, /*K=*/VOL1,
-                                       blas::NoTranspose, blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_e(cview2, L1, R1, /*M=*/std::size_t{1},
+                                      /*N=*/std::size_t{1}, /*K=*/VOL1,
+                                      blas::NoTranspose, blas::NoTranspose,
+                                      1.0);
 
   for (std::size_t b = 0; b < NB; ++b) {
     std::vector<double> ref(P * Q, 0.0);
@@ -638,8 +645,8 @@ BOOST_AUTO_TEST_CASE(regime_a_oprod_mapping_p1_q1) {
     const double* got = C.data()[b].data();
     BOOST_CHECK_CLOSE(got[0], ref[0], 1e-12);
   }
-#ifdef TA_STRIDED_DGEMM_COUNT
-  BOOST_CHECK_EQUAL(TA::detail::g_strided_dgemm_ce_e_calls.load(),
+#ifdef TA_STRIDED_GEMM_COUNT
+  BOOST_CHECK_EQUAL(TA::detail::g_strided_gemm_ce_e_calls.load(),
                     std::size_t{2} * NB);
 #endif
 }
@@ -661,8 +668,9 @@ BOOST_AUTO_TEST_CASE(ce_ce_matches_reference_canonical) {
       TA::Range{Mmu}, 1, [&](std::size_t){return TA::Range{P};});  // zero-init
   namespace blas = TiledArray::math::blas;
   // Mo=1 (no left external), No=Mmu (mu), Ko=nK (k); canonical right_op=Transpose.
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, /*Mo=*/1, /*No=*/Mmu, /*Ko=*/nK,
-                                        blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(C, L, R, /*Mo=*/1, /*No=*/Mmu,
+                                             /*Ko=*/nK, blas::NoTranspose,
+                                             blas::Transpose, 1.0);
   auto ref = ref_ce_ce(L, R, Mmu, nK, P, Q, 1.0);
   for (std::size_t mu = 0; mu < Mmu; ++mu) {
     const double* got = C.data()[mu].data();
@@ -694,8 +702,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_orientation_aware_no_transpose) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mmu}, 1, [&](std::size_t){return TA::Range{P};});
   namespace blas = TiledArray::math::blas;
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, 1, Mmu, nK,
-                                        blas::NoTranspose, blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, 1, Mmu, nK, blas::NoTranspose, blas::NoTranspose, 1.0);
   auto ref = ref_ce_ce(L, Rc, Mmu, nK, P, Q, 1.0);
   for (std::size_t mu = 0; mu < Mmu; ++mu) {
     const double* got = C.data()[mu].data();
@@ -719,8 +727,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_multi_batch) {
     for (std::size_t e = 0; e < R.data()[o].size(); ++e)
       R.data()[o].data()[e] = 2.0 + 0.01 * o + e;
   namespace blas = TiledArray::math::blas;
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, 1, Mmu, nK,
-                                        blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, 1, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
   for (std::size_t b = 0; b < NB; ++b) {
     std::vector<double> ref(Mmu * P, 0.0);
     for (std::size_t k = 0; k < nK; ++k) {
@@ -764,8 +772,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_ragged_batch_falls_back_inline) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mmu}, NB, [&](std::size_t){return TA::Range{P};});
   namespace blas = TiledArray::math::blas;
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, 1, Mmu, nK,
-                                        blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, 1, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
   for (std::size_t b = 0; b < NB; ++b) {
     std::vector<double> ref(Mmu * P, 0.0);
     for (std::size_t k = 0; k < nK; ++k) {
@@ -804,8 +812,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_applies_factor) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mmu}, 1, [&](std::size_t){return TA::Range{P};});
   namespace blas = TiledArray::math::blas;
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, 1, Mmu, nK,
-                                        blas::NoTranspose, blas::Transpose, 0.5);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, 1, Mmu, nK, blas::NoTranspose, blas::Transpose, 0.5);
   auto ref = ref_ce_ce(L, R, Mmu, nK, P, Q, 0.5);
   for (std::size_t mu = 0; mu < Mmu; ++mu) {
     const double* got = C.data()[mu].data();
@@ -833,8 +841,9 @@ BOOST_AUTO_TEST_CASE(ce_ce_empty_mid_run_falls_back) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mmu}, 1, [&](std::size_t){return TA::Range{P};});
   namespace blas = TiledArray::math::blas;
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, /*Mo=*/1, /*No=*/Mmu, /*Ko=*/nK,
-                                        blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(C, L, R, /*Mo=*/1, /*No=*/Mmu,
+                                             /*Ko=*/nK, blas::NoTranspose,
+                                             blas::Transpose, 1.0);
   std::vector<double> ref(Mmu * P, 0.0);
   for (std::size_t k = 0; k < nK; ++k) {
     const double* l = L.data()[k].data();
@@ -877,9 +886,9 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_external) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mo, Mmu}, 1, [&](std::size_t){return TA::Range{P};});
   namespace blas = TiledArray::math::blas;
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, /*Mo=*/Mo, /*No=*/Mmu,
-                                        /*Ko=*/nK, blas::NoTranspose,
-                                        blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(C, L, R, /*Mo=*/Mo, /*No=*/Mmu,
+                                             /*Ko=*/nK, blas::NoTranspose,
+                                             blas::Transpose, 1.0);
   for (std::size_t m = 0; m < Mo; ++m) {
     std::vector<double> ref(Mmu * P, 0.0);
     for (std::size_t k = 0; k < nK; ++k) {
@@ -917,8 +926,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_external_multi_batch) {
     for (std::size_t e = 0; e < R.data()[o].size(); ++e)
       R.data()[o].data()[e] = 2.0 + 0.01 * o + e;
   namespace blas = TiledArray::math::blas;
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK,
-                                        blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
   for (std::size_t b = 0; b < NB; ++b)
     for (std::size_t m = 0; m < Mo; ++m) {
       std::vector<double> ref(Mmu * P, 0.0);
@@ -963,8 +972,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_external_orientation_no_transpose) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mo, Mmu}, 1, [&](std::size_t){return TA::Range{P};});
   namespace blas = TiledArray::math::blas;
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK, blas::NoTranspose,
-                                        blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::NoTranspose, blas::NoTranspose, 1.0);
   for (std::size_t m = 0; m < Mo; ++m) {
     std::vector<double> ref(Mmu * P, 0.0);
     for (std::size_t k = 0; k < nK; ++k) {
@@ -1009,8 +1018,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_external_ragged_falls_back) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mo, Mmu}, 1, [&](std::size_t){return TA::Range{P};});
   namespace blas = TiledArray::math::blas;
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK, blas::NoTranspose,
-                                        blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
   for (std::size_t m = 0; m < Mo; ++m) {
     std::vector<double> ref(Mmu * P, 0.0);
     for (std::size_t k = 0; k < nK; ++k) {
@@ -1059,9 +1068,9 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_clean_core) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mo, No}, 1, [&](std::size_t) { return TA::Range{P}; });
   namespace blas = TiledArray::math::blas;
-  TA::detail::arena_strided_dgemm_ce_ce_left(C, L, R, /*Mo=*/Mo, /*No=*/No,
-                                             /*Ko=*/nK, blas::NoTranspose,
-                                             blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_left(C, L, R, /*Mo=*/Mo, /*No=*/No,
+                                            /*Ko=*/nK, blas::NoTranspose,
+                                            blas::NoTranspose, 1.0);
   for (std::size_t m = 0; m < Mo; ++m)
     for (std::size_t n = 0; n < No; ++n) {
       std::vector<double> ref(P, 0.0);
@@ -1122,10 +1131,10 @@ void zero_result(Outer& C, std::size_t ncells) {
 }
 }  // namespace
 
-#ifdef TA_STRIDED_DGEMM_COUNT
+#ifdef TA_STRIDED_GEMM_COUNT
 BOOST_AUTO_TEST_CASE(ce_ce_fires_clean_path) {
   const std::size_t Mmu = 3, nK = 2, P = 4, Q = 5, NB = 2;
-  // NB batches, all uniform => every (b,k) DGEMM fires => count == NB*Mo*nK.
+  // NB batches, all uniform => every (b,k) GEMM fires => count == NB*Mo*nK.
   Outer L = TA::detail::arena_outer_init<Outer>(
       TA::Range{nK}, NB, [&](std::size_t){return TA::Range{P, Q};});
   Outer R = TA::detail::arena_outer_init<Outer>(
@@ -1139,11 +1148,12 @@ BOOST_AUTO_TEST_CASE(ce_ce_fires_clean_path) {
     for (std::size_t e = 0; e < R.data()[o].size(); ++e)
       R.data()[o].data()[e] = 2.0 + 0.01 * o + e;
   namespace blas = TiledArray::math::blas;
-  TA::detail::g_strided_dgemm_ce_ce_right_calls.store(0);
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, 1, Mmu, nK,
-                                        blas::NoTranspose, blas::Transpose, 1.0);
-  // per-DGEMM count: Mo(==1) * nK per batch
-  BOOST_CHECK_EQUAL(TA::detail::g_strided_dgemm_ce_ce_right_calls.load(), NB * 1 * nK);
+  TA::detail::g_strided_gemm_ce_ce_right_calls.store(0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, 1, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
+  // per-GEMM count: Mo(==1) * nK per batch
+  BOOST_CHECK_EQUAL(TA::detail::g_strided_gemm_ce_ce_right_calls.load(),
+                    NB * 1 * nK);
 }
 
 // Addition B firing count: Mo>1, nbatch>1 -> clean count == NB*Mo*nK.
@@ -1162,10 +1172,11 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_external_fires_clean_path) {
     for (std::size_t e = 0; e < R.data()[o].size(); ++e)
       R.data()[o].data()[e] = 2.0 + 0.01 * o + e;
   namespace blas = TiledArray::math::blas;
-  TA::detail::g_strided_dgemm_ce_ce_right_calls.store(0);
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK,
-                                        blas::NoTranspose, blas::Transpose, 1.0);
-  BOOST_CHECK_EQUAL(TA::detail::g_strided_dgemm_ce_ce_right_calls.load(), NB * Mo * nK);
+  TA::detail::g_strided_gemm_ce_ce_right_calls.store(0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
+  BOOST_CHECK_EQUAL(TA::detail::g_strided_gemm_ce_ce_right_calls.load(),
+                    NB * Mo * nK);
 }
 
 // Was "does_not_fire": under per-k segmentation a mid-run hole no longer drops
@@ -1186,12 +1197,13 @@ BOOST_AUTO_TEST_CASE(ce_ce_scattered_run_segments_and_is_correct) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mmu}, 1, [&](std::size_t){return TA::Range{P};});
   namespace blas = TiledArray::math::blas;
-  TA::detail::g_strided_dgemm_ce_ce_right_calls.store(0);
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, /*Mo=*/1, /*No=*/Mmu, /*Ko=*/nK,
-                                        blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::g_strided_gemm_ce_ce_right_calls.store(0);
+  TA::detail::arena_strided_gemm_ce_ce_right(C, L, R, /*Mo=*/1, /*No=*/Mmu,
+                                             /*Ko=*/nK, blas::NoTranspose,
+                                             blas::Transpose, 1.0);
   // mu=1 has a mismatched size, so per k the walker emits segments {0} and {2}
   // (the size-mismatched mu=1 cannot join either) => 2 segments x nK(=2) = 4.
-  BOOST_CHECK_EQUAL(TA::detail::g_strided_dgemm_ce_ce_right_calls.load(), 4u);
+  BOOST_CHECK_EQUAL(TA::detail::g_strided_gemm_ce_ce_right_calls.load(), 4u);
   std::vector<double> ref(Mmu * P, 0.0);
   for (std::size_t k = 0; k < nK; ++k) {
     const auto& lk = L.data()[k];
@@ -1252,12 +1264,13 @@ BOOST_AUTO_TEST_CASE(ce_ce_page_jump_run_segments_and_is_correct) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mmu}, 1, [&](std::size_t){return TA::Range{P};});
   namespace blas = TiledArray::math::blas;
-  TA::detail::g_strided_dgemm_ce_ce_right_calls.store(0);
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, /*Mo=*/1, /*No=*/Mmu, /*Ko=*/nK,
-                                        blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::g_strided_gemm_ce_ce_right_calls.store(0);
+  TA::detail::arena_strided_gemm_ce_ce_right(C, L, R, /*Mo=*/1, /*No=*/Mmu,
+                                             /*Ko=*/nK, blas::NoTranspose,
+                                             blas::Transpose, 1.0);
   // perm {0,2,1} makes the inter-cell stride non-constant, so per k the walker
   // breaks the run into constant-stride segments {0,1} and {2} => 2 x nK(=2) = 4.
-  BOOST_CHECK_EQUAL(TA::detail::g_strided_dgemm_ce_ce_right_calls.load(), 4u);
+  BOOST_CHECK_EQUAL(TA::detail::g_strided_gemm_ce_ce_right_calls.load(), 4u);
   auto ref = ref_ce_ce(L, R, Mmu, nK, P, Q, 1.0);
   for (std::size_t mu = 0; mu < Mmu; ++mu) {
     const double* got = C.data()[mu].data();
@@ -1266,7 +1279,7 @@ BOOST_AUTO_TEST_CASE(ce_ce_page_jump_run_segments_and_is_correct) {
   }
 }
 
-// LEFT-clean firing count: Mo>1, No>1, single batch -> one DGEMM per (n,k)
+// LEFT-clean firing count: Mo>1, No>1, single batch -> one GEMM per (n,k)
 // (the left-external m is ridden into BLAS M) => count == No*nK.
 BOOST_AUTO_TEST_CASE(ce_ce_left_clean_fires_clean_path) {
   const std::size_t Mo = 2, No = 3, nK = 2, P = 4, Q = 5;
@@ -1283,11 +1296,10 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_clean_fires_clean_path) {
     for (std::size_t e = 0; e < R.data()[o].size(); ++e)
       R.data()[o].data()[e] = 2.0 + 0.01 * o + e;
   namespace blas = TiledArray::math::blas;
-  TA::detail::g_strided_dgemm_ce_ce_left_calls.store(0);
-  TA::detail::arena_strided_dgemm_ce_ce_left(C, L, R, Mo, No, nK,
-                                             blas::NoTranspose, blas::NoTranspose,
-                                             1.0);
-  BOOST_CHECK_EQUAL(TA::detail::g_strided_dgemm_ce_ce_left_calls.load(),
+  TA::detail::g_strided_gemm_ce_ce_left_calls.store(0);
+  TA::detail::arena_strided_gemm_ce_ce_left(
+      C, L, R, Mo, No, nK, blas::NoTranspose, blas::NoTranspose, 1.0);
+  BOOST_CHECK_EQUAL(TA::detail::g_strided_gemm_ce_ce_left_calls.load(),
                     No * nK);
 }
 
@@ -1324,10 +1336,10 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_page_jump_run_segments_and_is_correct) {
       TA::Range{Mo, No}, 1, [&](std::size_t){ return TA::Range{P}; });
   zero_result(C, C.range().volume());
   namespace blas = TiledArray::math::blas;
-  TA::detail::g_strided_dgemm_ce_ce_left_calls.store(0);
-  TA::detail::arena_strided_dgemm_ce_ce_left(C, L, R, Mo, No, nK,
-      blas::NoTranspose, blas::NoTranspose, 1.0);
-  BOOST_CHECK_EQUAL(TA::detail::g_strided_dgemm_ce_ce_left_calls.load(), 4u);
+  TA::detail::g_strided_gemm_ce_ce_left_calls.store(0);
+  TA::detail::arena_strided_gemm_ce_ce_left(
+      C, L, R, Mo, No, nK, blas::NoTranspose, blas::NoTranspose, 1.0);
+  BOOST_CHECK_EQUAL(TA::detail::g_strided_gemm_ce_ce_left_calls.load(), 4u);
   auto ref = ref_ce_ce_left_sparse(L, R, Mo, No, nK, P, 1.0);
   check_ce_ce(C, ref, 1, Mo, No, P);
 }
@@ -1358,10 +1370,11 @@ BOOST_AUTO_TEST_CASE(ce_ce_right_result_page_jump_segments_and_is_correct) {
   const std::ptrdiff_t d12 = C.data()[2].data() - C.data()[1].data();
   BOOST_REQUIRE_NE(d01, d12);  // non-constant result stride
   namespace blas = TiledArray::math::blas;
-  TA::detail::g_strided_dgemm_ce_ce_right_calls.store(0);
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, /*Mo=*/1, /*No=*/Mmu, /*Ko=*/nK,
-      blas::NoTranspose, blas::Transpose, 1.0);
-  BOOST_CHECK_EQUAL(TA::detail::g_strided_dgemm_ce_ce_right_calls.load(), 4u);
+  TA::detail::g_strided_gemm_ce_ce_right_calls.store(0);
+  TA::detail::arena_strided_gemm_ce_ce_right(C, L, R, /*Mo=*/1, /*No=*/Mmu,
+                                             /*Ko=*/nK, blas::NoTranspose,
+                                             blas::Transpose, 1.0);
+  BOOST_CHECK_EQUAL(TA::detail::g_strided_gemm_ce_ce_right_calls.load(), 4u);
   auto ref = ref_ce_ce(L, R, Mmu, nK, P, Q, 1.0);
   for (std::size_t mu = 0; mu < Mmu; ++mu) {
     const double* got = C.data()[mu].data();
@@ -1372,7 +1385,7 @@ BOOST_AUTO_TEST_CASE(ce_ce_right_result_page_jump_segments_and_is_correct) {
 #endif
 
 // ===========================================================================
-// Per-k segmented strided-DGEMM tests (T1-T15). The kernel walks each present k
+// Per-k segmented strided-GEMM tests (T1-T15). The kernel walks each present k
 // and emits one strided GEMM per maximal contiguous (present + uniform-stride +
 // size-matched) segment along the strided axis, skipping holes, accumulating
 // with beta=1 across k and across segments, never touching absent result cells.
@@ -1393,8 +1406,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_dense_regression) {
       R.data()[o].data()[e] = 2.0 + 0.01 * o + e;
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mmu}, 1, [&](std::size_t){ return TA::Range{P}; });
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK,
-      blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
   auto ref = ref_ce_ce_right_sparse(L, R, Mo, Mmu, nK, P, 1.0);
   check_ce_ce(C, ref, 1, Mo, Mmu, P);
   // Independent naive-oracle cross-check.
@@ -1433,8 +1446,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_single_interior_hole) {
   Outer C = make_sparse(TA::Range{Mmu}, 1,
                         [&](std::size_t){ return TA::Range{P}; }, chole, 0.0);
   zero_result(C, Mmu);
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK,
-      blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
   auto ref = ref_ce_ce_right_sparse(L, R, Mo, Mmu, nK, P, 1.0);
   check_ce_ce(C, ref, 1, Mo, Mmu, P);
 }
@@ -1454,8 +1467,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_holes_stay_absent) {
   Outer C = make_sparse(TA::Range{Mmu}, 1,
                         [&](std::size_t){ return TA::Range{P}; }, chole, 0.0);
   zero_result(C, Mmu);
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK,
-      blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
   // hole cells stay absent; present cells stay present.
   for (std::size_t mu = 0; mu < Mmu; ++mu) {
     if (chole(mu))
@@ -1482,8 +1495,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_edge_holes) {
   Outer C = make_sparse(TA::Range{Mmu}, 1,
                         [&](std::size_t){ return TA::Range{P}; }, chole, 0.0);
   zero_result(C, Mmu);
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK,
-      blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
   auto ref = ref_ce_ce_right_sparse(L, R, Mo, Mmu, nK, P, 1.0);
   check_ce_ce(C, ref, 1, Mo, Mmu, P);
 }
@@ -1500,8 +1513,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_alternating_gemv) {
   Outer C = make_sparse(TA::Range{Mmu}, 1,
                         [&](std::size_t){ return TA::Range{P}; }, chole, 0.0);
   zero_result(C, Mmu);
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK,
-      blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
   auto ref = ref_ce_ce_right_sparse(L, R, Mo, Mmu, nK, P, 1.0);
   check_ce_ce(C, ref, 1, Mo, Mmu, P);
 }
@@ -1520,8 +1533,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_per_k_misaligned) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mmu}, 1, [&](std::size_t){ return TA::Range{P}; });
   zero_result(C, Mmu);
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK,
-      blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
   auto ref = ref_ce_ce_right_sparse(L, R, Mo, Mmu, nK, P, 1.0);
   check_ce_ce(C, ref, 1, Mo, Mmu, P);
 }
@@ -1541,8 +1554,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_absent_k) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mmu}, 1, [&](std::size_t){ return TA::Range{P}; });
   zero_result(C, Mmu);
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK,
-      blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
   auto ref = ref_ce_ce_right_sparse(L, R, Mo, Mmu, nK, P, 1.0);
   check_ce_ce(C, ref, 1, Mo, Mmu, P);
 }
@@ -1561,8 +1574,9 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_transposed_inner) {
   Outer C = make_sparse(TA::Range{Mmu}, 1,
                         [&](std::size_t){ return TA::Range{P}; }, chole, 0.0);
   zero_result(C, Mmu);
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK,
-      blas::NoTranspose, blas::Transpose, 1.0, /*left_inner_transposed=*/true);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0,
+      /*left_inner_transposed=*/true);
   auto ref = ref_ce_ce_right_sparse(L, R, Mo, Mmu, nK, P, 1.0, 1, /*lt=*/true);
   check_ce_ce(C, ref, 1, Mo, Mmu, P);
 }
@@ -1587,8 +1601,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_multi_batch_sparse) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mmu}, NB, [&](std::size_t){ return TA::Range{P}; });
   zero_result(C, NB * Mmu);
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, Lb, R, Mo, Mmu, nK,
-      blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, Lb, R, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
   auto ref = ref_ce_ce_right_sparse(Lb, R, Mo, Mmu, nK, P, 1.0, NB);
   check_ce_ce(C, ref, NB, Mo, Mmu, P);
 }
@@ -1605,8 +1619,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_applies_factor) {
   Outer C = make_sparse(TA::Range{Mmu}, 1,
                         [&](std::size_t){ return TA::Range{P}; }, chole, 0.0);
   zero_result(C, Mmu);
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK,
-      blas::NoTranspose, blas::Transpose, 2.5);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 2.5);
   auto ref = ref_ce_ce_right_sparse(L, R, Mo, Mmu, nK, P, 2.5);
   check_ce_ce(C, ref, 1, Mo, Mmu, P);
 }
@@ -1628,8 +1642,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_size_mismatch_defensive) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mmu}, 1, [&](std::size_t){ return TA::Range{P}; });
   zero_result(C, Mmu);
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK,
-      blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
   auto ref = ref_ce_ce_right_sparse(L, R, Mo, Mmu, nK, P, 1.0);
   check_ce_ce(C, ref, 1, Mo, Mmu, P);
 }
@@ -1652,8 +1666,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_seg_per_k_misaligned) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mo, No}, 1, [&](std::size_t){ return TA::Range{P}; });
   zero_result(C, Mo * No);
-  TA::detail::arena_strided_dgemm_ce_ce_left(C, L, R, Mo, No, nK,
-      blas::NoTranspose, blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_left(
+      C, L, R, Mo, No, nK, blas::NoTranspose, blas::NoTranspose, 1.0);
   auto ref = ref_ce_ce_left_sparse(L, R, Mo, No, nK, P, 1.0);
   check_ce_ce(C, ref, 1, Mo, No, P);
 }
@@ -1674,17 +1688,17 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_seg_single_interior_hole) {
   Outer C = make_sparse(TA::Range{Mo, No}, 1,
                         [&](std::size_t){ return TA::Range{P}; }, chole, 0.0);
   zero_result(C, Mo * No);
-  TA::detail::arena_strided_dgemm_ce_ce_left(C, L, R, Mo, No, nK,
-      blas::NoTranspose, blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_left(
+      C, L, R, Mo, No, nK, blas::NoTranspose, blas::NoTranspose, 1.0);
   auto ref = ref_ce_ce_left_sparse(L, R, Mo, No, nK, P, 1.0);
   check_ce_ce(C, ref, 1, Mo, No, P);
 }
 
-// ---- Segment-count assertions (need -DTA_STRIDED_DGEMM_COUNT) ----
+// ---- Segment-count assertions (need -DTA_STRIDED_GEMM_COUNT) ----
 
 // T13: dense Mmu=6, nK=2 -> 2 segment-GEMMs (one full-run segment per k).
 BOOST_AUTO_TEST_CASE(ce_ce_seg_count_dense) {
-#ifdef TA_STRIDED_DGEMM_COUNT
+#ifdef TA_STRIDED_GEMM_COUNT
   namespace blas = TA::math::blas;
   const std::size_t Mo = 1, Mmu = 6, nK = 2, P = 3, Q = 4;
   Outer L = make_filled(TA::Range{nK}, [&](std::size_t){return TA::Range{P, Q};}, 1.0);
@@ -1696,19 +1710,20 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_count_dense) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mmu}, 1, [&](std::size_t){ return TA::Range{P}; });
   zero_result(C, Mmu);
-  TA::detail::g_strided_dgemm_ce_ce_right_calls = 0;
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK,
-      blas::NoTranspose, blas::Transpose, 1.0);
-  BOOST_CHECK_EQUAL(
-      TA::detail::g_strided_dgemm_ce_ce_right_calls.load(), std::size_t{2});
+  TA::detail::g_strided_gemm_ce_ce_right_calls = 0;
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
+  BOOST_CHECK_EQUAL(TA::detail::g_strided_gemm_ce_ce_right_calls.load(),
+                    std::size_t{2});
 #else
-  BOOST_TEST_MESSAGE("ce_ce_seg_count_dense skipped (no TA_STRIDED_DGEMM_COUNT)");
+  BOOST_TEST_MESSAGE(
+      "ce_ce_seg_count_dense skipped (no TA_STRIDED_GEMM_COUNT)");
 #endif
 }
 
 // T14: T5 pattern -> 3 segment-GEMMs total (k=0: {0},{2}=2; k=1: {1,2}=1).
 BOOST_AUTO_TEST_CASE(ce_ce_seg_count_per_k_misaligned) {
-#ifdef TA_STRIDED_DGEMM_COUNT
+#ifdef TA_STRIDED_GEMM_COUNT
   namespace blas = TA::math::blas;
   const std::size_t Mo = 1, Mmu = 3, nK = 2, P = 3, Q = 4;
   auto rhole = [&](std::size_t o) { return o == 2 || o == 1; };
@@ -1718,20 +1733,20 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_count_per_k_misaligned) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mmu}, 1, [&](std::size_t){ return TA::Range{P}; });
   zero_result(C, Mmu);
-  TA::detail::g_strided_dgemm_ce_ce_right_calls = 0;
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK,
-      blas::NoTranspose, blas::Transpose, 1.0);
-  BOOST_CHECK_EQUAL(
-      TA::detail::g_strided_dgemm_ce_ce_right_calls.load(), std::size_t{3});
+  TA::detail::g_strided_gemm_ce_ce_right_calls = 0;
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
+  BOOST_CHECK_EQUAL(TA::detail::g_strided_gemm_ce_ce_right_calls.load(),
+                    std::size_t{3});
 #else
   BOOST_TEST_MESSAGE(
-      "ce_ce_seg_count_per_k_misaligned skipped (no TA_STRIDED_DGEMM_COUNT)");
+      "ce_ce_seg_count_per_k_misaligned skipped (no TA_STRIDED_GEMM_COUNT)");
 #endif
 }
 
 // T15: T4 pattern (even present, Mmu=6, nK=1) -> 3 segment-GEMMs (M=1 each).
 BOOST_AUTO_TEST_CASE(ce_ce_seg_count_alternating) {
-#ifdef TA_STRIDED_DGEMM_COUNT
+#ifdef TA_STRIDED_GEMM_COUNT
   namespace blas = TA::math::blas;
   const std::size_t Mo = 1, Mmu = 6, nK = 1, P = 3, Q = 4;
   auto rhole = [&](std::size_t o) { return ((o / nK) % 2) == 1; };
@@ -1742,14 +1757,14 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_count_alternating) {
   Outer C = make_sparse(TA::Range{Mmu}, 1,
                         [&](std::size_t){ return TA::Range{P}; }, chole, 0.0);
   zero_result(C, Mmu);
-  TA::detail::g_strided_dgemm_ce_ce_right_calls = 0;
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK,
-      blas::NoTranspose, blas::Transpose, 1.0);
-  BOOST_CHECK_EQUAL(
-      TA::detail::g_strided_dgemm_ce_ce_right_calls.load(), std::size_t{3});
+  TA::detail::g_strided_gemm_ce_ce_right_calls = 0;
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
+  BOOST_CHECK_EQUAL(TA::detail::g_strided_gemm_ce_ce_right_calls.load(),
+                    std::size_t{3});
 #else
   BOOST_TEST_MESSAGE(
-      "ce_ce_seg_count_alternating skipped (no TA_STRIDED_DGEMM_COUNT)");
+      "ce_ce_seg_count_alternating skipped (no TA_STRIDED_GEMM_COUNT)");
 #endif
 }
 
@@ -1758,7 +1773,7 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_count_alternating) {
 // (k=0: m in {0},{2} = 2 segs; k=1: m in {1,2} = 1 seg). Proves the LEFT kernel
 // segments rather than dropping the whole run to the scalar fallback.
 BOOST_AUTO_TEST_CASE(ce_ce_left_seg_count_per_k_misaligned) {
-#ifdef TA_STRIDED_DGEMM_COUNT
+#ifdef TA_STRIDED_GEMM_COUNT
   namespace blas = TA::math::blas;
   const std::size_t Mo = 3, No = 1, nK = 2, P = 3, Q = 4;
   // L outer (Mo,nK) ordinal = m*nK + k. Present set: k=0 -> m{0,2}; k=1 -> m{1,2}.
@@ -1774,17 +1789,18 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_seg_count_per_k_misaligned) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mo, No}, 1, [&](std::size_t){ return TA::Range{P}; });
   zero_result(C, Mo * No);
-  TA::detail::g_strided_dgemm_ce_ce_left_calls.store(0);
-  TA::detail::arena_strided_dgemm_ce_ce_left(C, L, R, Mo, No, nK,
-      blas::NoTranspose, blas::NoTranspose, 1.0);
-  BOOST_CHECK_EQUAL(TA::detail::g_strided_dgemm_ce_ce_left_calls.load(),
+  TA::detail::g_strided_gemm_ce_ce_left_calls.store(0);
+  TA::detail::arena_strided_gemm_ce_ce_left(
+      C, L, R, Mo, No, nK, blas::NoTranspose, blas::NoTranspose, 1.0);
+  BOOST_CHECK_EQUAL(TA::detail::g_strided_gemm_ce_ce_left_calls.load(),
                     std::size_t{3});
   // also correctness against the sparsity-aware reference.
   auto ref = ref_ce_ce_left_sparse(L, R, Mo, No, nK, P, 1.0);
   check_ce_ce(C, ref, 1, Mo, No, P);
 #else
   BOOST_TEST_MESSAGE(
-      "ce_ce_left_seg_count_per_k_misaligned skipped (no TA_STRIDED_DGEMM_COUNT)");
+      "ce_ce_left_seg_count_per_k_misaligned skipped (no "
+      "TA_STRIDED_GEMM_COUNT)");
 #endif
 }
 
@@ -1803,7 +1819,7 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_seg_transposed_inner) {
   Outer C = make_sparse(TA::Range{Mo, No}, 1,
                         [&](std::size_t){ return TA::Range{P}; }, chole, 0.0);
   zero_result(C, Mo * No);
-  TA::detail::arena_strided_dgemm_ce_ce_left(
+  TA::detail::arena_strided_gemm_ce_ce_left(
       C, L, R, Mo, No, nK, blas::NoTranspose, blas::NoTranspose, 1.0,
       /*right_inner_transposed=*/true);
   auto ref = ref_ce_ce_left_sparse(L, R, Mo, No, nK, P, 1.0, 1, /*rt=*/true);
@@ -1826,8 +1842,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_right_seg_left_op_transpose) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mo, Mmu}, 1, [&](std::size_t){ return TA::Range{P}; });
   zero_result(C, Mo * Mmu);
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, Mo, Mmu, nK,
-      blas::Transpose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      C, L, R, Mo, Mmu, nK, blas::Transpose, blas::Transpose, 1.0);
   // C[m,mu](a1) = sum_k sum_a4 L_phys[k*Mo+m](a1,a4) * R[mu,k](a4)
   for (std::size_t m = 0; m < Mo; ++m)
     for (std::size_t mu = 0; mu < Mmu; ++mu) {
@@ -1861,8 +1877,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_seg_right_op_transpose) {
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mo, No}, 1, [&](std::size_t){ return TA::Range{P}; });
   zero_result(C, Mo * No);
-  TA::detail::arena_strided_dgemm_ce_ce_left(C, L, R, Mo, No, nK,
-      blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_left(
+      C, L, R, Mo, No, nK, blas::NoTranspose, blas::Transpose, 1.0);
   // C[m,n](b1) = sum_k sum_a4 L[m*nK+k](a4) * R_phys[n*nK+k](a4,b1)
   for (std::size_t m = 0; m < Mo; ++m)
     for (std::size_t n = 0; n < No; ++n) {
@@ -1894,8 +1910,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_seg_hole_and_factor) {
   Outer C = make_sparse(TA::Range{Mo, No}, 1,
                         [&](std::size_t){ return TA::Range{P}; }, chole, 0.0);
   zero_result(C, C.range().volume());
-  TA::detail::arena_strided_dgemm_ce_ce_left(C, L, R, Mo, No, nK,
-      blas::NoTranspose, blas::NoTranspose, factor);
+  TA::detail::arena_strided_gemm_ce_ce_left(
+      C, L, R, Mo, No, nK, blas::NoTranspose, blas::NoTranspose, factor);
   auto ref = ref_ce_ce_left_sparse(L, R, Mo, No, nK, P, factor);
   check_ce_ce(C, ref, 1, Mo, No, P);
 }
@@ -1915,8 +1931,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_seg_absent_k) {
   Outer C = make_filled(TA::Range{Mo, No},
                         [&](std::size_t){ return TA::Range{P}; }, 0.0);
   zero_result(C, C.range().volume());
-  TA::detail::arena_strided_dgemm_ce_ce_left(C, L, R, Mo, No, nK,
-      blas::NoTranspose, blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_left(
+      C, L, R, Mo, No, nK, blas::NoTranspose, blas::NoTranspose, 1.0);
   auto ref = ref_ce_ce_left_sparse(L, R, Mo, No, nK, P, 1.0);
   check_ce_ce(C, ref, 1, Mo, No, P);
 }
@@ -1937,8 +1953,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_seg_strided_operand_absent_k) {
   Outer C = make_filled(TA::Range{Mo, No},
                         [&](std::size_t){ return TA::Range{P}; }, 0.0);
   zero_result(C, C.range().volume());
-  TA::detail::arena_strided_dgemm_ce_ce_left(C, L, R, Mo, No, nK,
-      blas::NoTranspose, blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_left(
+      C, L, R, Mo, No, nK, blas::NoTranspose, blas::NoTranspose, 1.0);
   auto ref = ref_ce_ce_left_sparse(L, R, Mo, No, nK, P, 1.0);
   check_ce_ce(C, ref, 1, Mo, No, P);
 }
@@ -1962,8 +1978,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_seg_size_mismatch_defensive) {
   Outer C = make_filled(TA::Range{Mo, No},
                         [&](std::size_t){ return TA::Range{P}; }, 0.0);
   zero_result(C, C.range().volume());
-  TA::detail::arena_strided_dgemm_ce_ce_left(C, L, R, Mo, No, nK,
-      blas::NoTranspose, blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_left(
+      C, L, R, Mo, No, nK, blas::NoTranspose, blas::NoTranspose, 1.0);
   // Reference skips any k where L[m,k].size() != Q (R[k,n].size()==P*Q gate).
   auto ref = ref_ce_ce_left_sparse(L, R, Mo, No, nK, P, 1.0);
   check_ce_ce(C, ref, 1, Mo, No, P);
@@ -1996,8 +2012,8 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_seg_multi_batch_sparse) {
   Outer C = make_sparse(TA::Range{Mo, No}, NB,
                         [&](std::size_t){ return TA::Range{P}; }, chole, 0.0);
   zero_result(C, C.range().volume() * NB);
-  TA::detail::arena_strided_dgemm_ce_ce_left(C, L, Rb, Mo, No, nK,
-      blas::NoTranspose, blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_left(
+      C, L, Rb, Mo, No, nK, blas::NoTranspose, blas::NoTranspose, 1.0);
   auto ref = ref_ce_ce_left_sparse(L, Rb, Mo, No, nK, P, 1.0, NB);
   check_ce_ce(C, ref, NB, Mo, No, P);
 }
@@ -2013,7 +2029,7 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_all_absent_run_is_noop) {
   Outer Cr = make_sparse(TA::Range{Mmu}, 1,
                          [&](std::size_t){ return TA::Range{P}; },
                          [](std::size_t){ return true; }, 0.0);  // all holes
-  BOOST_REQUIRE_NO_THROW(TA::detail::arena_strided_dgemm_ce_ce_right(
+  BOOST_REQUIRE_NO_THROW(TA::detail::arena_strided_gemm_ce_ce_right(
       Cr, Lr, Rr, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0));
   for (std::size_t o = 0; o < Cr.range().volume(); ++o)
     BOOST_CHECK(!Cr.data()[o]);  // all stay absent
@@ -2023,7 +2039,7 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_all_absent_run_is_noop) {
   Outer Cl = make_sparse(TA::Range{Mo, No}, 1,
                          [&](std::size_t){ return TA::Range{P}; },
                          [](std::size_t){ return true; }, 0.0);
-  BOOST_REQUIRE_NO_THROW(TA::detail::arena_strided_dgemm_ce_ce_left(
+  BOOST_REQUIRE_NO_THROW(TA::detail::arena_strided_gemm_ce_ce_left(
       Cl, Ll, Rl, Mo, No, nK, blas::NoTranspose, blas::NoTranspose, 1.0));
   for (std::size_t o = 0; o < Cl.range().volume(); ++o)
     BOOST_CHECK(!Cl.data()[o]);
@@ -2058,12 +2074,12 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_killswitch_matches_right) {
   };
   auto [Ls, Rs, Cs] = build();  // switch OFF (segment walker)
   TA::detail::ce_ce_strided_disabled() = false;
-  TA::detail::arena_strided_dgemm_ce_ce_right(Cs, Ls, Rs, Mo, Mmu, nK,
-      blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      Cs, Ls, Rs, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
   auto [Lp, Rp, Cp] = build();  // switch ON (per-cell)
   TA::detail::ce_ce_strided_disabled() = true;
-  TA::detail::arena_strided_dgemm_ce_ce_right(Cp, Lp, Rp, Mo, Mmu, nK,
-      blas::NoTranspose, blas::Transpose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_right(
+      Cp, Lp, Rp, Mo, Mmu, nK, blas::NoTranspose, blas::Transpose, 1.0);
   TA::detail::ce_ce_strided_disabled() = false;  // restore production default
   for (std::size_t o = 0; o < Cs.range().volume(); ++o) {
     BOOST_REQUIRE_EQUAL(bool(Cs.data()[o]), bool(Cp.data()[o]));
@@ -2099,12 +2115,12 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_killswitch_matches_left) {
   };
   auto [Ls, Rs, Cs] = build();
   TA::detail::ce_ce_strided_disabled() = false;
-  TA::detail::arena_strided_dgemm_ce_ce_left(Cs, Ls, Rs, Mo, No, nK,
-      blas::NoTranspose, blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_left(
+      Cs, Ls, Rs, Mo, No, nK, blas::NoTranspose, blas::NoTranspose, 1.0);
   auto [Lp, Rp, Cp] = build();
   TA::detail::ce_ce_strided_disabled() = true;
-  TA::detail::arena_strided_dgemm_ce_ce_left(Cp, Lp, Rp, Mo, No, nK,
-      blas::NoTranspose, blas::NoTranspose, 1.0);
+  TA::detail::arena_strided_gemm_ce_ce_left(
+      Cp, Lp, Rp, Mo, No, nK, blas::NoTranspose, blas::NoTranspose, 1.0);
   TA::detail::ce_ce_strided_disabled() = false;
   for (std::size_t o = 0; o < Cs.range().volume(); ++o) {
     BOOST_REQUIRE_EQUAL(bool(Cs.data()[o]), bool(Cp.data()[o]));
@@ -2115,7 +2131,7 @@ BOOST_AUTO_TEST_CASE(ce_ce_seg_killswitch_matches_left) {
 }
 
 // ---------------------------------------------------------------------------
-// Every other BLAS GEMM element type admitted by is_strided_dgemm_numeric_v
+// Every other BLAS GEMM element type admitted by is_strided_gemm_numeric_v
 // (double is the type of the whole suite above): the three strided kernels
 // are templated on the inner numeric type, so float, complex<float> and
 // complex<double> ToT contractions (e.g. Kramers/relativistic CSV amplitudes)
@@ -2175,8 +2191,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ce_e_numeric_matches_reference, T,
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{M, N}, 1,
       [&](std::size_t) { return TA::Range{P, Q}; });  // zero-init
-  TA::detail::arena_strided_dgemm_ce_e(C, L, R, M, N, K, blas::NoTranspose,
-                                       blas::Transpose, factor);
+  TA::detail::arena_strided_gemm_ce_e(C, L, R, M, N, K, blas::NoTranspose,
+                                      blas::Transpose, factor);
   for (std::size_t m = 0; m < M; ++m)
     for (std::size_t n = 0; n < N; ++n) {
       std::vector<T> ref(P * Q, T{});
@@ -2207,9 +2223,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ce_ce_right_numeric_matches_reference, T,
   // C outer (Mo,Mmu) row-major (m slow, mu fast), inner {P}.
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mo, Mmu}, 1, [&](std::size_t) { return TA::Range{P}; });
-  TA::detail::arena_strided_dgemm_ce_ce_right(C, L, R, /*Mo=*/Mo, /*No=*/Mmu,
-                                              /*Ko=*/nK, blas::NoTranspose,
-                                              blas::Transpose, factor);
+  TA::detail::arena_strided_gemm_ce_ce_right(C, L, R, /*Mo=*/Mo, /*No=*/Mmu,
+                                             /*Ko=*/nK, blas::NoTranspose,
+                                             blas::Transpose, factor);
   for (std::size_t m = 0; m < Mo; ++m)
     for (std::size_t mu = 0; mu < Mmu; ++mu) {
       std::vector<T> ref(P, T{});
@@ -2242,9 +2258,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ce_ce_left_numeric_matches_reference, T,
   // C outer (Mo,No) row-major (m slow, n fast), inner {P}.
   Outer C = TA::detail::arena_outer_init<Outer>(
       TA::Range{Mo, No}, 1, [&](std::size_t) { return TA::Range{P}; });
-  TA::detail::arena_strided_dgemm_ce_ce_left(C, L, R, /*Mo=*/Mo, /*No=*/No,
-                                             /*Ko=*/nK, blas::NoTranspose,
-                                             blas::NoTranspose, factor);
+  TA::detail::arena_strided_gemm_ce_ce_left(C, L, R, /*Mo=*/Mo, /*No=*/No,
+                                            /*Ko=*/nK, blas::NoTranspose,
+                                            blas::NoTranspose, factor);
   for (std::size_t m = 0; m < Mo; ++m)
     for (std::size_t n = 0; n < No; ++n) {
       std::vector<T> ref(P, T{});

--- a/tests/einsum.cpp
+++ b/tests/einsum.cpp
@@ -1421,8 +1421,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(hce_e_contraction_arena_matches_owning, T,
 
   ArenaArr ah(world, a_trange);
   ah.init_tiles([&](const TA::Range& tr) {
+    // [=]: in a template body g++ requires the constexpr extents captured
     ArenaOuter t = TA::detail::arena_outer_init<ArenaOuter>(
-        tr, 1, [](std::size_t /*ord*/) { return TA::Range{P}; });
+        tr, 1, [=](std::size_t /*ord*/) { return TA::Range{P}; });
     for (std::size_t o = 0; o < t.range().volume(); ++o) {
       ArenaInner& c = t.data()[o];
       if (!c) continue;
@@ -1435,7 +1436,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(hce_e_contraction_arena_matches_owning, T,
   ArenaArr bh(world, b_trange);
   bh.init_tiles([&](const TA::Range& tr) {
     ArenaOuter t = TA::detail::arena_outer_init<ArenaOuter>(
-        tr, 1, [](std::size_t /*ord*/) { return TA::Range{Q}; });
+        tr, 1, [=](std::size_t /*ord*/) { return TA::Range{Q}; });
     for (std::size_t o = 0; o < t.range().volume(); ++o) {
       ArenaInner& c = t.data()[o];
       if (!c) continue;
@@ -1694,8 +1695,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(regime_a_hce_e_strided_equals_percell, T,
 
   ArenaArr ah(world, a_trange);
   ah.init_tiles([&](const TA::Range& tr) {
+    // [=]: in a template body g++ requires the constexpr extents captured
     ArenaOuter t = TA::detail::arena_outer_init<ArenaOuter>(
-        tr, 1, [](std::size_t /*ord*/) { return TA::Range{P}; });
+        tr, 1, [=](std::size_t /*ord*/) { return TA::Range{P}; });
     for (std::size_t o = 0; o < t.range().volume(); ++o) {
       ArenaInner& c = t.data()[o];
       if (!c) continue;
@@ -1710,7 +1712,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(regime_a_hce_e_strided_equals_percell, T,
   ArenaArr bh(world, b_trange);
   bh.init_tiles([&](const TA::Range& tr) {
     ArenaOuter t = TA::detail::arena_outer_init<ArenaOuter>(
-        tr, 1, [](std::size_t /*ord*/) { return TA::Range{Q}; });
+        tr, 1, [=](std::size_t /*ord*/) { return TA::Range{Q}; });
     for (std::size_t o = 0; o < t.range().volume(); ++o) {
       ArenaInner& c = t.data()[o];
       if (!c) continue;

--- a/tests/einsum.cpp
+++ b/tests/einsum.cpp
@@ -27,6 +27,10 @@
 #include "TiledArray/tensor/arena_kernels.h"
 #include "TiledArray/tensor/arena_tensor.h"
 
+#include <algorithm>
+#include <cmath>
+#include <complex>
+
 BOOST_AUTO_TEST_SUITE(einsum_manual)
 
 namespace {
@@ -1375,11 +1379,27 @@ BOOST_AUTO_TEST_CASE(tensor_contract) {
 // numeric problem on (a) an *arena*-backed ToT DistArray (inner cells are
 // ArenaTensor views) and (b) an *owning* ToT DistArray (inner cells are
 // TA::Tensor), then asserts the two einsum results agree elementwise.
-BOOST_AUTO_TEST_CASE(hce_e_contraction_arena_matches_owning) {
-  using ArenaInner = TA::ArenaTensor<double, TA::Range>;
+// Inner numeric types the arena strided path serves (double and the complex
+// type the Kramers/relativistic ToT amplitudes need); the value helper gives
+// a real value for double and a complex one otherwise.
+using einsum_inner_numeric_types =
+    boost::mpl::list<double, std::complex<double>>;
+namespace {
+template <typename T>
+T einsum_val(double re, double im) {
+  if constexpr (TA::detail::is_complex_v<T>)
+    return T(re, im);
+  else
+    return static_cast<T>(re);
+}
+}  // namespace
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(hce_e_contraction_arena_matches_owning, T,
+                              einsum_inner_numeric_types) {
+  using ArenaInner = TA::ArenaTensor<T, TA::Range>;
   using ArenaOuter = TA::Tensor<ArenaInner>;
   using ArenaArr = TA::DistArray<ArenaOuter, TA::DensePolicy>;
-  using OwnInner = TA::Tensor<double>;
+  using OwnInner = TA::Tensor<T>;
   using OwnOuter = TA::Tensor<OwnInner>;
   using OwnArr = TA::DistArray<OwnOuter, TA::DensePolicy>;
 
@@ -1391,10 +1411,12 @@ BOOST_AUTO_TEST_CASE(hce_e_contraction_arena_matches_owning) {
   TA::TiledRange b_trange{{0l, K}, {0l, J}};  // outer (k,j)
 
   auto a_val = [](long i, long j, long p) {
-    return 1.0 + 0.5 * i + 0.25 * j + 0.125 * p;
+    return einsum_val<T>(1.0 + 0.5 * i + 0.25 * j + 0.125 * p,
+                         0.3 * i - 0.2 * j + 0.07 * p);
   };
   auto b_val = [](long k, long j, long q) {
-    return 2.0 - 0.3 * k + 0.2 * j + 0.05 * q;
+    return einsum_val<T>(2.0 - 0.3 * k + 0.2 * j + 0.05 * q,
+                         -0.4 * k + 0.1 * j - 0.03 * q);
   };
 
   ArenaArr ah(world, a_trange);
@@ -1647,8 +1669,9 @@ BOOST_AUTO_TEST_CASE(regime_a_hce_e_arena_matches_owning) {
 // the two results cell-by-cell, element-by-element. The toggle is RESTORED to
 // false before the compare loop so a failed assertion cannot leak `true` into
 // later tests.
-BOOST_AUTO_TEST_CASE(regime_a_hce_e_strided_equals_percell) {
-  using ArenaInner = TA::ArenaTensor<double, TA::Range>;
+BOOST_AUTO_TEST_CASE_TEMPLATE(regime_a_hce_e_strided_equals_percell, T,
+                              einsum_inner_numeric_types) {
+  using ArenaInner = TA::ArenaTensor<T, TA::Range>;
   using ArenaOuter = TA::Tensor<ArenaInner>;
   using ArenaArr = TA::DistArray<ArenaOuter, TA::DensePolicy>;
 
@@ -1661,10 +1684,12 @@ BOOST_AUTO_TEST_CASE(regime_a_hce_e_strided_equals_percell) {
                           TA::TiledRange1{0l, 2, 5}};  // outer (h,i,k)
 
   auto a_val = [](long h, long i, long k, long a1) {
-    return 1.0 + 0.5 * i + 0.25 * k + 0.125 * a1 + 0.0625 * h;
+    return einsum_val<T>(1.0 + 0.5 * i + 0.25 * k + 0.125 * a1 + 0.0625 * h,
+                         0.2 * i - 0.1 * k + 0.05 * a1 + 0.01 * h);
   };
   auto b_val = [](long h, long i, long k, long a2) {
-    return 2.0 - 0.3 * k + 0.2 * i + 0.05 * a2 + 0.03 * h;
+    return einsum_val<T>(2.0 - 0.3 * k + 0.2 * i + 0.05 * a2 + 0.03 * h,
+                         -0.15 * k + 0.25 * i - 0.02 * a2 + 0.04 * h);
   };
 
   ArenaArr ah(world, a_trange);
@@ -1742,7 +1767,8 @@ BOOST_AUTO_TEST_CASE(regime_a_hce_e_strided_equals_percell) {
       BOOST_REQUIRE_EQUAL(sc.size(), static_cast<std::size_t>(P * Q));
       ++result_outer_cells_seen;
       for (std::size_t e = 0; e < sc.size(); ++e) {
-        BOOST_CHECK_CLOSE(sc.data()[e], pc.data()[e], 1e-12);
+        BOOST_CHECK_SMALL(std::abs(sc.data()[e] - pc.data()[e]),
+                          1e-12 * std::max(1.0, std::abs(pc.data()[e])));
         ++elements_compared;
       }
     }

--- a/tests/einsum.cpp
+++ b/tests/einsum.cpp
@@ -1371,7 +1371,7 @@ BOOST_AUTO_TEST_CASE(tensor_contract) {
 #endif
 
 // --------------------------------------------------------------------------
-// strided-DGEMM ce+e (hce+e) e2e oracles
+// strided-GEMM ce+e (hce+e) e2e oracles
 // --------------------------------------------------------------------------
 
 // c(i,k;p,q) = sum_j a(i,j;p) * b(k,j;q): distinct externals i,k; contract
@@ -1917,7 +1917,7 @@ BOOST_AUTO_TEST_CASE(regime_a_hce_e_noncanonical_inner_matches_owning) {
   BOOST_CHECK_LT(max_abs_diff, 1e-12);
 }
 
-#ifdef TA_STRIDED_DGEMM_COUNT
+#ifdef TA_STRIDED_GEMM_COUNT
 BOOST_AUTO_TEST_CASE(hce_e_uses_strided_path) {
   using ArenaInner = TA::ArenaTensor<double, TA::Range>;
   using ArenaOuter = TA::Tensor<ArenaInner>;
@@ -1970,10 +1970,10 @@ BOOST_AUTO_TEST_CASE(hce_e_uses_strided_path) {
   });
   world.gop.fence();
 
-  TiledArray::detail::g_strided_dgemm_ce_e_calls.store(0);
+  TiledArray::detail::g_strided_gemm_ce_e_calls.store(0);
   auto ca = einsum(ah("h,i,j;p"), bh("h,k,j;q"), "h,i,k;p,q");
   ca.world().gop.fence();
-  BOOST_CHECK_GT(TiledArray::detail::g_strided_dgemm_ce_e_calls.load(), 0u);
+  BOOST_CHECK_GT(TiledArray::detail::g_strided_gemm_ce_e_calls.load(), 0u);
 }
 
 // Regime A (hc+e) firing witness: same shape/fill as
@@ -2031,10 +2031,10 @@ BOOST_AUTO_TEST_CASE(regime_a_hce_e_uses_strided_path) {
   });
   world.gop.fence();
 
-  TiledArray::detail::g_strided_dgemm_ce_e_calls.store(0);
+  TiledArray::detail::g_strided_gemm_ce_e_calls.store(0);
   auto ca = einsum(ah("h,i,k;a1"), bh("h,i,k;a2"), "h,i;a1,a2");
   ca.world().gop.fence();
-  BOOST_CHECK_GT(TiledArray::detail::g_strided_dgemm_ce_e_calls.load(), 0u);
+  BOOST_CHECK_GT(TiledArray::detail::g_strided_gemm_ce_e_calls.load(), 0u);
 }
 
 // Codex must-fix #2 guard: an OWNING ToT contraction (TA::Tensor inner, NOT a
@@ -2088,14 +2088,14 @@ BOOST_AUTO_TEST_CASE(owning_tot_does_not_use_strided_path) {
   });
   world.gop.fence();
 
-  TiledArray::detail::g_strided_dgemm_ce_e_calls.store(0);
-  TiledArray::detail::g_strided_dgemm_ce_ce_right_calls.store(0);
+  TiledArray::detail::g_strided_gemm_ce_e_calls.store(0);
+  TiledArray::detail::g_strided_gemm_ce_ce_right_calls.store(0);
   auto co = einsum(ao("h,i,j;p"), bo("h,k,j;q"), "h,i,k;p,q");
   co.world().gop.fence();
   // owning inner cells never take the view-only strided path
-  BOOST_CHECK_EQUAL(TiledArray::detail::g_strided_dgemm_ce_e_calls.load(), 0u);
-  BOOST_CHECK_EQUAL(
-      TiledArray::detail::g_strided_dgemm_ce_ce_right_calls.load(), 0u);
+  BOOST_CHECK_EQUAL(TiledArray::detail::g_strided_gemm_ce_e_calls.load(), 0u);
+  BOOST_CHECK_EQUAL(TiledArray::detail::g_strided_gemm_ce_ce_right_calls.load(),
+                    0u);
   // sanity: the contraction actually ran and produced the expected outer shape
   BOOST_CHECK_EQUAL(co.trange().elements_range().volume(),
                     static_cast<std::size_t>(H * I * K));
@@ -2182,8 +2182,8 @@ BOOST_AUTO_TEST_CASE(ce_e_multi_external_arena_matches_owning) {
   });
   world.gop.fence();
 
-#ifdef TA_STRIDED_DGEMM_COUNT
-  TiledArray::detail::g_strided_dgemm_ce_e_calls.store(0);
+#ifdef TA_STRIDED_GEMM_COUNT
+  TiledArray::detail::g_strided_gemm_ce_e_calls.store(0);
 #endif
   ArenaArr ca = einsum(ah("i,j;a1,a2"), bh("k,j;a3,a4"), "i,k;a1,a2,a3,a4");
   OwnArr co = einsum(ao("i,j;a1,a2"), bo("k,j;a3,a4"), "i,k;a1,a2,a3,a4");
@@ -2213,8 +2213,8 @@ BOOST_AUTO_TEST_CASE(ce_e_multi_external_arena_matches_owning) {
   world.gop.max(max_abs_diff);
   BOOST_REQUIRE_GT(elements_compared, 0u);
   BOOST_CHECK_LT(max_abs_diff, 1e-12);
-#ifdef TA_STRIDED_DGEMM_COUNT
-  BOOST_CHECK_GT(TiledArray::detail::g_strided_dgemm_ce_e_calls.load(), 0u);
+#ifdef TA_STRIDED_GEMM_COUNT
+  BOOST_CHECK_GT(TiledArray::detail::g_strided_gemm_ce_e_calls.load(), 0u);
 #endif
 }
 
@@ -2308,8 +2308,8 @@ BOOST_AUTO_TEST_CASE(hce_e_multi_external_arena_matches_owning) {
   });
   world.gop.fence();
 
-#ifdef TA_STRIDED_DGEMM_COUNT
-  TiledArray::detail::g_strided_dgemm_ce_e_calls.store(0);
+#ifdef TA_STRIDED_GEMM_COUNT
+  TiledArray::detail::g_strided_gemm_ce_e_calls.store(0);
 #endif
   ArenaArr ca =
       einsum(ah("h,i,j;a1,a2"), bh("h,k,j;a3,a4"), "h,i,k;a1,a2,a3,a4");
@@ -2340,13 +2340,13 @@ BOOST_AUTO_TEST_CASE(hce_e_multi_external_arena_matches_owning) {
   world.gop.max(max_abs_diff);
   BOOST_REQUIRE_GT(elements_compared, 0u);
   BOOST_CHECK_LT(max_abs_diff, 1e-12);
-#ifdef TA_STRIDED_DGEMM_COUNT
-  BOOST_CHECK_GT(TiledArray::detail::g_strided_dgemm_ce_e_calls.load(), 0u);
+#ifdef TA_STRIDED_GEMM_COUNT
+  BOOST_CHECK_GT(TiledArray::detail::g_strided_gemm_ce_e_calls.load(), 0u);
 #endif
 }
 
 // --------------------------------------------------------------------------
-// strided-DGEMM ce+ce (hce+ce) e2e oracles
+// strided-GEMM ce+ce (hce+ce) e2e oracles
 // --------------------------------------------------------------------------
 
 // c(i,m;a1) = sum_{k,a4} a(i,k;a1,a4) * b(i,m,k;a4): Hadamard i (single tile of
@@ -2472,7 +2472,7 @@ BOOST_AUTO_TEST_CASE(hce_ce_contraction_arena_matches_owning) {
   BOOST_CHECK_LT(max_abs_diff, 1e-12);
 }
 
-#ifdef TA_STRIDED_DGEMM_COUNT
+#ifdef TA_STRIDED_GEMM_COUNT
 BOOST_AUTO_TEST_CASE(hce_ce_uses_strided_path) {
   using ArenaInner = TA::ArenaTensor<double, TA::Range>;
   using ArenaOuter = TA::Tensor<ArenaInner>;
@@ -2522,10 +2522,10 @@ BOOST_AUTO_TEST_CASE(hce_ce_uses_strided_path) {
   });
   world.gop.fence();
 
-  TiledArray::detail::g_strided_dgemm_ce_ce_right_calls.store(0);
+  TiledArray::detail::g_strided_gemm_ce_ce_right_calls.store(0);
   auto ca = einsum(ah("i,k;a1,a4"), bh("i,m,k;a4"), "i,m;a1");
   ca.world().gop.fence();
-  BOOST_CHECK_GT(TiledArray::detail::g_strided_dgemm_ce_ce_right_calls.load(),
+  BOOST_CHECK_GT(TiledArray::detail::g_strided_gemm_ce_ce_right_calls.load(),
                  0u);
 }
 #endif
@@ -2610,14 +2610,14 @@ BOOST_AUTO_TEST_CASE(ce_ce_no_hadamard_arena_matches_owning) {
   });
   world.gop.fence();
 
-#ifdef TA_STRIDED_DGEMM_COUNT
-  TiledArray::detail::g_strided_dgemm_ce_ce_right_calls.store(0);
+#ifdef TA_STRIDED_GEMM_COUNT
+  TiledArray::detail::g_strided_gemm_ce_ce_right_calls.store(0);
 #endif
   ArenaArr ca = einsum(ah("k;a1,a4"), bh("m,k;a4"), "m;a1");
   OwnArr co = einsum(ao("k;a1,a4"), bo("m,k;a4"), "m;a1");
   world.gop.fence();
-#ifdef TA_STRIDED_DGEMM_COUNT
-  BOOST_CHECK_GT(TiledArray::detail::g_strided_dgemm_ce_ce_right_calls.load(),
+#ifdef TA_STRIDED_GEMM_COUNT
+  BOOST_CHECK_GT(TiledArray::detail::g_strided_gemm_ce_ce_right_calls.load(),
                  0u);
 #endif
 
@@ -2731,14 +2731,14 @@ BOOST_AUTO_TEST_CASE(ce_ce_left_clean_arena_matches_owning) {
   });
   world.gop.fence();
 
-#ifdef TA_STRIDED_DGEMM_COUNT
-  TiledArray::detail::g_strided_dgemm_ce_ce_left_calls.store(0);
+#ifdef TA_STRIDED_GEMM_COUNT
+  TiledArray::detail::g_strided_gemm_ce_ce_left_calls.store(0);
 #endif
   ArenaArr ca = einsum(ah("m,k;a4"), bh("k,n;a4,b1"), "m,n;b1");
   OwnArr co = einsum(ao("m,k;a4"), bo("k,n;a4,b1"), "m,n;b1");
   world.gop.fence();
-#ifdef TA_STRIDED_DGEMM_COUNT
-  BOOST_CHECK_GT(TiledArray::detail::g_strided_dgemm_ce_ce_left_calls.load(),
+#ifdef TA_STRIDED_GEMM_COUNT
+  BOOST_CHECK_GT(TiledArray::detail::g_strided_gemm_ce_ce_left_calls.load(),
                  0u);
 #endif
 
@@ -2857,18 +2857,18 @@ BOOST_AUTO_TEST_CASE(ce_ce_general_matrix_matrix_not_strided) {
   });
   world.gop.fence();
 
-#ifdef TA_STRIDED_DGEMM_COUNT
-  TiledArray::detail::g_strided_dgemm_ce_ce_right_calls.store(0);
-  TiledArray::detail::g_strided_dgemm_ce_ce_left_calls.store(0);
+#ifdef TA_STRIDED_GEMM_COUNT
+  TiledArray::detail::g_strided_gemm_ce_ce_right_calls.store(0);
+  TiledArray::detail::g_strided_gemm_ce_ce_left_calls.store(0);
 #endif
   ArenaArr ca = einsum(ah("m,k;a1,a4"), bh("k,n;a4,b1"), "m,n;a1,b1");
   OwnArr co = einsum(ao("m,k;a1,a4"), bo("k,n;a4,b1"), "m,n;a1,b1");
   world.gop.fence();
-#ifdef TA_STRIDED_DGEMM_COUNT
+#ifdef TA_STRIDED_GEMM_COUNT
   // matrix x matrix inner: neither strided orientation may fire.
-  BOOST_CHECK_EQUAL(
-      TiledArray::detail::g_strided_dgemm_ce_ce_right_calls.load(), 0u);
-  BOOST_CHECK_EQUAL(TiledArray::detail::g_strided_dgemm_ce_ce_left_calls.load(),
+  BOOST_CHECK_EQUAL(TiledArray::detail::g_strided_gemm_ce_ce_right_calls.load(),
+                    0u);
+  BOOST_CHECK_EQUAL(TiledArray::detail::g_strided_gemm_ce_ce_left_calls.load(),
                     0u);
 #endif
 
@@ -2988,14 +2988,14 @@ BOOST_AUTO_TEST_CASE(hce_ce_left_external_arena_matches_owning) {
   });
   world.gop.fence();
 
-#ifdef TA_STRIDED_DGEMM_COUNT
-  TiledArray::detail::g_strided_dgemm_ce_ce_right_calls.store(0);
+#ifdef TA_STRIDED_GEMM_COUNT
+  TiledArray::detail::g_strided_gemm_ce_ce_right_calls.store(0);
 #endif
   ArenaArr ca = einsum(ah("h,i,j;a1,a4"), bh("h,j,k;a4"), "h,i,k;a1");
   OwnArr co = einsum(ao("h,i,j;a1,a4"), bo("h,j,k;a4"), "h,i,k;a1");
   world.gop.fence();
-#ifdef TA_STRIDED_DGEMM_COUNT
-  BOOST_CHECK_GT(TiledArray::detail::g_strided_dgemm_ce_ce_right_calls.load(),
+#ifdef TA_STRIDED_GEMM_COUNT
+  BOOST_CHECK_GT(TiledArray::detail::g_strided_gemm_ce_ce_right_calls.load(),
                  0u);
 #endif
 
@@ -3026,7 +3026,7 @@ BOOST_AUTO_TEST_CASE(hce_ce_left_external_arena_matches_owning) {
 }
 
 // --------------------------------------------------------------------------
-// strided-DGEMM combined equivalence matrices (REVISION: multi-external +
+// strided-GEMM combined equivalence matrices (REVISION: multi-external +
 // left-external + nbatch>1, multi-tile contracted index, edge sizes).
 // --------------------------------------------------------------------------
 
@@ -3118,14 +3118,14 @@ BOOST_AUTO_TEST_CASE(hce_e_combined_equivalence_strided) {
   });
   world.gop.fence();
 
-#ifdef TA_STRIDED_DGEMM_COUNT
-  TiledArray::detail::g_strided_dgemm_ce_e_calls.store(0);
+#ifdef TA_STRIDED_GEMM_COUNT
+  TiledArray::detail::g_strided_gemm_ce_e_calls.store(0);
 #endif
   ArenaArr ca = einsum(ah("h,i,j;a1,a2"), bh("h,k,j;a3"), "h,i,k;a1,a2,a3");
   OwnArr co = einsum(ao("h,i,j;a1,a2"), bo("h,k,j;a3"), "h,i,k;a1,a2,a3");
   world.gop.fence();
-#ifdef TA_STRIDED_DGEMM_COUNT
-  BOOST_CHECK_GT(TiledArray::detail::g_strided_dgemm_ce_e_calls.load(), 0u);
+#ifdef TA_STRIDED_GEMM_COUNT
+  BOOST_CHECK_GT(TiledArray::detail::g_strided_gemm_ce_e_calls.load(), 0u);
 #endif
 
   double max_abs_diff = 0.0;
@@ -3243,14 +3243,14 @@ BOOST_AUTO_TEST_CASE(hce_ce_combined_equivalence_strided) {
   });
   world.gop.fence();
 
-#ifdef TA_STRIDED_DGEMM_COUNT
-  TiledArray::detail::g_strided_dgemm_ce_ce_right_calls.store(0);
+#ifdef TA_STRIDED_GEMM_COUNT
+  TiledArray::detail::g_strided_gemm_ce_ce_right_calls.store(0);
 #endif
   ArenaArr ca = einsum(ah("h,i,j;a1,a2,a4"), bh("h,j,k;a4"), "h,i,k;a1,a2");
   OwnArr co = einsum(ao("h,i,j;a1,a2,a4"), bo("h,j,k;a4"), "h,i,k;a1,a2");
   world.gop.fence();
-#ifdef TA_STRIDED_DGEMM_COUNT
-  BOOST_CHECK_GT(TiledArray::detail::g_strided_dgemm_ce_ce_right_calls.load(),
+#ifdef TA_STRIDED_GEMM_COUNT
+  BOOST_CHECK_GT(TiledArray::detail::g_strided_gemm_ce_ce_right_calls.load(),
                  0u);
 #endif
 

--- a/tests/tot_array_fixture.h
+++ b/tests/tot_array_fixture.h
@@ -23,6 +23,7 @@
 #include <TiledArray/conversions/make_array.h>
 #include <TiledArray/einsum/tiledarray.h>
 #include <TiledArray/expressions/tsr_expr.h>
+#include <complex>
 #include "unit_test_config.h"
 #ifdef TILEDARRAY_HAS_BTAS
 #include <TiledArray/conversions/btas.h>
@@ -44,15 +45,16 @@
 using namespace TiledArray;
 
 // These are all of the template parameters we are going to test over
-using test_params =
-    boost::mpl::list<std::tuple<int, Tensor<Tensor<int>>>,
-                     std::tuple<float, Tensor<Tensor<float>>>,
-                     std::tuple<double, Tensor<Tensor<double>>>
+using test_params = boost::mpl::list<
+    std::tuple<int, Tensor<Tensor<int>>>,
+    std::tuple<float, Tensor<Tensor<float>>>,
+    std::tuple<double, Tensor<Tensor<double>>>,
+    std::tuple<std::complex<double>, Tensor<Tensor<std::complex<double>>>>
 #ifdef TILEDARRAY_HAS_BTAS
-                     ,
-                     std::tuple<int, Tensor<btas::Tensor<int, Range>>>,
-                     std::tuple<float, Tensor<btas::Tensor<float, Range>>>,
-                     std::tuple<double, Tensor<btas::Tensor<double, Range>>>
+    ,
+    std::tuple<int, Tensor<btas::Tensor<int, Range>>>,
+    std::tuple<float, Tensor<btas::Tensor<float, Range>>>,
+    std::tuple<double, Tensor<btas::Tensor<double, Range>>>
 //    ,std::tuple<int, btas::Tensor<btas::Tensor<int, Range>, Range>>,
 //    std::tuple<float, btas::Tensor<btas::Tensor<float, Range>, Range>>,
 //    std::tuple<double, btas::Tensor<btas::Tensor<double, Range>, Range>>
@@ -60,7 +62,7 @@ using test_params =
 //    std::tuple<float, Tile<btas::Tensor<btas::Tensor<float, Range>, Range>>>,
 //    std::tuple<double, Tile<btas::Tensor<btas::Tensor<double, Range>, Range>>>
 #endif
-                     >;
+    >;
 
 // These typedefs unpack the unit test template parameter
 //{

--- a/tests/tot_array_fixture.h
+++ b/tests/tot_array_fixture.h
@@ -66,8 +66,10 @@ using test_params = boost::mpl::list<
 
 // These typedefs unpack the unit test template parameter
 //{
+/// the ELEMENT type of the tile (std::complex<double> for the complex row);
+/// TiledArray::detail::scalar_t<element_type<...>> is the real scalar type
 template <typename TupleElementType>
-using scalar_type = std::tuple_element_t<0, TupleElementType>;
+using element_type = std::tuple_element_t<0, TupleElementType>;
 
 template <typename TupleElementType>
 using tile_type = std::tuple_element_t<1, TupleElementType>;

--- a/tests/tot_dist_array_part1.cpp
+++ b/tests/tot_dist_array_part1.cpp
@@ -16,7 +16,7 @@ BOOST_FIXTURE_TEST_SUITE(tot_array_suite1, ToTArrayFixture)
  */
 BOOST_AUTO_TEST_CASE_TEMPLATE(typedefs, TestParam, test_params) {
   // Unpack the types for the test
-  using scalar_type = scalar_type<TestParam>;
+  using element_type = element_type<TestParam>;
   using tile_type = tile_type<TestParam>;
   using policy_type = policy_type<TestParam>;
 
@@ -34,16 +34,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(typedefs, TestParam, test_params) {
 
   {
     constexpr bool is_same =
-        std::is_same_v<typename tensor_t::numeric_type, scalar_type>;
+        std::is_same_v<typename tensor_t::numeric_type, element_type>;
     BOOST_TEST(is_same);
   }
 
   {
     // scalar_type is the REAL type underlying the element type (complex<T>
-    // -> T), so compare against the fixture's element type stripped likewise.
+    // -> T)
     constexpr bool is_same =
         std::is_same_v<typename tensor_t::scalar_type,
-                       TiledArray::detail::scalar_t<scalar_type>>;
+                       TiledArray::detail::scalar_t<element_type>>;
     BOOST_TEST(is_same);
   }
 

--- a/tests/tot_dist_array_part1.cpp
+++ b/tests/tot_dist_array_part1.cpp
@@ -39,8 +39,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(typedefs, TestParam, test_params) {
   }
 
   {
+    // scalar_type is the REAL type underlying the element type (complex<T>
+    // -> T), so compare against the fixture's element type stripped likewise.
     constexpr bool is_same =
-        std::is_same_v<typename tensor_t::scalar_type, scalar_type>;
+        std::is_same_v<typename tensor_t::scalar_type,
+                       TiledArray::detail::scalar_t<scalar_type>>;
     BOOST_TEST(is_same);
   }
 

--- a/tests/tot_expressions.cpp
+++ b/tests/tot_expressions.cpp
@@ -4232,7 +4232,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(vov_inner_contraction, TestParam, test_params) {
   rhs_1({2}) = 4;
   il_type rhs_il{rhs_0, rhs_1};
 
-  using result_type = DistArray<Tensor<scalar_type<TestParam>>, policy_type>;
+  using result_type = DistArray<Tensor<element_type<TestParam>>, policy_type>;
   // N.B. explicitly declare il type here due to
   // https://bugs.llvm.org//show_bug.cgi?id=23689
   result_type corr(m_world, TiledArray::detail::vector_il<double>{2.0, 20.0});


### PR DESCRIPTION
## Problem

ToT×ToT contractions with `std::complex<double>` inner cells never use the strided arena kernels. `arena_strided_dgemm_ce_e` / `_ce_ce_right` / `_ce_ce_left` and their install gates in `ContEngine` are hard-coded to `double`, so a complex contraction falls back to the generic per-cell path: one tiny inner op per result cell and contracted index, instead of one strided BLAS gemm per cell. The kernels themselves are only layout/stride logic on top of `blas::gemm`, which already has the complex overloads.

Separately, scaling a complex ToT by an integral factor (`2 * A("i;j")`) does not compile: the ToT fill lambdas in `Tensor::scale/add/subt/mult` and `ArenaTensor::scale_to` use the raw `elem * factor` and miss the mixed complex×scalar `operator*` in `detail` that the non-nested `scale` branch already uses.

## Changes

- The three strided kernels are templated on the inner numeric type; `detail::is_strided_dgemm_numeric_v<T>` admits `float`, `double`, `complex<float>`, `complex<double>`. All three operands must share the type.
- `ContEngine` install gates and the hc+e reuse gate use the trait; the diagnostic helpers' cell pointers are made type-generic.
- ToT `scale/add/subt/mult` fill lambdas and `ArenaTensor::scale_to` pick up `detail`'s mixed operators.
- Tests: complex cases for the three kernels; a `complex<double>` row in the ToT fixture, so `tot_expressions` / `tot_dist_array` now cover complex ToTs.

## Testing

`arena_strided_dgemm`, `einsum*`, `tot_expressions`, `tot_dist_array_part{1,2}`: 807 cases, no errors. With the change a complex ToT×ToT contraction reports strided ce+e installs where before it reported none.

## Not addressed

- `conj()` on a ToT contraction does not compile (`ComplexConjugate<void>` has no conversion to the element type; `ContractReduce<…, ComplexConjugate<void>>` needs a value-returning `gemm`).
- The ToT × plain-tensor scale GEMM path requires identical element types; a complex ToT scaled by a real plain tensor uses per-cell AXPY.
