### PR TITLE
Tensor<ArenaTensor>: in-place binary ops must not drop populated cells into null destinations

### DIFF
--- a/src/TiledArray/tensor/arena_tensor.h
+++ b/src/TiledArray/tensor/arena_tensor.h
@@ -448,44 +448,91 @@ void scale_to(ArenaTensor<T, R>& dst, Scalar factor) {
   for (std::size_t i = 0; i < n; ++i) d[i] *= factor;
 }
 
-/// `dst += src`. Asserts both views non-null and shape-compatible.
+/// `dst += src`. Asserts shape compatibility.
+/// A null `src` is an implicit zero and a no-op; a null `dst` with a populated
+/// `src` throws (a view has no storage to write into and cannot allocate, so
+/// returning would drop `src`). Contrast `mult_to`, where an annihilating
+/// product makes the same case a legitimate no-op.
 template <typename T, typename R>
 void add_to(ArenaTensor<T, R>& dst, const ArenaTensor<T, R>& src) {
-  if (!dst || !src) return;
+  if (!src) return;
+  if (!dst)
+    TA_EXCEPTION(
+        "TiledArray::add_to(ArenaTensor&, ...): destination cell is null while "
+        "the source cell is populated; an ArenaTensor is a non-owning view, so "
+        "it cannot allocate to adopt the source, and returning would silently "
+        "drop data. Route through the value-returning (union-sparsity) kernel "
+        "instead -- see Tensor::inplace_binary_drops_cells");
   TA_ASSERT(dst.size() == src.size());
   auto* d = dst.data();
   const auto* s = src.data();
   for (std::size_t i = 0; i < dst.size(); ++i) d[i] += s[i];
 }
 
-/// `dst -= src`. Asserts both views non-null and shape-compatible.
+/// `dst -= src`. Asserts shape compatibility.
+/// A null `src` is an implicit zero and a no-op; a null `dst` with a populated
+/// `src` throws (a view has no storage to write into and cannot allocate).
 template <typename T, typename R>
 void subt_to(ArenaTensor<T, R>& dst, const ArenaTensor<T, R>& src) {
-  if (!dst || !src) return;
+  if (!src) return;
+  if (!dst)
+    TA_EXCEPTION(
+        "TiledArray::subt_to(ArenaTensor&, ...): destination cell is null "
+        "while "
+        "the source cell is populated; an ArenaTensor is a non-owning view, so "
+        "it cannot allocate to adopt the source, and returning would silently "
+        "drop data. Route through the value-returning (union-sparsity) kernel "
+        "instead -- see Tensor::inplace_binary_drops_cells");
   TA_ASSERT(dst.size() == src.size());
   auto* d = dst.data();
   const auto* s = src.data();
   for (std::size_t i = 0; i < dst.size(); ++i) d[i] -= s[i];
 }
 
-/// `dst *= src` element-wise. Asserts both views non-null and shape-compatible.
+/// `dst *= src` element-wise. Asserts shape compatibility.
+///
+/// A null cell is the sparse representation of zero, and multiplication --
+/// unlike `add_to` / `subt_to` / `axpy_to` -- is annihilating, so this kernel
+/// is deliberately asymmetric with those three:
+///   - null `src`: `dst *= 0`, so `dst` is *zeroed* (not a no-op, as it is for
+///     the additive ops, where a zero operand leaves `dst` alone).
+///   - null `dst`: `0 * src == 0`, which the null `dst` already represents, so
+///     this is a no-op and *not* an error. Screened-pair Hadamard products
+///     routinely leave a destination cell null while the source is populated;
+///     no data is lost, so the additive ops' exception would be wrong here.
+///     (The value-returning kernel materializes an explicit zero cell for the
+///     same case; both spellings denote zero.)
 template <typename T, typename R>
 void mult_to(ArenaTensor<T, R>& dst, const ArenaTensor<T, R>& src) {
-  if (!dst || !src) return;
+  if (!src) {
+    zero(dst);  // dst *= 0; no-op when dst is itself null
+    return;
+  }
+  if (!dst) return;  // 0 * src == 0, already what a null dst denotes
   TA_ASSERT(dst.size() == src.size());
   auto* d = dst.data();
   const auto* s = src.data();
   for (std::size_t i = 0; i < dst.size(); ++i) d[i] *= s[i];
 }
 
-/// `dst += src * alpha` (in-place BLAS-like AXPY). Asserts both views
-/// non-null and shape-compatible. Argument order matches TA's `_to` CPO
-/// convention `(result, arg, factor)`; the BLAS name AXPY captures the
-/// semantics (in-place, not value-producing).
+/// `dst += src * alpha` (in-place BLAS-like AXPY). Asserts shape
+/// compatibility. Argument order matches TA's `_to` CPO convention
+/// `(result, arg, factor)`; the BLAS name AXPY captures the semantics
+/// (in-place, not value-producing).
+/// A null `src` is an implicit zero and a no-op; a null `dst` with a populated
+/// `src` throws (a view has no storage to write into and cannot allocate).
 template <typename T, typename R, typename Scalar>
 void axpy_to(ArenaTensor<T, R>& dst, const ArenaTensor<T, R>& src,
              Scalar alpha) {
-  if (!dst || !src) return;
+  if (!src) return;
+  if (!dst)
+    TA_EXCEPTION(
+        "TiledArray::axpy_to(ArenaTensor&, ...): destination cell is null "
+        "while "
+        "the source cell is populated; an ArenaTensor is a non-owning view, so "
+        "it cannot allocate to adopt the source, and returning would silently "
+        "drop data. Route through the value-returning (union-sparsity) kernel "
+        "instead -- see Tensor::inplace_binary_drops_cells");
   TA_ASSERT(dst.size() == src.size());
   auto* d = dst.data();
   const auto* s = src.data();

--- a/src/TiledArray/tensor/tensor.h
+++ b/src/TiledArray/tensor/tensor.h
@@ -2065,6 +2065,52 @@ class Tensor {
     }
   }
 
+  /// Does an in-place binary op against a \p Right of this shape ever need
+  /// the null-destination fallback?
+
+  /// True only when this tensor's cells are non-owning *views*. Every use is
+  /// an `if constexpr` condition, never a runtime one: the fallback body calls
+  /// the *value-returning* kernels, which need not be well-formed for a
+  /// `Tensor` / `Scalar` combination that the in-place path nonetheless
+  /// supports -- e.g. `Tensor<std::complex<double>>::subt_to(right, int)` is
+  /// fine in place, while the corresponding `subt(right, int)` is ill-formed
+  /// (`std::complex<double> * int`). Guarding with `if constexpr` keeps the
+  /// fallback out of every non-view instantiation.
+  /// \tparam Right The right-hand tensor type
+  template <typename Right>
+  static constexpr bool binary_needs_view_cell_fallback_v =
+      detail::is_tensor_of_tensor_v<Tensor> && is_tensor_view_v<value_type> &&
+      is_tensor_view_v<typename Right::value_type>;
+
+  /// Would an element-wise in-place binary op against \p right drop data?
+
+  /// When `value_type` is a non-owning *view* (e.g. `ArenaTensor`) a null
+  /// inner cell has no storage to write into and cannot allocate any, so the
+  /// view's in-place kernels have no choice but to leave it null. If the
+  /// corresponding cell of \p right is populated, updating in place would
+  /// silently discard it. Callers must instead route through the
+  /// value-returning kernel, which builds a fresh slab with union sparsity.
+  /// Always `false` unless both operands' cells are views.
+  /// \tparam Right The right-hand tensor type
+  /// \param right The right-hand operand
+  /// \return true if some ordinal has a null left cell and a populated right
+  ///         cell
+  template <typename Right>
+  bool inplace_binary_drops_cells(const Right& right) const {
+    if constexpr (binary_needs_view_cell_fallback_v<Right>) {
+      if (empty() || right.empty()) return false;
+      const std::size_t n = static_cast<std::size_t>(this->total_size());
+      if (n != static_cast<std::size_t>(right.total_size())) return false;
+      for (std::size_t ord = 0; ord < n; ++ord)
+        if (this->data()[ord].empty() && !right.data()[ord].empty())
+          return true;
+      return false;
+    } else {
+      (void)right;
+      return false;
+    }
+  }
+
   // Addition operations
 
   /// Element-wise add for `Tensor<ArenaTensor>` ToT operands. Routes through
@@ -2361,6 +2407,15 @@ class Tensor {
       return *this;
     }
 
+    // a null view cell cannot adopt a populated right cell in place -- fall
+    // back to the value-returning (union-sparsity) kernel
+    if constexpr (binary_needs_view_cell_fallback_v<Right>) {
+      if (inplace_binary_drops_cells(right)) {
+        *this = this->add(right);
+        return *this;
+      }
+    }
+
     return inplace_binary(right, [](value_type& MADNESS_RESTRICT l,
                                     const value_t<Right> r) { l += r; });
   }
@@ -2376,6 +2431,12 @@ class Tensor {
     requires(is_tensor<Right>::value && detail::is_numeric_v<Scalar> &&
              detail::addable_to<value_type&, const value_t<Right>&>)
   Tensor& add_to(const Right& right, const Scalar factor) {
+    if constexpr (binary_needs_view_cell_fallback_v<Right>) {
+      if (inplace_binary_drops_cells(right)) {
+        *this = this->add(right, factor);
+        return *this;
+      }
+    }
     return inplace_binary(
         right, [factor](value_type& MADNESS_RESTRICT l,
                         const value_t<Right> r) { (l += r) *= factor; });
@@ -2400,6 +2461,13 @@ class Tensor {
       *this = detail::clone_or_cast<Tensor>(right);
       this->scale_to(factor);
       return *this;
+    }
+    if constexpr (binary_needs_view_cell_fallback_v<Right>) {
+      if (inplace_binary_drops_cells(right)) {
+        // no value-returning `axpy`; compose scale-then-add on the union kernel
+        *this = this->add(right.scale(factor));
+        return *this;
+      }
     }
     return inplace_binary(right,
                           [factor](auto& MADNESS_RESTRICT l, const auto& r) {
@@ -2679,6 +2747,15 @@ class Tensor {
     // early exit for empty right
     if (right.empty()) return *this;
 
+    // a null view cell cannot adopt a populated right cell in place -- fall
+    // back to the value-returning (union-sparsity) kernel
+    if constexpr (binary_needs_view_cell_fallback_v<Right>) {
+      if (inplace_binary_drops_cells(right)) {
+        *this = this->subt(right);
+        return *this;
+      }
+    }
+
     return inplace_binary(
         right, [](auto& MADNESS_RESTRICT l, const auto& r) { l -= r; });
   }
@@ -2698,6 +2775,13 @@ class Tensor {
     // early exit for empty right
     if (right.empty()) {
       return this->scale_to(factor);
+    }
+
+    if constexpr (binary_needs_view_cell_fallback_v<Right>) {
+      if (inplace_binary_drops_cells(right)) {
+        *this = this->subt(right, factor);
+        return *this;
+      }
     }
 
     return inplace_binary(right,
@@ -2925,6 +3009,10 @@ class Tensor {
     // early exit for empty this
     if (empty()) return *this;
 
+    // No fallback here, unlike add_to/subt_to/axpy_to: multiplication
+    // annihilates, so a null destination cell against a populated source has an
+    // identically zero product and loses nothing. The free per-cell `mult_to`
+    // leaves it null, which is how a sparse ToT spells zero.
     return inplace_binary(right, [](value_type& MADNESS_RESTRICT l,
                                     const value_t<Right>& r) { l *= r; });
   }
@@ -2944,6 +3032,7 @@ class Tensor {
     // early exit for empty this
     if (empty()) return *this;
 
+    // No fallback -- see the unscaled `mult_to` above.
     return inplace_binary(
         right, [factor](value_type& MADNESS_RESTRICT l,
                         const value_t<Right>& r) { (l *= r) *= factor; });

--- a/src/TiledArray/tensor/tensor.h
+++ b/src/TiledArray/tensor/tensor.h
@@ -2186,7 +2186,7 @@ class Tensor {
     if (right.empty()) return this->clone();
 
     // early exit for empty this
-    if (empty()) detail::clone_or_cast<Tensor>(right);
+    if (empty()) return detail::clone_or_cast<Tensor>(right);
 
     if constexpr (detail::is_tensor_of_tensor_v<Tensor> &&
                   detail::is_ta_tensor_v<value_type> &&

--- a/tests/arena_tot_trivial.cpp
+++ b/tests/arena_tot_trivial.cpp
@@ -231,4 +231,12 @@ BOOST_AUTO_TEST_CASE(mult_mismatched_null_inners) {
   }
 }
 
+// --- regression: `add` on an empty (default-constructed) left outer -------
+BOOST_AUTO_TEST_CASE(add_empty_left_outer_returns_right) {
+  outer_t L;  // default-constructed -> empty outer
+  outer_t R = make_tot(3, 4, 7.0);
+  BOOST_REQUIRE(L.empty());
+  BOOST_CHECK(tot_equal(L.add(R), R));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/arena_tot_trivial.cpp
+++ b/tests/arena_tot_trivial.cpp
@@ -4,8 +4,10 @@
 #include "tiledarray.h"
 #include "unit_test_config.h"
 
+#include <complex>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <vector>
 
 namespace TA = TiledArray;
@@ -231,12 +233,301 @@ BOOST_AUTO_TEST_CASE(mult_mismatched_null_inners) {
   }
 }
 
+// --- null destination cell in an IN-PLACE binary op ----------------------
+// `Tensor<ArenaTensor>` inner cells are non-owning views: a null cell has no
+// storage and cannot allocate. An in-place `add_to` therefore cannot adopt a
+// populated right-hand cell, and silently returning would drop it. The
+// in-place ops must detect this and fall back to the value-returning
+// (union-sparsity) kernel.
+
+namespace {
+
+using arena_inner_t = TA::ArenaTensor<double, TA::Range>;
+using arena_outer_t = TA::Tensor<arena_inner_t>;
+
+// The in-place null-cell fallback is gated on exactly these two traits (see
+// `Tensor::binary_needs_view_cell_fallback_v`). If either went false for the
+// arena ToT type the fallback would silently vanish, so pin them here.
+static_assert(TA::detail::is_tensor_of_tensor_v<arena_outer_t>);
+static_assert(TA::is_tensor_view_v<arena_inner_t>);
+static_assert(!TA::is_tensor_view_v<TA::Tensor<double>>);
+
+/// `present[ord]==false` requests a zero-volume inner range, which
+/// `arena_outer_init` turns into a deliberately-null inner cell.
+arena_outer_t make_arena_tot_sparse(std::size_t N_outer, std::size_t n_inner,
+                                    double base,
+                                    const std::vector<bool>& present) {
+  auto range_fn = [&present, n_inner](std::size_t ord) {
+    return present[ord] ? TA::Range{static_cast<long>(n_inner)} : TA::Range{};
+  };
+  arena_outer_t t = TA::detail::arena_outer_init<arena_outer_t>(
+      TA::Range{static_cast<long>(N_outer)}, 1, range_fn, alignof(double),
+      /*zero_init=*/true);
+  for (std::size_t ord = 0; ord < N_outer; ++ord) {
+    arena_inner_t& c = t.data()[ord];
+    if (c.empty()) continue;
+    for (std::size_t i = 0; i < n_inner; ++i)
+      c.data()[i] = base + ord * 100.0 + i;
+  }
+  return t;
+}
+
+/// Elementwise check against the implicit-zero (union sparsity) reference:
+/// every element of `got` must equal `op(l, r)` with an absent operand read as
+/// zero. This checks the *value*, not the representation: a null cell and an
+/// explicit zero cell both denote zero, so a null cell in `got` is accepted
+/// wherever every expected element is zero (which is what an annihilating
+/// `mult` produces for a cell present in only one operand).
+template <typename Op>
+void check_union(const arena_outer_t& got, const arena_outer_t& L,
+                 const arena_outer_t& R, Op op) {
+  BOOST_REQUIRE_EQUAL(got.range().volume(), L.range().volume());
+  for (std::size_t ord = 0; ord < L.range().volume(); ++ord) {
+    const arena_inner_t& l = L.data()[ord];
+    const arena_inner_t& r = R.data()[ord];
+    const arena_inner_t& d = got.data()[ord];
+    const bool hl = !l.empty(), hr = !r.empty();
+    if (!hl && !hr) {
+      BOOST_CHECK(d.empty());
+      continue;
+    }
+    const std::size_t n = hl ? l.size() : r.size();
+    auto expected = [&](std::size_t i) {
+      const double lv = hl ? l.data()[i] : 0.0;
+      const double rv = hr ? r.data()[i] : 0.0;
+      return op(lv, rv);
+    };
+    if (d.empty()) {
+      // a null cell is the sparse spelling of zero -- fine iff zero is right
+      for (std::size_t i = 0; i < n; ++i) BOOST_CHECK_EQUAL(0.0, expected(i));
+      continue;
+    }
+    BOOST_REQUIRE_EQUAL(d.size(), n);
+    for (std::size_t i = 0; i < n; ++i)
+      BOOST_CHECK_EQUAL(d.data()[i], expected(i));
+  }
+}
+
+const std::vector<bool> all_null_5{false, false, false, false, false};
+const std::vector<bool> all_present_5{true, true, true, true, true};
+
+}  // namespace
+
+// Baseline: the *value-returning* kernel already handles an all-null left.
+BOOST_AUTO_TEST_CASE(arena_add_all_null_left_cells) {
+  arena_outer_t L = make_arena_tot_sparse(5, 4, 1.0, all_null_5);
+  arena_outer_t R = make_arena_tot_sparse(5, 4, 0.5, all_present_5);
+  check_union(L.add(R), L, R, [](double a, double b) { return a + b; });
+}
+
+// The in-place kernel must not drop the right-hand cells.
+BOOST_AUTO_TEST_CASE(arena_add_to_all_null_left_cells) {
+  arena_outer_t L = make_arena_tot_sparse(5, 4, 1.0, all_null_5);
+  arena_outer_t R = make_arena_tot_sparse(5, 4, 0.5, all_present_5);
+  arena_outer_t t = L.clone();
+  t.add_to(R);
+  check_union(t, L, R, [](double a, double b) { return a + b; });
+}
+
+BOOST_AUTO_TEST_CASE(arena_add_to_mismatched_null_inners) {
+  arena_outer_t L = make_arena_tot_sparse(5, 4, 1.0, nz_L);
+  arena_outer_t R = make_arena_tot_sparse(5, 4, 0.5, nz_R);
+  arena_outer_t t = L.clone();
+  t.add_to(R);
+  check_union(t, L, R, [](double a, double b) { return a + b; });
+}
+
+BOOST_AUTO_TEST_CASE(arena_subt_to_mismatched_null_inners) {
+  arena_outer_t L = make_arena_tot_sparse(5, 4, 5.0, nz_L);
+  arena_outer_t R = make_arena_tot_sparse(5, 4, 1.0, nz_R);
+  arena_outer_t t = L.clone();
+  t.subt_to(R);
+  check_union(t, L, R, [](double a, double b) { return a - b; });
+}
+
+// `nz_L`/`nz_R` disagree in both directions: cell 0 is left-only (the in-place
+// kernel must zero it) and cell 4 is right-only, which is what drives
+// `Tensor::mult_to` onto its tensor-of-view fallback.
+BOOST_AUTO_TEST_CASE(arena_mult_to_mismatched_null_inners) {
+  arena_outer_t L = make_arena_tot_sparse(5, 4, 2.0, nz_L);
+  arena_outer_t R = make_arena_tot_sparse(5, 4, 0.5, nz_R);
+  arena_outer_t t = L.clone();
+  t.mult_to(R);
+  check_union(t, L, R, [](double a, double b) { return a * b; });
+}
+
+BOOST_AUTO_TEST_CASE(arena_add_to_scaled_mismatched_null_inners) {
+  arena_outer_t L = make_arena_tot_sparse(5, 4, 1.0, nz_L);
+  arena_outer_t R = make_arena_tot_sparse(5, 4, 0.5, nz_R);
+  arena_outer_t t = L.clone();
+  t.add_to(R, 2.0);  // legacy semantics: (l + r) * factor
+  check_union(t, L, R, [](double a, double b) { return (a + b) * 2.0; });
+}
+
+BOOST_AUTO_TEST_CASE(arena_axpy_to_mismatched_null_inners) {
+  arena_outer_t L = make_arena_tot_sparse(5, 4, 1.0, nz_L);
+  arena_outer_t R = make_arena_tot_sparse(5, 4, 0.5, nz_R);
+  arena_outer_t t = L.clone();
+  t.axpy_to(R, 2.0);
+  check_union(t, L, R, [](double a, double b) { return a + b * 2.0; });
+}
+
+// The free per-cell kernels are deliberately asymmetric about a null
+// destination: the additive ops would drop the source, so they refuse
+// loudly; `mult_to` annihilates to zero, which a null cell already
+// denotes, so it stays a no-op.
+BOOST_AUTO_TEST_CASE(arena_cell_kernels_null_destination_policy) {
+  arena_outer_t L = make_arena_tot_sparse(2, 4, 1.0, {false, true});
+  arena_outer_t R = make_arena_tot_sparse(2, 4, 0.5, {true, false});
+  arena_inner_t& null_dst = L.data()[0];
+  const arena_inner_t& live_src = R.data()[0];
+  BOOST_REQUIRE(null_dst.empty());
+  BOOST_REQUIRE(!live_src.empty());
+  // additive ops: the source would be dropped, so refuse loudly
+  BOOST_CHECK_THROW(TiledArray::add_to(null_dst, live_src),
+                    TiledArray::Exception);
+  BOOST_CHECK_THROW(TiledArray::subt_to(null_dst, live_src),
+                    TiledArray::Exception);
+  BOOST_CHECK_THROW(TiledArray::axpy_to(null_dst, live_src, 2.0),
+                    TiledArray::Exception);
+  // mult annihilates: 0 * src == 0, which the null destination already
+  // denotes, so nothing is lost and this is a legitimate no-op
+  BOOST_CHECK_NO_THROW(TiledArray::mult_to(null_dst, live_src));
+  BOOST_CHECK(null_dst.empty());
+
+  // a null *source* is a no-op for the additive ops ...
+  arena_inner_t& live_dst = L.data()[1];
+  const arena_inner_t& null_src = R.data()[1];
+  BOOST_REQUIRE(null_src.empty());
+  const double before = live_dst.data()[0];
+  BOOST_CHECK_NO_THROW(TiledArray::add_to(live_dst, null_src));
+  BOOST_CHECK_EQUAL(live_dst.data()[0], before);
+  // ... but zeroes the destination for mult (dst *= 0)
+  BOOST_CHECK_NO_THROW(TiledArray::mult_to(live_dst, null_src));
+  BOOST_CHECK_EQUAL(live_dst.data()[0], 0.0);
+}
+
+// --- compile-only regression: non-view tensors never instantiate the -----
+// tensor-of-view fallback. `Tensor<std::complex<double>>` accepts an `int`
+// factor in place -- `(l -= r) *= 2` goes through
+// `complex<double>::operator*=(const double&)` -- but the value-returning
+// `subt(right, int)` the fallback would call is ill-formed, because the
+// binary `operator*(const complex<_Tp>&, const _Tp&)` cannot deduce `_Tp`
+// from a `complex<double>` / `int` pair. Guarding the fallback with
+// `if constexpr` keeps it uninstantiated here; without that guard this test
+// case does not compile. (This is the shape MPQC instantiates.)
+BOOST_AUTO_TEST_CASE(complex_tile_inplace_ops_with_int_factor) {
+  using ztile_t = TA::Tensor<std::complex<double>>;
+  const TA::Range r{4l};
+  auto make = [&r](double v) {
+    ztile_t t(r);
+    for (std::size_t i = 0; i < r.volume(); ++i)
+      t.at_ordinal(i) = std::complex<double>(v + i, -v);
+    return t;
+  };
+  const ztile_t L = make(1.0), R = make(0.5);
+
+  ztile_t a = L.clone();
+  a.add_to(R, int{2});  // legacy semantics: (l + r) * factor
+  ztile_t d = L.clone();
+  d.subt_to(R, int{2});
+  ztile_t m = L.clone();
+  m.mult_to(R, int{2});
+  // `axpy_to`'s own in-place body is `l += r * factor`, so a mixed
+  // complex/int pair is ill-formed there independently of the fallback --
+  // exercise it with a scalar the elementwise body accepts.
+  ztile_t x = L.clone();
+  x.axpy_to(R, 2.0);
+
+  for (std::size_t i = 0; i < r.volume(); ++i) {
+    const std::complex<double> l = L.at_ordinal(i), rr = R.at_ordinal(i);
+    BOOST_CHECK_EQUAL(a.at_ordinal(i), (l + rr) * 2.0);
+    BOOST_CHECK_EQUAL(d.at_ordinal(i), (l - rr) * 2.0);
+    BOOST_CHECK_EQUAL(m.at_ordinal(i), (l * rr) * 2.0);
+    BOOST_CHECK_EQUAL(x.at_ordinal(i), l + rr * 2.0);
+  }
+}
+
 // --- regression: `add` on an empty (default-constructed) left outer -------
 BOOST_AUTO_TEST_CASE(add_empty_left_outer_returns_right) {
   outer_t L;  // default-constructed -> empty outer
   outer_t R = make_tot(3, 4, 7.0);
   BOOST_REQUIRE(L.empty());
   BOOST_CHECK(tot_equal(L.add(R), R));
+}
+
+// --- expression level: a permuted operand must not turn the add in place --
+// `ArrayEvalImpl::is_consumable()` is true for any permuted operand, which
+// makes `BinaryWrapper` rewrite `A(perm) + B` as `A(perm).add_to(B)`. With
+// all of A's inner cells null that in-place add used to drop B entirely.
+BOOST_AUTO_TEST_CASE(expr_permuted_add_null_left_cells_keeps_right) {
+  using ArenaInner = TA::ArenaTensor<double, TA::Range>;
+  using ArenaOuter = TA::Tensor<ArenaInner>;
+  using ArenaArr = TA::DistArray<ArenaOuter, TA::SparsePolicy>;
+
+  auto& world = TA::get_default_world();
+  constexpr long P = 2, Q = 3;
+  TA::TiledRange trange{{0l, 2l, 4l}, {0l, 2l, 4l}};  // 2x2 tiles, 4x4 outer
+
+  TA::Tensor<float> norms(trange.tiles_range(), 1.0f);
+  TA::SparseShape<float> shape(norms, trange);
+
+  auto b_val = [](long i, long j, long a, long b) {
+    return 1.0 + 10.0 * i + 100.0 * j + 0.5 * a + 0.25 * b;
+  };
+
+  // A: every tile present, every inner cell null (an all-zero ToT)
+  ArenaArr A(world, trange, shape);
+  A.init_tiles([](const TA::Range& tr) {
+    return TA::detail::arena_outer_init<ArenaOuter>(
+        tr, 1, [](std::size_t) { return TA::Range{}; });
+  });
+  // B: every tile present, every inner cell populated
+  ArenaArr B(world, trange, shape);
+  B.init_tiles([&](const TA::Range& tr) {
+    ArenaOuter t =
+        TA::detail::arena_outer_init<ArenaOuter>(tr, 1, [](std::size_t) {
+          return TA::Range{P, Q};
+        });
+    for (std::size_t o = 0; o < t.range().volume(); ++o) {
+      ArenaInner& c = t.data()[o];
+      if (c.empty()) continue;
+      const auto idx = tr.idx(o);
+      for (long a = 0; a < P; ++a)
+        for (long b = 0; b < Q; ++b)
+          c.data()[a * Q + b] = b_val(idx[0], idx[1], a, b);
+    }
+    return t;
+  });
+  world.gop.fence();
+
+  // A is transposed on the outer indices only (arena cells reject an inner
+  // permutation); since A is all zeros the sum must reproduce B exactly.
+  ArenaArr C;
+  C("i,j;a,b") = A("j,i;a,b") + B("i,j;a,b");
+  world.gop.fence();
+
+  ArenaArr D;  // control: no permutation
+  D("i,j;a,b") = A("i,j;a,b") + B("i,j;a,b");
+  world.gop.fence();
+
+  for (const auto& out : {std::ref(C), std::ref(D)}) {
+    const ArenaArr& got = out.get();
+    for (std::size_t t = 0; t < trange.tiles_range().volume(); ++t) {
+      BOOST_REQUIRE(!got.is_zero(t));
+      ArenaOuter gt = got.find(t).get();
+      const TA::Range& tr = trange.make_tile_range(t);
+      BOOST_REQUIRE_EQUAL(gt.range().volume(), tr.volume());
+      for (std::size_t o = 0; o < gt.range().volume(); ++o) {
+        const ArenaInner& c = gt.data()[o];
+        BOOST_REQUIRE(!c.empty());
+        const auto idx = tr.idx(o);
+        for (long a = 0; a < P; ++a)
+          for (long b = 0; b < Q; ++b)
+            BOOST_CHECK_EQUAL(c.data()[a * Q + b], b_val(idx[0], idx[1], a, b));
+      }
+    }
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Nested tiles `Tensor<ArenaTensor<T>>` lost data in in-place addition when a destination
inner cell was null while the source cell was populated: the arena `add_to` kernel returned
silently on a null destination (an `ArenaTensor` is a non-owning view and cannot adopt the
source), so an entire addend was dropped whenever two ToT operands disagreed on which inner
cells are populated — a routine case, since the same outer tile can aggregate several pairs
with some screened to null. Found through a NaN residual in a downstream application: an
all-empty nested intermediate added to a populated one.

Changes:

- `Tensor::add_to` / `subt_to` / `axpy_to` (scaled and unscaled) for tensor-of-view value
  types fall back to the value-returning union kernel when any destination cell is null and
  the source cell is not. The gate is used only as an `if constexpr` condition, never a
  runtime one, so nothing is instantiated for non-view tensors — the fallback body calls the
  value-returning kernels, which need not be well-formed for an operand/scalar mix the
  in-place path does support (`Tensor<std::complex<double>>::subt_to(right, int)` is fine
  elementwise, while the `subt(right, int)` it would fall back to is not).
- The free arena kernels `add_to` / `subt_to` / `axpy_to` throw `TiledArray::Exception` on a
  null destination with a populated source instead of dropping data. `mult_to` is
  deliberately asymmetric and does *not*: multiplication annihilates, the product is zero,
  and a null cell is exactly how a sparse ToT spells zero, so nothing is lost — screened-pair
  Hadamard products routinely produce that shape. `mult_to` also gains the mirror fix, zeroing
  the destination on a null source (previously left unchanged).
- Missing `return` in the tensor-of-tensor `Tensor::add` when the left operand is empty (fell
  through into the kernel and produced an empty result, or tripped a TA_ASSERT).
- Tests in `tests/arena_tot_trivial.cpp`: tile-level `add_to`/`subt_to`/`mult_to`/`axpy_to`
  with all-null and mixed-null cells, the kernel null-destination policy, an
  expression-level permuted add over an all-null arena array, an empty-left plain
  tensor-of-tensor add, and a complex-tile instantiation regression. Each data-loss case
  failed before the fix.

Verified on macOS/clang, Debug, `TA_ASSERT_THROW`, PaRSEC: full serial suite and np=2 both
clean.

A follow-up branch builds on this with further hardening (a `total_size` CPO, strided-operand
support in the arena kernels, missing empty-operand guards on the remaining in-place ops, and
intersection sparsity for `mult`).
