### PR TITLE
cmake: drop target-referencing genexes before probing MADNESS for TBB

### DIFF
--- a/cmake/modules/DetectMADNESSConfig.cmake
+++ b/cmake/modules/DetectMADNESSConfig.cmake
@@ -8,17 +8,35 @@ macro (detect_MADNESS_configuration)
   # only extract include dirs, don't use MADworld target directly since it may have not been built yet
   # unfortunately this is not easy to check since the target is defined but not ready
   get_property(_MADNESS_INCLUDE_DIRS TARGET MADworld PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
-  # some targets don't even exist in the build tree (El) so filter them out and cache the result
-  if (TARGET El)
-    set(MADNESS_INTERNAL_INCLUDE_DIRS )
-    foreach(_inc ${_MADNESS_INCLUDE_DIRS})
-      if (NOT (${_inc} MATCHES "El"))
-        list(APPEND MADNESS_INTERNAL_INCLUDE_DIRS ${_inc})
-      endif()
-    endforeach()
-  else()
-    set(MADNESS_INTERNAL_INCLUDE_DIRS ${_MADNESS_INCLUDE_DIRS})
-  endif()
+  # Every entry here is a generator expression (see add_mad_library), but they
+  # are not all equal:
+  #
+  #   $<BUILD_INTERFACE:...> / $<INSTALL_INTERFACE:...>
+  #       reference no target, evaluate fine inside a try_compile project, and
+  #       carry the directory holding madness/config.h -- the probe below needs
+  #       these, so they must be kept.
+  #
+  #   $<TARGET_PROPERTY:MADmisc,INTERFACE_INCLUDE_DIRECTORIES>
+  #       names a MADNESS target. CHECK_CXX_SOURCE_COMPILES runs try_compile(),
+  #       which generates a standalone project where no MADNESS target exists,
+  #       so this is a hard error there ("Target MADmisc not found") rather than
+  #       an include path.
+  #
+  # MADworld only grew a $<TARGET_PROPERTY:...> entry once it took a dependency
+  # on another MAD* library target (MADmisc, in MADNESS 48dc6494b); before that
+  # its interface was $<BUILD_INTERFACE>/$<INSTALL_INTERFACE> only, which is why
+  # this never bit earlier.
+  #
+  # So filter on target-referencing genexes specifically, not on "$<". This also
+  # supersedes an earlier special case for El -- its entry is a
+  # $<TARGET_PROPERTY:El,...> -- and is safer than the substring match on "El"
+  # it replaces, which would have dropped a real path containing those letters.
+  set(MADNESS_INTERNAL_INCLUDE_DIRS )
+  foreach(_inc ${_MADNESS_INCLUDE_DIRS})
+    if (NOT (_inc MATCHES "\\$<TARGET_"))
+      list(APPEND MADNESS_INTERNAL_INCLUDE_DIRS "${_inc}")
+    endif()
+  endforeach()
   set(MADNESS_INTERNAL_INCLUDE_DIRS "${MADNESS_INTERNAL_INCLUDE_DIRS}"
           CACHE STRING "Sanitized list of MADNESS include directories usable in build tree")
 


### PR DESCRIPTION
Fixes #576.

## Problem

`detect_MADNESS_configuration()` copies `MADworld`'s `INTERFACE_INCLUDE_DIRECTORIES` into
`CMAKE_REQUIRED_INCLUDES` and runs `CHECK_CXX_SOURCE_COMPILES`. That property holds
unevaluated generator expressions, and since MADNESS
[`48dc6494b`](https://github.com/m-a-d-n-e-s-s/madness/commit/48dc6494bc9b34e21ba7c9deb9ecc0428e53acb4)
("misc: make it a leaf component so world can depend on it") one of them names a target:

```
$<TARGET_PROPERTY:MADmisc,INTERFACE_INCLUDE_DIRECTORIES>
```

`CHECK_CXX_SOURCE_COMPILES` runs `try_compile()`, which generates a standalone project
where no MADNESS target exists, so configure dies:

```
Error evaluating generator expression:
  $<TARGET_PROPERTY:MADmisc,INTERFACE_INCLUDE_DIRECTORIES>
Target "MADmisc" not found.
```

`MADworld` only grew such an entry once it took a dependency on another `MAD*` library
target — `misc` is the first — so before that its interface was
`$<BUILD_INTERFACE>`/`$<INSTALL_INTERFACE>` only, which is why this never bit earlier.

The currently pinned `TA_TRACKED_MADNESS_TAG` (`666765ca6`) predates the MADNESS change, so
CI is unaffected; this bites anyone pointing `FETCHCONTENT_SOURCE_DIR_MADNESS` at a newer
checkout, and it would block the next pin bump.

## Fix

Filter out entries naming a target; keep the rest.

The distinction is load-bearing. `$<BUILD_INTERFACE:...>` references no target, evaluates
fine inside a `try_compile` project, and carries the directories holding
`madness/config.h`. Filtering on `"$<"` rather than `"$<TARGET_"` would therefore leave the
probe with **no include path at all** — it would still "succeed", but report *no TBB*
because the header was missing rather than because TBB is absent. That is a silently wrong
configuration instead of a loud failure, so the narrower match is deliberate. (I wrote the
blunt version first and caught it exactly this way; see Verification.)

This also supersedes the pre-existing `El` special case — that entry is a
`$<TARGET_PROPERTY:El,...>`, covered by the same rule — and is safer than the substring
match on `"El"` it replaces, which would have dropped a real include path containing those
letters (e.g. `/opt/Elemental/include`).

## Verification

Against MADNESS `cb46c1578` (past `48dc6494b`), where configure previously failed outright:

- configure now completes with zero CMake errors and generates a build system;
- `MADNESS_INTERNAL_INCLUDE_DIRS` retains both `$<BUILD_INTERFACE:...>` directories (MADNESS
  source tree and build tree) and drops only the `$<TARGET_PROPERTY:...>` entry;
- the TBB probe **compiles** and fails on its own `#error "MADNESS does not have TBB"`,
  rather than on `fatal error: 'madness/config.h' file not found` — i.e. it now answers for
  the right reason. With the blunt `"$<"` filter the log showed the latter, which is how the
  over-broad version was caught.

No behavior change for the pinned MADNESS, whose interface contains no `$<TARGET_*>` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
