### PR TITLE
Tensor<ArenaTensor> follow-ups: total_size CPO, strided operands, empty-operand guards, intersection sparsity for mult

### DIFF
--- a/src/TiledArray/dist_array.h
+++ b/src/TiledArray/dist_array.h
@@ -2189,25 +2189,18 @@ size_t volume(const DistArray<Tile, Policy>& array) {
     if constexpr (detail::is_tensor_of_tensor_v<Tile>) {
       // Inner tile pointer is passed (see is_reduce_op_v in
       // tensor/type_traits.h selecting the pointer-passing tensor_reduce
-      // overload). Prefer `total_size()` (TA::Tensor exposes it, batches
-      // included); fall back to `size()` for inner tile types that don't
+      // overload). `TiledArray::total_size` counts batches where the inner
+      // tile type has them and falls back to `size()` where it does not
       // (e.g. btas::Tensor).
       auto reduce_op = [](size_t& MADNESS_RESTRICT result, auto&& arg) {
-        using InnerTile =
-            std::remove_cv_t<std::remove_reference_t<decltype(*arg)>>;
-        if constexpr (detail::has_member_function_total_size_anyreturn_v<
-                          InnerTile>) {
-          result += arg->total_size();
-        } else {
-          result += arg->size();
-        }
+        result += TiledArray::total_size(*arg);
       };
       auto join_op = [](auto& MADNESS_RESTRICT result, size_t count) {
         result += count;
       };
       vol += in_tile.reduce(reduce_op, join_op, size_t{0});
     } else
-      vol += in_tile.total_size();
+      vol += TiledArray::total_size(in_tile);
   };
 
   for (auto&& local_tile_future : array)

--- a/src/TiledArray/einsum/tiledarray.h
+++ b/src/TiledArray/einsum/tiledarray.h
@@ -948,17 +948,35 @@ auto einsum(expressions::TsrExpr<ArrayA_> A, expressions::TsrExpr<ArrayB_> B,
               if constexpr (inner_is_view) {
                 // `tile` is built with default-constructed (null) inner cells
                 // and a view cell cannot allocate, so it has no storage to
-                // accept the first contribution: the free `axpy_to` refuses a
-                // null destination rather than silently drop the source. Only
+                // accept a contribution: the free `axpy_to` refuses a null
+                // destination rather than silently drop the source. Only
                 // run_regime_a_arena grows result cells, so reaching this
                 // legacy path means the arena plan was inactive (e.g. under
-                // detail::arena_disabled()). Report that here rather than let
-                // the per-cell kernel raise a lower-level diagnostic --
-                // mirrors the ToT x ToT branch above.
-                TA_EXCEPTION(
-                    "TA::einsum: ToT x T product with view inner cells (e.g. "
-                    "ArenaTensor) is supported only via the regime-A arena "
-                    "fast path, which was inactive for this expression");
+                // detail::arena_disabled()).
+                //
+                // Report that here rather than let the per-cell kernel raise a
+                // lower-level diagnostic -- but only once a source cell is
+                // actually populated. A fully screened operand contributes
+                // nothing, leaves the null result tile correct, and must keep
+                // working: `axpy_to` early-returns on a null source, so that
+                // case never needed the destination to have storage.
+                auto aik = ai.batch(k);
+                auto bik = bi.batch(k);
+                const auto vol = aik.total_size();
+                TA_ASSERT(vol == bik.total_size());
+                for (auto i = 0; i < vol; ++i) {
+                  bool src_populated;
+                  if constexpr (IsArrayToT<ArrayA>)
+                    src_populated = !aik.data()[i].empty();
+                  else
+                    src_populated = !bik.data()[i].empty();
+                  if (src_populated)
+                    TA_EXCEPTION(
+                        "TA::einsum: ToT x T product with view inner cells "
+                        "(e.g. ArenaTensor) is supported only via the regime-A "
+                        "arena fast path, which was inactive for this "
+                        "expression");
+                }
               } else {
                 auto aik = ai.batch(k);
                 auto bik = bi.batch(k);

--- a/src/TiledArray/einsum/tiledarray.h
+++ b/src/TiledArray/einsum/tiledarray.h
@@ -945,23 +945,37 @@ auto einsum(expressions::TsrExpr<ArrayA_> A, expressions::TsrExpr<ArrayB_> B,
                   add_to(el, element_product_op(aik.data()[i], bik.data()[i]));
               }
             } else if constexpr (!AreArraySame<ArrayA, ArrayB>) {
-              auto aik = ai.batch(k);
-              auto bik = bi.batch(k);
-              auto vol = aik.total_size();
-              TA_ASSERT(vol == bik.total_size());
+              if constexpr (inner_is_view) {
+                // `tile` is built with default-constructed (null) inner cells
+                // and a view cell cannot allocate, so it has no storage to
+                // accept the first contribution: the free `axpy_to` refuses a
+                // null destination rather than silently drop the source. Only
+                // run_regime_a_arena grows result cells, so reaching this
+                // legacy path means the arena plan was inactive (e.g. under
+                // detail::arena_disabled()). Report that here rather than let
+                // the per-cell kernel raise a lower-level diagnostic --
+                // mirrors the ToT x ToT branch above.
+                TA_EXCEPTION(
+                    "TA::einsum: ToT x T product with view inner cells (e.g. "
+                    "ArenaTensor) is supported only via the regime-A arena "
+                    "fast path, which was inactive for this expression");
+              } else {
+                auto aik = ai.batch(k);
+                auto bik = bi.batch(k);
+                auto vol = aik.total_size();
+                TA_ASSERT(vol == bik.total_size());
 
-              auto &el = tile({k});
+                auto &el = tile({k});
 
-              // Fused `el += inner_tensor * scalar` -- no scaled temporary
-              // (axpy_to works in-place, so it also supports view inner
-              // cells that cannot value-return a scaled tensor).
-              using TiledArray::axpy_to;
-              for (auto i = 0; i < vol; ++i)
-                if constexpr (IsArrayToT<ArrayA>) {
-                  axpy_to(el, aik.data()[i], bik.data()[i]);
-                } else {
-                  axpy_to(el, bik.data()[i], aik.data()[i]);
-                }
+                // Fused `el += inner_tensor * scalar` -- no scaled temporary.
+                using TiledArray::axpy_to;
+                for (auto i = 0; i < vol; ++i)
+                  if constexpr (IsArrayToT<ArrayA>) {
+                    axpy_to(el, aik.data()[i], bik.data()[i]);
+                  } else {
+                    axpy_to(el, bik.data()[i], aik.data()[i]);
+                  }
+              }
 
             } else {
               auto hk = ai.batch(k).dot(bi.batch(k));

--- a/src/TiledArray/tensor/arena_kernels.h
+++ b/src/TiledArray/tensor/arena_kernels.h
@@ -489,21 +489,26 @@ OuterTensor arena_trivial_scaled(const ToTSide& tot_outer,
                                  FillOp&& fill_op) {
   using elem_t = typename OuterTensor::value_type::value_type;
   using inner_range_t = typename OuterTensor::value_type::range_type;
+  // Either side may be a strided view; address both through `arena_cell_offset`
+  // and take the cell/batch counts from the `total_size` CPO, as the unary and
+  // binary kernels do. `nbatch()` is a TA::Tensor member a view does not have.
   TA_ASSERT(tot_outer.range().volume() == scalar_outer.range().volume());
-  TA_ASSERT(tot_outer.nbatch() == scalar_outer.nbatch());
+  TA_ASSERT(TiledArray::total_size(tot_outer) ==
+            TiledArray::total_size(scalar_outer));
   auto range_fn = [&tot_outer](std::size_t ord) -> inner_range_t {
-    const auto& t = tot_outer.data()[ord];
+    const auto& t = tot_outer.data()[arena_cell_offset(tot_outer, ord)];
     return t.empty() ? inner_range_t{} : t.range();
   };
-  OuterTensor result = arena_outer_init<OuterTensor>(
-      tot_outer.range(), tot_outer.nbatch(), range_fn, alignof(elem_t),
-      /*zero_init=*/false);
-  const std::size_t N_cells = tot_outer.range().volume() * tot_outer.nbatch();
+  const auto [N_cells, tot_nbatch] = arena_cells_and_batches(tot_outer);
+  OuterTensor result =
+      arena_outer_init<OuterTensor>(tot_outer.range(), tot_nbatch, range_fn,
+                                    alignof(elem_t), /*zero_init=*/false);
   for (std::size_t ord = 0; ord < N_cells; ++ord) {
     auto& dst = result.data()[ord];
     if (dst.empty()) continue;
-    fill_op(dst.data(), tot_outer.data()[ord].data(), scalar_outer.data()[ord],
-            dst.size());
+    fill_op(
+        dst.data(), tot_outer.data()[arena_cell_offset(tot_outer, ord)].data(),
+        scalar_outer.data()[arena_cell_offset(scalar_outer, ord)], dst.size());
   }
   return result;
 }

--- a/src/TiledArray/tensor/arena_kernels.h
+++ b/src/TiledArray/tensor/arena_kernels.h
@@ -402,12 +402,25 @@ OuterTensor arena_compact(const OuterTensor& src) {
       [](auto* dst, const auto* s, std::size_t n) { std::copy_n(s, n, dst); });
 }
 
+/// Which result cells a binary arena kernel materializes.
+
+/// The two rules differ because zero plays a different role in each op:
+///   - `Union` -- zero is the identity (add, subt), so a cell present in only
+///     one operand still carries information and must be emitted, combined
+///     against an implicit zero slab.
+///   - `Intersection` -- zero annihilates (mult), so a cell absent from either
+///     operand has an identically zero product. Emitting it would allocate a
+///     slab of zeros that a null cell already denotes, densifying exactly the
+///     cells screening removed.
+enum class ArenaBinarySparsity { Union, Intersection };
+
 /// Apply a binary fill op using the left operand's inner ranges (asserted
 /// equal to the right's per cell). `fill_op(dst, l, r, n_elements)`.
 template <typename OuterTensor, typename LeftTensor, typename RightTensor,
           typename FillOp>
-OuterTensor arena_trivial_binary(const LeftTensor& left,
-                                 const RightTensor& right, FillOp&& fill_op) {
+OuterTensor arena_trivial_binary(
+    const LeftTensor& left, const RightTensor& right, FillOp&& fill_op,
+    ArenaBinarySparsity sparsity = ArenaBinarySparsity::Union) {
   // Either operand may be a strided view (`Tensor::block()` yields a
   // `TensorInterface<T, BlockRange>`); `arena_cell_offset` maps a logical cell
   // ordinal to its physical slot, so the loops below stay ordinal-driven. The
@@ -416,19 +429,26 @@ OuterTensor arena_trivial_binary(const LeftTensor& left,
   using inner_range_t = typename OuterTensor::value_type::range_type;
   TA_ASSERT(left.range().volume() == right.range().volume());
   TA_ASSERT(TiledArray::total_size(left) == TiledArray::total_size(right));
-  // Union sparsity: a result cell is present if *either* operand cell is.
   // ToT arrays with the same outer shape can still differ in which inner cells
   // are populated within an outer tile (e.g. occ_tile_size>1 aggregates several
-  // pairs, some screened to null). A cell present in only one operand is
-  // combined against an implicit zero slab below -- correct for the linear ops
-  // (add: l+0 / 0+r; subt: l-0 / 0-r) and numerically correct for mult (l*0=0,
-  // emitted as an explicit zero tile). Without this, a lone-left cell would
-  // read a null right slab (segfault) and a lone-right cell would be silently
-  // dropped, losing that addend.
-  auto range_fn = [&left, &right](std::size_t ord) -> inner_range_t {
+  // pairs, some screened to null), so the two operands' cell patterns need not
+  // agree. `sparsity` says what to do where they disagree.
+  //
+  // Under `Union` a cell present in only one operand is emitted and combined
+  // against an implicit zero slab below -- correct for the linear ops (add:
+  // l+0 / 0+r; subt: l-0 / 0-r). Without it a lone-left cell would read a null
+  // right slab (segfault) and a lone-right cell would be dropped, losing that
+  // addend.
+  //
+  // Under `Intersection` such a cell is left null: its product is identically
+  // zero, which a null cell already denotes, so emitting an explicit zero slab
+  // would only densify the cells screening removed.
+  auto range_fn = [&left, &right, sparsity](std::size_t ord) -> inner_range_t {
     const auto& l = left.data()[arena_cell_offset(left, ord)];
-    if (!l.empty()) return l.range();
     const auto& r = right.data()[arena_cell_offset(right, ord)];
+    if (sparsity == ArenaBinarySparsity::Intersection)
+      return (l.empty() || r.empty()) ? inner_range_t{} : l.range();
+    if (!l.empty()) return l.range();
     return r.empty() ? inner_range_t{} : r.range();
   };
   // `left` shapes the result: its range and batch count become the result's.

--- a/src/TiledArray/tensor/arena_kernels.h
+++ b/src/TiledArray/tensor/arena_kernels.h
@@ -15,6 +15,7 @@
 #include "TiledArray/error.h"
 #include "TiledArray/tensor/arena.h"
 #include "TiledArray/tensor/arena_tensor.h"
+#include "TiledArray/tile_op/tile_interface.h"
 
 #include <algorithm>
 #include <atomic>
@@ -336,33 +337,54 @@ OuterTensor make_nested_tile(
   return result;
 }
 
+/// Physical offset of logical cell ordinal \p ord within `t.data()`.
+
+/// Identity for a contiguous tensor, whose cells are laid out in ordinal
+/// order; a strided view (e.g. `Tensor::block()`'s
+/// `TensorInterface<T, BlockRange>`) maps through its range instead, the same
+/// way `detail::inplace_tensor_op` addresses a non-contiguous operand.
+template <typename T>
+inline std::size_t arena_cell_offset(const T& t, std::size_t ord) {
+  if constexpr (is_contiguous_tensor<T>::value) {
+    (void)t;
+    return ord;
+  } else {
+    return static_cast<std::size_t>(t.range().ordinal(ord));
+  }
+}
+
+/// Number of cells in \p t (batches included) and its batch count. A strided
+/// view has no batch dimension, so its batch count is 1.
+template <typename T>
+inline std::pair<std::size_t, std::size_t> arena_cells_and_batches(const T& t) {
+  const std::size_t n = static_cast<std::size_t>(TiledArray::total_size(t));
+  const std::size_t volume = static_cast<std::size_t>(t.range().volume());
+  return {n, volume ? n / volume : std::size_t{1}};
+}
+
 /// Apply a unary fill op while preserving each source inner range.
 /// `fill_op(dst_data, src_data, n_elements)` writes the result cell.
 template <typename OuterTensor, typename SrcOuterTensor, typename FillOp>
 OuterTensor arena_trivial_unary(const SrcOuterTensor& src, FillOp&& fill_op) {
-  // As in `arena_trivial_binary`: `src` is addressed by linear ordinal.
-  static_assert(
-      is_contiguous_tensor<SrcOuterTensor>::value,
-      "arena_trivial_unary: the source is indexed linearly by ordinal, so it "
-      "must be a contiguous tensor (not a block/strided view)");
   using elem_t = typename OuterTensor::value_type::value_type;
   using inner_range_t = typename OuterTensor::value_type::range_type;
   // A null inner cell has no range to query (`ArenaTensor::range()` asserts
   // non-null); map it to a default range -> a null result cell.
   auto range_fn = [&src](std::size_t ord) -> inner_range_t {
-    const auto& s = src.data()[ord];
+    const auto& s = src.data()[arena_cell_offset(src, ord)];
     return s.empty() ? inner_range_t{} : s.range();
   };
+  const auto [N_cells, src_nbatch] = arena_cells_and_batches(src);
   // Elementwise kernels pack tight (no cross-cell GEMM to amortize padding);
   // the fill overwrites every element, so the slab need not be zero-init'd.
-  OuterTensor result = arena_outer_init<OuterTensor>(src.range(), src.nbatch(),
+  OuterTensor result = arena_outer_init<OuterTensor>(src.range(), src_nbatch,
                                                      range_fn, alignof(elem_t),
                                                      /*zero_init=*/false);
-  const std::size_t N_cells = src.range().volume() * src.nbatch();
   for (std::size_t ord = 0; ord < N_cells; ++ord) {
     auto& dst = result.data()[ord];
     if (dst.empty()) continue;
-    fill_op(dst.data(), src.data()[ord].data(), dst.size());
+    fill_op(dst.data(), src.data()[arena_cell_offset(src, ord)].data(),
+            dst.size());
   }
   return result;
 }
@@ -386,20 +408,14 @@ template <typename OuterTensor, typename LeftTensor, typename RightTensor,
           typename FillOp>
 OuterTensor arena_trivial_binary(const LeftTensor& left,
                                  const RightTensor& right, FillOp&& fill_op) {
-  // Both operands are addressed as `data()[ord]` over a single linear ordinal
-  // range below, so neither may be a strided view: a block view would read
-  // the wrong cells rather than fail. `Tensor::inplace_binary_drops_cells`
-  // can detect a dropped cell for a non-contiguous operand, but there is no
-  // value-returning arena kernel to fall back *to* for one -- so make that a
-  // compile error here instead of a silent misread there.
-  static_assert(
-      is_contiguous_tensor<LeftTensor, RightTensor>::value,
-      "arena_trivial_binary: operands are indexed linearly by ordinal, so "
-      "both must be contiguous tensors (not block/strided views)");
+  // Either operand may be a strided view (`Tensor::block()` yields a
+  // `TensorInterface<T, BlockRange>`); `arena_cell_offset` maps a logical cell
+  // ordinal to its physical slot, so the loops below stay ordinal-driven. The
+  // result is always a freshly built contiguous tensor, indexed directly.
   using elem_t = typename OuterTensor::value_type::value_type;
   using inner_range_t = typename OuterTensor::value_type::range_type;
   TA_ASSERT(left.range().volume() == right.range().volume());
-  TA_ASSERT(left.nbatch() == right.nbatch());
+  TA_ASSERT(TiledArray::total_size(left) == TiledArray::total_size(right));
   // Union sparsity: a result cell is present if *either* operand cell is.
   // ToT arrays with the same outer shape can still differ in which inner cells
   // are populated within an outer tile (e.g. occ_tile_size>1 aggregates several
@@ -410,21 +426,22 @@ OuterTensor arena_trivial_binary(const LeftTensor& left,
   // read a null right slab (segfault) and a lone-right cell would be silently
   // dropped, losing that addend.
   auto range_fn = [&left, &right](std::size_t ord) -> inner_range_t {
-    const auto& l = left.data()[ord];
+    const auto& l = left.data()[arena_cell_offset(left, ord)];
     if (!l.empty()) return l.range();
-    const auto& r = right.data()[ord];
+    const auto& r = right.data()[arena_cell_offset(right, ord)];
     return r.empty() ? inner_range_t{} : r.range();
   };
-  OuterTensor result = arena_outer_init<OuterTensor>(
-      left.range(), left.nbatch(), range_fn, alignof(elem_t),
-      /*zero_init=*/false);
-  const std::size_t N_cells = left.range().volume() * left.nbatch();
+  // `left` shapes the result: its range and batch count become the result's.
+  const auto [N_cells, left_nbatch] = arena_cells_and_batches(left);
+  OuterTensor result = arena_outer_init<OuterTensor>(left.range(), left_nbatch,
+                                                     range_fn, alignof(elem_t),
+                                                     /*zero_init=*/false);
   std::vector<elem_t> zeros;  // grown lazily; implicit-zero slab for lone cells
   for (std::size_t ord = 0; ord < N_cells; ++ord) {
     auto& dst = result.data()[ord];
     if (dst.empty()) continue;
-    const auto& l = left.data()[ord];
-    const auto& r = right.data()[ord];
+    const auto& l = left.data()[arena_cell_offset(left, ord)];
+    const auto& r = right.data()[arena_cell_offset(right, ord)];
     const std::size_t n = dst.size();
     const bool have_l = !l.empty();
     const bool have_r = !r.empty();

--- a/src/TiledArray/tensor/arena_kernels.h
+++ b/src/TiledArray/tensor/arena_kernels.h
@@ -100,10 +100,11 @@ inline void arena_assert_single_page(const Arena& arena, const char* where) {
   const std::size_t pages = arena.page_count();
   if (pages > 1) {
     arena_single_page_violation_count().fetch_add(1, std::memory_order_relaxed);
-    std::fprintf(stderr,
-                 "[TA_ASSERT_SINGLE_PAGE] VIOLATION at %s: arena ToT outer tile "
-                 "spans %zu pages (expected <= 1)\n",
-                 where, pages);
+    std::fprintf(
+        stderr,
+        "[TA_ASSERT_SINGLE_PAGE] VIOLATION at %s: arena ToT outer tile "
+        "spans %zu pages (expected <= 1)\n",
+        where, pages);
     TA_EXCEPTION(
         "TA_ASSERT_SINGLE_PAGE: arena ToT outer tile spans multiple arena "
         "pages -- a size-determinable ToT must be single-page");
@@ -339,6 +340,11 @@ OuterTensor make_nested_tile(
 /// `fill_op(dst_data, src_data, n_elements)` writes the result cell.
 template <typename OuterTensor, typename SrcOuterTensor, typename FillOp>
 OuterTensor arena_trivial_unary(const SrcOuterTensor& src, FillOp&& fill_op) {
+  // As in `arena_trivial_binary`: `src` is addressed by linear ordinal.
+  static_assert(
+      is_contiguous_tensor<SrcOuterTensor>::value,
+      "arena_trivial_unary: the source is indexed linearly by ordinal, so it "
+      "must be a contiguous tensor (not a block/strided view)");
   using elem_t = typename OuterTensor::value_type::value_type;
   using inner_range_t = typename OuterTensor::value_type::range_type;
   // A null inner cell has no range to query (`ArenaTensor::range()` asserts
@@ -380,6 +386,16 @@ template <typename OuterTensor, typename LeftTensor, typename RightTensor,
           typename FillOp>
 OuterTensor arena_trivial_binary(const LeftTensor& left,
                                  const RightTensor& right, FillOp&& fill_op) {
+  // Both operands are addressed as `data()[ord]` over a single linear ordinal
+  // range below, so neither may be a strided view: a block view would read
+  // the wrong cells rather than fail. `Tensor::inplace_binary_drops_cells`
+  // can detect a dropped cell for a non-contiguous operand, but there is no
+  // value-returning arena kernel to fall back *to* for one -- so make that a
+  // compile error here instead of a silent misread there.
+  static_assert(
+      is_contiguous_tensor<LeftTensor, RightTensor>::value,
+      "arena_trivial_binary: operands are indexed linearly by ordinal, so "
+      "both must be contiguous tensors (not block/strided views)");
   using elem_t = typename OuterTensor::value_type::value_type;
   using inner_range_t = typename OuterTensor::value_type::range_type;
   TA_ASSERT(left.range().volume() == right.range().volume());

--- a/src/TiledArray/tensor/arena_tensor.h
+++ b/src/TiledArray/tensor/arena_tensor.h
@@ -536,6 +536,11 @@ void axpy_to(ArenaTensor<T, R>& dst, const ArenaTensor<T, R>& src,
   TA_ASSERT(dst.size() == src.size());
   auto* d = dst.data();
   const auto* s = src.data();
+  // `alpha * s[i]` is scalar x element. For a complex element and a scalar of
+  // a different type (e.g. int * complex<double>) std's operator* fails
+  // deduction and ADL never reaches TiledArray::detail, so the mixed
+  // scalar x complex operators have to be pulled in by hand.
+  using namespace TiledArray::detail;
   for (std::size_t i = 0; i < dst.size(); ++i) d[i] += alpha * s[i];
 }
 

--- a/src/TiledArray/tensor/kernels.h
+++ b/src/TiledArray/tensor/kernels.h
@@ -31,6 +31,7 @@
 #include <TiledArray/tensor/arena_tensor.h>
 #include <TiledArray/tensor/permute.h>
 #include <TiledArray/tensor/utility.h>
+#include <TiledArray/tile_op/tile_interface.h>
 #include <TiledArray/util/vector.h>
 
 namespace TiledArray {
@@ -920,12 +921,7 @@ auto tensor_reduce(ReduceOp&& reduce_op, JoinOp&& join_op, Identity&& identity,
   if (!empty(tensor1, tensors...)) {
     TA_ASSERT(is_range_set_congruent(tensor1, tensors...));
 
-    const auto volume = [&tensor1]() {
-      if constexpr (detail::has_member_function_total_size_anyreturn_v<T1>)
-        return tensor1.total_size();
-      else
-        return tensor1.size();
-    }();
+    const auto volume = TiledArray::total_size(tensor1);
 
     math::reduce_op(std::forward<ReduceOp>(reduce_op),
                     std::forward<JoinOp>(join_op), init, volume, init,
@@ -993,12 +989,7 @@ auto tensor_reduce(ReduceOp&& reduce_op, JoinOp&& join_op,
   TA_ASSERT(!empty(tensor1, tensors...));
   TA_ASSERT(is_range_set_congruent(tensor1, tensors...));
 
-  const auto volume = [&tensor1]() {
-    if constexpr (detail::has_member_function_total_size_anyreturn_v<T1>)
-      return tensor1.total_size();
-    else
-      return tensor1.size();
-  }();
+  const auto volume = TiledArray::total_size(tensor1);
 
   auto result = identity;
   for (std::remove_cv_t<decltype(volume)> ord = 0ul; ord < volume; ++ord) {
@@ -1040,12 +1031,7 @@ auto tensor_reduce(ReduceOp&& reduce_op, JoinOp&& join_op,
   TA_ASSERT(!empty(tensor1, tensors...));
   TA_ASSERT(is_range_set_congruent(tensor1, tensors...));
 
-  const auto volume = [&tensor1]() {
-    if constexpr (detail::has_member_function_total_size_anyreturn_v<T1>)
-      return tensor1.total_size();
-    else
-      return tensor1.size();
-  }();
+  const auto volume = TiledArray::total_size(tensor1);
 
   auto result = identity;
   if constexpr (detail::has_member_function_data_anyreturn_v<T1> &&
@@ -1109,12 +1095,7 @@ Scalar tensor_reduce(ReduceOp&& reduce_op, JoinOp&& join_op,
   // TA_ASSERT(tensor1.nbatch() == 1); // todo: assert the same for the
   // remaining tensors
 
-  const auto volume = [&tensor1]() {
-    if constexpr (detail::has_member_function_total_size_anyreturn_v<T1>)
-      return tensor1.total_size();
-    else
-      return tensor1.size();
-  }();
+  const auto volume = TiledArray::total_size(tensor1);
 
   Scalar result = identity;
 

--- a/src/TiledArray/tensor/tensor.h
+++ b/src/TiledArray/tensor/tensor.h
@@ -2167,6 +2167,39 @@ class Tensor {
     }
   }
 
+  /// An owning deep copy of \p right, safe to mutate without touching it.
+
+  /// `detail::clone_or_cast` deep-copies only when `Right` *is* `Tensor`, in
+  /// which case it calls `clone()`. For any other nested-tensor `Right` it
+  /// falls into a generic branch that `std::copy`s the *cells*, and a cell is
+  /// a shallow handle -- an `ArenaTensor` is a non-owning view, and
+  /// `TA::Tensor` is itself reference-counted. The copy would then share
+  /// storage with \p right, so negating or scaling it afterwards writes
+  /// through to the source, corrupting a const operand.
+  ///
+  /// Route nested tensors through the arena unary kernel instead: it allocates
+  /// a fresh slab and copies *elements*, and being range-addressed it handles
+  /// a strided (block-view) source correctly.
+  /// \tparam Right The source tensor type
+  /// \param right The tensor to copy
+  /// \return An owning `Tensor` sharing no storage with \p right
+  template <typename Right>
+  static Tensor owning_copy_of(const Right& right) {
+    using RightT = std::remove_cv_t<std::remove_reference_t<Right>>;
+    if constexpr (detail::is_tensor_of_tensor_v<Tensor> &&
+                  !std::is_same_v<RightT, Tensor> &&
+                  std::is_same_v<value_type, typename RightT::value_type>) {
+      auto fill = [](typename value_type::value_type* dst,
+                     const typename value_type::value_type* src,
+                     std::size_t n) {
+        for (std::size_t i = 0; i < n; ++i) dst[i] = src[i];
+      };
+      return detail::arena_trivial_unary<Tensor>(right, fill);
+    } else {
+      return detail::clone_or_cast<Tensor>(right);
+    }
+  }
+
   // Addition operations
 
   /// Element-wise add for `Tensor<ArenaTensor>` ToT operands. Routes through
@@ -2175,7 +2208,7 @@ class Tensor {
     requires(is_arena_tensor_v<value_type> &&
              is_arena_tensor_v<typename Right::value_type>)
   Tensor add(const Right& right) const {
-    if (empty()) return detail::clone_or_cast<Tensor>(right);
+    if (empty()) return owning_copy_of(right);
     if (right.empty()) return this->clone();
     auto fill = [](typename value_type::value_type* dst,
                    const typename value_type::value_type* l,
@@ -2290,7 +2323,7 @@ class Tensor {
     if (right.empty()) return this->clone();
 
     // early exit for empty this
-    if (empty()) return detail::clone_or_cast<Tensor>(right);
+    if (empty()) return owning_copy_of(right);
 
     if constexpr (detail::is_tensor_of_tensor_v<Tensor> &&
                   detail::is_ta_tensor_v<value_type> &&
@@ -2461,7 +2494,7 @@ class Tensor {
 
     // early exit for empty this
     if (empty()) {
-      *this = detail::clone_or_cast<Tensor>(right);
+      *this = owning_copy_of(right);
       return *this;
     }
 
@@ -2497,7 +2530,7 @@ class Tensor {
 
     // early exit for empty this: (0 + right) * factor
     if (empty()) {
-      *this = detail::clone_or_cast<Tensor>(right);
+      *this = owning_copy_of(right);
       this->scale_to(factor);
       return *this;
     }
@@ -2529,7 +2562,7 @@ class Tensor {
   Tensor& axpy_to(const Right& right, const Scalar factor) {
     if (right.empty()) return *this;
     if (empty()) {
-      *this = detail::clone_or_cast<Tensor>(right);
+      *this = owning_copy_of(right);
       this->scale_to(factor);
       return *this;
     }
@@ -2585,7 +2618,7 @@ class Tensor {
         // result inner cell): initialize to factor * (perm ^ arg) rather
         // than asserting non-empty in inplace_binary -- mirrors the
         // non-permuting axpy_to overload above.
-        *this = detail::clone_or_cast<Tensor>(permuted);
+        *this = owning_copy_of(permuted);
         this->scale_to(factor);
         return *this;
       }
@@ -2837,7 +2870,7 @@ class Tensor {
 
     // early exit for empty this: 0 - right == -right
     if (empty()) {
-      *this = detail::clone_or_cast<Tensor>(right);
+      *this = owning_copy_of(right);
       this->neg_to();
       return *this;
     }
@@ -2874,7 +2907,7 @@ class Tensor {
 
     // early exit for empty this: (0 - right) * factor
     if (empty()) {
-      *this = detail::clone_or_cast<Tensor>(right);
+      *this = owning_copy_of(right);
       this->neg_to();
       this->scale_to(factor);
       return *this;

--- a/src/TiledArray/tensor/tensor.h
+++ b/src/TiledArray/tensor/tensor.h
@@ -2068,19 +2068,25 @@ class Tensor {
   /// Does an in-place binary op against a \p Right of this shape ever need
   /// the null-destination fallback?
 
-  /// True only when this tensor's cells are non-owning *views*. Every use is
-  /// an `if constexpr` condition, never a runtime one: the fallback body calls
-  /// the *value-returning* kernels, which need not be well-formed for a
-  /// `Tensor` / `Scalar` combination that the in-place path nonetheless
-  /// supports -- e.g. `Tensor<std::complex<double>>::subt_to(right, int)` is
-  /// fine in place, while the corresponding `subt(right, int)` is ill-formed
+  /// True only when both operands' cells are `ArenaTensor`s. The fallback
+  /// body calls the *value-returning* kernels, which allocate a fresh arena
+  /// slab, so by `arena_tensor.h`'s own trait convention this is
+  /// `is_arena_tensor_v` territory rather than the broader
+  /// `is_tensor_view_v` -- the latter also covers `btas::TensorView`, for
+  /// which no such value-returning kernel exists.
+  ///
+  /// Every use is an `if constexpr` condition, never a runtime one: the
+  /// fallback body need not be well-formed for a `Tensor` / `Scalar`
+  /// combination that the in-place path nonetheless supports -- e.g.
+  /// `Tensor<std::complex<double>>::subt_to(right, int)` is fine in place,
+  /// while the corresponding `subt(right, int)` is ill-formed
   /// (`std::complex<double> * int`). Guarding with `if constexpr` keeps the
-  /// fallback out of every non-view instantiation.
+  /// fallback out of every non-arena instantiation.
   /// \tparam Right The right-hand tensor type
   template <typename Right>
   static constexpr bool binary_needs_view_cell_fallback_v =
-      detail::is_tensor_of_tensor_v<Tensor> && is_tensor_view_v<value_type> &&
-      is_tensor_view_v<typename Right::value_type>;
+      detail::is_tensor_of_tensor_v<Tensor> && is_arena_tensor_v<value_type> &&
+      is_arena_tensor_v<typename Right::value_type>;
 
   /// Would an element-wise in-place binary op against \p right drop data?
 
@@ -2090,7 +2096,23 @@ class Tensor {
   /// corresponding cell of \p right is populated, updating in place would
   /// silently discard it. Callers must instead route through the
   /// value-returning kernel, which builds a fresh slab with union sparsity.
-  /// Always `false` unless both operands' cells are views.
+  /// Always `false` unless both operands' cells are arena tensors.
+  ///
+  /// The scan mirrors how `detail::inplace_tensor_op` -- the kernel this
+  /// guards -- walks the very same operands: linearly over `total_size()`
+  /// when both are contiguous, and by strided range ordinal when they are
+  /// not. Keeping the two in step is what makes the guard exactly as general
+  /// as the operation it guards; a shape this predicate cannot scan must be
+  /// a compile error, never a `false`, since `false` reinstates the
+  /// cell-dropping bug this exists to prevent.
+  ///
+  /// \note A rebind (`*this = ...`) is the only remedy available to the
+  ///       caller, so a fallback replaces this handle's storage instead of
+  ///       mutating it. `TA::Tensor` is a shallow-copy handle, so sibling
+  ///       handles keep observing the pre-op values -- unlike a true in-place
+  ///       update. Callers in tree hold the tile by reference and are
+  ///       unaffected.
+  ///
   /// \tparam Right The right-hand tensor type
   /// \param right The right-hand operand
   /// \return true if some ordinal has a null left cell and a populated right
@@ -2098,13 +2120,47 @@ class Tensor {
   template <typename Right>
   bool inplace_binary_drops_cells(const Right& right) const {
     if constexpr (binary_needs_view_cell_fallback_v<Right>) {
+      static_assert(
+          detail::has_member_function_data_anyreturn_v<Tensor> &&
+              detail::has_member_function_data_anyreturn_v<Right>,
+          "Tensor::inplace_binary_drops_cells: both operands must expose "
+          "data(); an operand that cannot be scanned for null cells must not "
+          "silently answer \"no drop\"");
+
       if (empty() || right.empty()) return false;
-      const std::size_t n = static_cast<std::size_t>(this->total_size());
-      if (n != static_cast<std::size_t>(right.total_size())) return false;
-      for (std::size_t ord = 0; ord < n; ++ord)
-        if (this->data()[ord].empty() && !right.data()[ord].empty())
-          return true;
-      return false;
+
+      // Congruent operands are the in-place kernel's own precondition; a
+      // mismatch here is rejected there (loudly under TA_ASSERT_THROW). Bail
+      // rather than walk off the end of the shorter operand.
+      TA_ASSERT(detail::is_range_set_congruent(*this, right));
+
+      auto drops = [](const value_type* l, const typename Right::value_type* r,
+                      std::size_t n) {
+        for (std::size_t i = 0; i < n; ++i)
+          if (l[i].empty() && !r[i].empty()) return true;
+        return false;
+      };
+
+      if constexpr (detail::is_contiguous_tensor<Tensor, Right>::value) {
+        const std::size_t n =
+            static_cast<std::size_t>(TiledArray::total_size(*this));
+        if (n != static_cast<std::size_t>(TiledArray::total_size(right)))
+          return false;
+        return drops(this->data(), right.data(), n);
+      } else {
+        // Non-contiguous operand: walk contiguous runs the way
+        // `inplace_tensor_op` does, one `inner_size` stride at a time.
+        const auto volume = this->range().volume();
+        if (volume != right.range().volume()) return false;
+        const auto stride = detail::inner_size(*this, right);
+        for (std::decay_t<decltype(volume)> ord = 0ul; ord < volume;
+             ord += stride)
+          if (drops(this->data() + this->range().ordinal(ord),
+                    right.data() + right.range().ordinal(ord),
+                    static_cast<std::size_t>(stride)))
+            return true;
+        return false;
+      }
     } else {
       (void)right;
       return false;

--- a/src/TiledArray/tensor/tensor.h
+++ b/src/TiledArray/tensor/tensor.h
@@ -2229,6 +2229,8 @@ class Tensor {
     using ElemT = typename value_type::value_type;
     auto fill = [factor](ElemT* dst, const ElemT* l, const ElemT* r,
                          std::size_t n) {
+      // mixed complex x scalar operator*
+      using namespace TiledArray::detail;
       for (std::size_t i = 0; i < n; ++i) dst[i] = (l[i] + r[i]) * factor;
     };
     return detail::arena_trivial_binary<Tensor>(*this, right, fill);
@@ -2759,6 +2761,8 @@ class Tensor {
       using ElemT = typename value_type::value_type;
       auto fill = [factor](ElemT* dst, const ElemT* l, const ElemT* r,
                            std::size_t n) {
+        // mixed complex x scalar operator*
+        using namespace TiledArray::detail;
         for (std::size_t i = 0; i < n; ++i) dst[i] = (l[i] - r[i]) * factor;
       };
       return detail::arena_trivial_binary<Tensor>(*this, right, fill);
@@ -3050,6 +3054,8 @@ class Tensor {
       using ElemT = typename value_type::value_type;
       auto fill = [factor](ElemT* dst, const ElemT* l, const ElemT* r,
                            std::size_t n) {
+        // mixed complex x scalar operator*
+        using namespace TiledArray::detail;
         for (std::size_t i = 0; i < n; ++i) dst[i] = (l[i] * r[i]) * factor;
       };
       // mult annihilates -- see the unscaled overload above.

--- a/src/TiledArray/tensor/tensor.h
+++ b/src/TiledArray/tensor/tensor.h
@@ -2533,8 +2533,17 @@ class Tensor {
     }
     if constexpr (binary_needs_view_cell_fallback_v<Right>) {
       if (inplace_binary_drops_cells(right)) {
-        // no value-returning `axpy`; compose scale-then-add on the union kernel
-        *this = this->add(right.scale(factor));
+        // Fuse `l + r * factor` into a single union-sparsity pass. Composing
+        // `add(right.scale(factor))` would allocate a second arena slab just
+        // to hold the scaled intermediate. Both operands are non-null here:
+        // the empty cases returned above, and `inplace_binary_drops_cells`
+        // answers false for either operand empty.
+        using ElemT = typename value_type::value_type;
+        auto fill = [factor](ElemT* dst, const ElemT* l, const ElemT* r,
+                             std::size_t n) {
+          for (std::size_t i = 0; i < n; ++i) dst[i] = l[i] + r[i] * factor;
+        };
+        *this = detail::arena_trivial_binary<Tensor>(*this, right, fill);
         return *this;
       }
     }

--- a/src/TiledArray/tensor/tensor.h
+++ b/src/TiledArray/tensor/tensor.h
@@ -2541,6 +2541,8 @@ class Tensor {
         using ElemT = typename value_type::value_type;
         auto fill = [factor](ElemT* dst, const ElemT* l, const ElemT* r,
                              std::size_t n) {
+          // mixed complex x scalar operator*
+          using namespace TiledArray::detail;
           for (std::size_t i = 0; i < n; ++i) dst[i] = l[i] + r[i] * factor;
         };
         *this = detail::arena_trivial_binary<Tensor>(*this, right, fill);
@@ -2553,6 +2555,8 @@ class Tensor {
                             if constexpr (detail::is_tensor_helper<L>::value) {
                               l.axpy_to(r, factor);
                             } else {
+                              // mixed complex x scalar operator*
+                              using namespace TiledArray::detail;
                               l += r * factor;
                             }
                           });
@@ -2589,6 +2593,8 @@ class Tensor {
             if constexpr (detail::is_tensor_helper<L>::value) {
               l.axpy_to(r, factor);
             } else {
+              // mixed complex x scalar operator*
+              using namespace TiledArray::detail;
               l += r * factor;
             }
           });

--- a/src/TiledArray/tensor/tensor.h
+++ b/src/TiledArray/tensor/tensor.h
@@ -2487,6 +2487,19 @@ class Tensor {
     requires(is_tensor<Right>::value && detail::is_numeric_v<Scalar> &&
              detail::addable_to<value_type&, const value_t<Right>&>)
   Tensor& add_to(const Right& right, const Scalar factor) {
+    // early exit for empty right: (this + 0) * factor
+    if (right.empty()) {
+      this->scale_to(factor);
+      return *this;
+    }
+
+    // early exit for empty this: (0 + right) * factor
+    if (empty()) {
+      *this = detail::clone_or_cast<Tensor>(right);
+      this->scale_to(factor);
+      return *this;
+    }
+
     if constexpr (binary_needs_view_cell_fallback_v<Right>) {
       if (inplace_binary_drops_cells(right)) {
         *this = this->add(right, factor);
@@ -2803,6 +2816,13 @@ class Tensor {
     // early exit for empty right
     if (right.empty()) return *this;
 
+    // early exit for empty this: 0 - right == -right
+    if (empty()) {
+      *this = detail::clone_or_cast<Tensor>(right);
+      this->neg_to();
+      return *this;
+    }
+
     // a null view cell cannot adopt a populated right cell in place -- fall
     // back to the value-returning (union-sparsity) kernel
     if constexpr (binary_needs_view_cell_fallback_v<Right>) {
@@ -2831,6 +2851,14 @@ class Tensor {
     // early exit for empty right
     if (right.empty()) {
       return this->scale_to(factor);
+    }
+
+    // early exit for empty this: (0 - right) * factor
+    if (empty()) {
+      *this = detail::clone_or_cast<Tensor>(right);
+      this->neg_to();
+      this->scale_to(factor);
+      return *this;
     }
 
     if constexpr (binary_needs_view_cell_fallback_v<Right>) {
@@ -3085,6 +3113,13 @@ class Tensor {
       typename std::enable_if<detail::is_nested_tensor_v<Right> &&
                               detail::is_numeric_v<Scalar>>::type* = nullptr>
   Tensor& mult_to(const Right& right, const Scalar factor) {
+    // early exit for empty right: this * 0 == 0, spelled the way the
+    // unscaled `mult_to` spells it
+    if (right.empty()) {
+      *this = Tensor{};
+      return *this;
+    }
+
     // early exit for empty this
     if (empty()) return *this;
 

--- a/src/TiledArray/tensor/tensor.h
+++ b/src/TiledArray/tensor/tensor.h
@@ -2908,7 +2908,10 @@ class Tensor {
                    const typename value_type::value_type* r, std::size_t n) {
       for (std::size_t i = 0; i < n; ++i) dst[i] = l[i] * r[i];
     };
-    return detail::arena_trivial_binary<Tensor>(*this, right, fill);
+    // mult annihilates: a cell absent from either operand has an identically
+    // zero product, which a null cell already denotes.
+    return detail::arena_trivial_binary<Tensor>(
+        *this, right, fill, detail::ArenaBinarySparsity::Intersection);
   }
 
   /// Mixed `Tensor<ArenaTensor> * Tensor<scalar>`: outer Hadamard, each
@@ -2969,7 +2972,9 @@ class Tensor {
                      const typename value_type::value_type* r, std::size_t n) {
         for (std::size_t i = 0; i < n; ++i) dst[i] = l[i] * r[i];
       };
-      return detail::arena_trivial_binary<Tensor>(*this, right, fill);
+      // mult annihilates -- see the arena overload above.
+      return detail::arena_trivial_binary<Tensor>(
+          *this, right, fill, detail::ArenaBinarySparsity::Intersection);
     } else {
       return binary(right, mult_op);
     }
@@ -3041,7 +3046,9 @@ class Tensor {
                            std::size_t n) {
         for (std::size_t i = 0; i < n; ++i) dst[i] = (l[i] * r[i]) * factor;
       };
-      return detail::arena_trivial_binary<Tensor>(*this, right, fill);
+      // mult annihilates -- see the unscaled overload above.
+      return detail::arena_trivial_binary<Tensor>(
+          *this, right, fill, detail::ArenaBinarySparsity::Intersection);
     } else {
       return binary(right,
                     [factor](const value_type& l, const value_t<Right>& r) {
@@ -3102,10 +3109,13 @@ class Tensor {
     // early exit for empty this
     if (empty()) return *this;
 
-    // No fallback here, unlike add_to/subt_to/axpy_to: multiplication
-    // annihilates, so a null destination cell against a populated source has an
-    // identically zero product and loses nothing. The free per-cell `mult_to`
-    // leaves it null, which is how a sparse ToT spells zero.
+    // No fallback here, unlike add_to/subt_to/axpy_to. Multiplication
+    // annihilates, so a null destination cell against a populated source has
+    // an identically zero product and loses nothing: the free per-cell
+    // `mult_to` leaves it null, which is how a sparse ToT spells zero, and the
+    // value-returning kernel now agrees (ArenaBinarySparsity::Intersection).
+    // Routing through that kernel would rebuild the whole tile only to
+    // materialize explicit zeros where screening had removed cells.
     return inplace_binary(right, [](value_type& MADNESS_RESTRICT l,
                                     const value_t<Right>& r) { l *= r; });
   }

--- a/src/TiledArray/tile.h
+++ b/src/TiledArray/tile.h
@@ -23,6 +23,7 @@
 #include <TiledArray/tensor/tensor_interface.h>
 #include <TiledArray/tile_interface/cast.h>
 #include <TiledArray/tile_interface/trace.h>
+#include <TiledArray/tile_op/tile_interface.h>
 #include <memory>
 
 namespace TiledArray {
@@ -264,13 +265,7 @@ class Tile {
 
   /// \return The number of elements in the tensor, tallied across batches (if
   /// any)
-  decltype(auto) total_size() const {
-    if constexpr (detail::has_member_function_total_size_anyreturn_v<
-                      tensor_type>) {
-      return tensor().total_size();
-    } else
-      return size();
-  }
+  decltype(auto) total_size() const { return TiledArray::total_size(tensor()); }
 
   /// Range accessor
 

--- a/src/TiledArray/tile_op/tile_interface.h
+++ b/src/TiledArray/tile_op/tile_interface.h
@@ -880,6 +880,25 @@ inline Result& gemm(Result& result, const Left& left, const Right& right,
 template <typename... T>
 using result_of_gemm_t = decltype(gemm(std::declval<T>()...));
 
+// Query operations ----------------------------------------------------------
+
+/// Total number of elements in a tile
+
+/// Unlike `size()`, the result counts every batch for tile types that carry a
+/// batch dimension (e.g. `TA::Tensor`). Tile types with no batch concept
+/// (e.g. `btas::Tensor`, `TensorInterface`) do not declare `total_size()`; for
+/// those this falls back to `size()`, which is the whole tile by definition.
+/// \tparam Arg The tile argument type
+/// \param arg The tile to query
+/// \return The number of elements in \c arg, batches included
+template <typename Arg>
+inline auto total_size(const Arg& arg) {
+  if constexpr (detail::has_member_function_total_size_anyreturn_v<Arg>)
+    return arg.total_size();
+  else
+    return arg.size();
+}
+
 // Reduction operations ------------------------------------------------------
 
 /// Sum the hyper-diagonal elements a tile
@@ -1016,6 +1035,9 @@ inline auto inner_product(const Left& left, const Right& right) {
 
 // template <typename T>
 // using result_of_trace_t = decltype(mult(std::declval<T>()));
+
+template <typename T>
+using result_of_total_size_t = decltype(total_size(std::declval<T>()));
 
 template <typename T>
 using result_of_sum_t = decltype(sum(std::declval<T>()));

--- a/tests/arena_tensor_kernels.cpp
+++ b/tests/arena_tensor_kernels.cpp
@@ -11,6 +11,7 @@
 
 #include <optional>
 
+#include <complex>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
@@ -723,6 +724,71 @@ BOOST_AUTO_TEST_CASE(tot_axpy_to_accumulates_scaled_operand) {
       BOOST_CHECK_CLOSE(d.data()[i], initial[ord][i] + a.data()[i] * factor,
                         1e-12);
   }
+}
+
+// The axpy paths spell the leaf update as `alpha * cell[i]` (the free arena
+// kernel) or `cell[i] * factor` (Tensor's fill lambda and per-element leaf).
+// For a complex element and a scalar of a different type -- `int` x
+// `complex<double>` here -- std's operator* fails deduction and ADL never
+// reaches TiledArray::detail, so each of the four sites below was a hard
+// compile error until the mixed operators were pulled in by hand. This case
+// exists mainly to instantiate them; the value checks are secondary.
+BOOST_AUTO_TEST_CASE(axpy_to_complex_element_with_integral_factor) {
+  using Z = std::complex<double>;
+  using ZInner = TA::ArenaTensor<Z, TA::Range>;
+  using ZOuter = TA::Tensor<ZInner>;
+
+  const int factor = 2;
+  constexpr std::size_t n_outer = 2, n_inner = 3;
+  auto shape_fn = [](std::size_t /*ord*/) {
+    return TA::Range{static_cast<long>(n_inner)};
+  };
+  auto make_z_outer = [&](double base) {
+    ZOuter t = TA::detail::arena_outer_init<ZOuter>(
+        TA::Range{static_cast<long>(n_outer)}, 1, shape_fn);
+    for (std::size_t ord = 0; ord < n_outer; ++ord)
+      for (std::size_t i = 0; i < n_inner; ++i)
+        t.data()[ord].data()[i] = Z(base + ord + i, 0.5 * i - base);
+    return t;
+  };
+
+  // (1) free axpy_to(ArenaTensor&, const ArenaTensor&, Scalar): `alpha * s[i]`
+  ZOuter dst = make_z_outer(1.0);
+  const ZOuter src = make_z_outer(2.0);
+  std::vector<Z> dst0_before(n_inner);
+  for (std::size_t i = 0; i < n_inner; ++i)
+    dst0_before[i] = dst.data()[0].data()[i];
+  {
+    using TiledArray::axpy_to;
+    axpy_to(dst.data()[0], src.data()[0], factor);
+  }
+  for (std::size_t i = 0; i < n_inner; ++i) {
+    const Z expected =
+        dst0_before[i] + src.data()[0].data()[i] * static_cast<double>(factor);
+    BOOST_CHECK_SMALL(std::abs(dst.data()[0].data()[i] - expected), 1e-12);
+  }
+
+  // (2) Tensor<ArenaTensor>::axpy_to -- instantiates the arena
+  // union-sparsity fill lambda alongside the per-cell leaf.
+  ZOuter tot = make_z_outer(1.0);
+  tot.axpy_to(src, factor);
+
+  // (3)/(4) flat Tensor<complex>::axpy_to, without and with a fused
+  // permutation on the added operand.
+  TA::Tensor<Z> a(TA::Range{2, 2}), b(TA::Range{2, 2});
+  for (std::size_t i = 0; i < 4; ++i) {
+    a.data()[i] = Z(static_cast<double>(i), 1.0);
+    b.data()[i] = Z(1.0, static_cast<double>(i));
+  }
+  const TA::Tensor<Z> a_before = a.clone();
+  a.axpy_to(b, factor);
+  for (std::size_t i = 0; i < 4; ++i) {
+    const Z expected =
+        a_before.data()[i] + b.data()[i] * static_cast<double>(factor);
+    BOOST_CHECK_SMALL(std::abs(a.data()[i] - expected), 1e-12);
+  }
+  TA::Tensor<Z> c = a_before.clone();
+  c.axpy_to(b, factor, TA::Permutation{1, 0});
 }
 
 // --- mismatched null-inner-cell coverage --------------------------------

--- a/tests/arena_tot_trivial.cpp
+++ b/tests/arena_tot_trivial.cpp
@@ -694,4 +694,85 @@ BOOST_AUTO_TEST_CASE(arena_mult_to_does_not_densify_null_cells) {
   }
 }
 
+// --- an empty-`this` fast path must not alias, let alone mutate, the source
+// `detail::clone_or_cast` deep-copies only when `Right` *is* `Tensor`; for any
+// other nested-tensor `Right` (e.g. the `TensorInterface<..., BlockRange>` that
+// `block()` yields) it copies the cell *handles*, which for a view cell aliases
+// the source's storage. Scaling or negating the copy then writes through to a
+// const operand.
+
+BOOST_AUTO_TEST_CASE(subt_to_empty_left_must_not_mutate_source) {
+  arena_outer_t P =
+      make_arena_tot_2d(2, 3, 4, 1.0, {true, true, true, true, true, true});
+  const double before = P.data()[0].data()[0];
+  arena_outer_t t;
+  t.subt_to(P.block({0l, 0l}, {2l, 2l}));
+  BOOST_CHECK_EQUAL(P.data()[0].data()[0], before);
+  BOOST_CHECK_EQUAL(t.data()[0].data()[0], -before);
+}
+
+BOOST_AUTO_TEST_CASE(subt_to_scaled_empty_left_must_not_mutate_source) {
+  arena_outer_t P =
+      make_arena_tot_2d(2, 3, 4, 1.0, {true, true, true, true, true, true});
+  const double before = P.data()[0].data()[0];
+  arena_outer_t t;
+  t.subt_to(P.block({0l, 0l}, {2l, 2l}), 2.0);
+  BOOST_CHECK_EQUAL(P.data()[0].data()[0], before);
+  BOOST_CHECK_EQUAL(t.data()[0].data()[0], -before * 2.0);
+}
+
+BOOST_AUTO_TEST_CASE(add_to_scaled_empty_left_must_not_mutate_source) {
+  arena_outer_t P =
+      make_arena_tot_2d(2, 3, 4, 1.0, {true, true, true, true, true, true});
+  const double before = P.data()[0].data()[0];
+  arena_outer_t t;
+  t.add_to(P.block({0l, 0l}, {2l, 2l}), 3.0);
+  BOOST_CHECK_EQUAL(P.data()[0].data()[0], before);
+  BOOST_CHECK_EQUAL(t.data()[0].data()[0], before * 3.0);
+}
+
+BOOST_AUTO_TEST_CASE(axpy_to_empty_left_must_not_mutate_source) {
+  arena_outer_t P =
+      make_arena_tot_2d(2, 3, 4, 1.0, {true, true, true, true, true, true});
+  const double before = P.data()[0].data()[0];
+  arena_outer_t t;
+  t.axpy_to(P.block({0l, 0l}, {2l, 2l}), 2.0);
+  BOOST_CHECK_EQUAL(P.data()[0].data()[0], before);
+}
+
+// the value-returning empty-left exits have the same hazard: the result must
+// own its cells, or the caller's later mutation corrupts the source
+BOOST_AUTO_TEST_CASE(add_empty_left_result_must_not_alias_source) {
+  arena_outer_t P =
+      make_arena_tot_2d(2, 3, 4, 1.0, {true, true, true, true, true, true});
+  const double before = P.data()[0].data()[0];
+  const arena_outer_t empty_left;
+  arena_outer_t r = empty_left.add(P.block({0l, 0l}, {2l, 2l}));
+  r.scale_to(-1.0);
+  BOOST_CHECK_EQUAL(P.data()[0].data()[0], before);
+}
+
+// --- intersection sparsity also governs the plain owning ToT --------------
+// `Tensor::mult`'s intersection rule is applied in the `is_ta_tensor_v` branch
+// too, so it is a behavior change for `TA::Tensor<TA::Tensor<T>>`, not only for
+// arena tiles. Pin it: the pre-existing mult_mismatched_null_inners is written
+// permissively and passes under either rule.
+BOOST_AUTO_TEST_CASE(plain_tot_mult_uses_intersection_sparsity) {
+  outer_t L = make_tot_sparse(5, 4, 2.0, nz_L);
+  outer_t R = make_tot_sparse(5, 4, 0.5, nz_R);
+  outer_t prod = L.mult(R);
+  for (std::size_t ord = 0; ord < 5; ++ord) {
+    const inner_t& l = *(L.data() + ord);
+    const inner_t& r = *(R.data() + ord);
+    const inner_t& d = *(prod.data() + ord);
+    if (!l.empty() && !r.empty()) {
+      BOOST_REQUIRE(!d.empty());
+      for (std::size_t i = 0; i < d.range().volume(); ++i)
+        BOOST_CHECK_EQUAL(d.at_ordinal(i), l.at_ordinal(i) * r.at_ordinal(i));
+    } else {
+      BOOST_CHECK(d.empty());
+    }
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/arena_tot_trivial.cpp
+++ b/tests/arena_tot_trivial.cpp
@@ -530,4 +530,55 @@ BOOST_AUTO_TEST_CASE(expr_permuted_add_null_left_cells_keeps_right) {
   }
 }
 
+// --- empty-operand guards on the in-place binary ops ---------------------
+// An empty tensor denotes zero in these ops -- that is already how `add_to`
+// and the unscaled `mult_to` treat it. `subt_to` (both overloads), the scaled
+// `add_to` and the scaled `mult_to` were missing one or both guards, so they
+// fell through into `inplace_binary`, whose `!empty()` precondition is a
+// TA_ASSERT: it throws in a Debug build and, compiled out in Release, walks a
+// null `data()` or silently yields an empty (== zero) result. Same
+// silent-data-loss shape as the null-cell bug, one function over.
+
+BOOST_AUTO_TEST_CASE(subt_to_empty_left_yields_negated_right) {
+  outer_t L;  // default-constructed -> empty outer == zero
+  outer_t R = make_tot(3, 4, 7.0);
+  BOOST_REQUIRE(L.empty());
+  const outer_t expected = R.scale(-1.0);
+  L.subt_to(R);
+  BOOST_CHECK(tot_equal(L, expected));
+}
+
+BOOST_AUTO_TEST_CASE(subt_to_scaled_empty_left_yields_negated_scaled_right) {
+  outer_t L;
+  outer_t R = make_tot(3, 4, 7.0);
+  const outer_t expected = R.scale(-2.0);
+  L.subt_to(R, 2.0);  // legacy semantics: (l - r) * factor
+  BOOST_CHECK(tot_equal(L, expected));
+}
+
+BOOST_AUTO_TEST_CASE(add_to_scaled_empty_left_yields_scaled_right) {
+  outer_t L;
+  outer_t R = make_tot(3, 4, 7.0);
+  const outer_t expected = R.scale(2.0);
+  L.add_to(R, 2.0);  // legacy semantics: (l + r) * factor
+  BOOST_CHECK(tot_equal(L, expected));
+}
+
+BOOST_AUTO_TEST_CASE(add_to_scaled_empty_right_scales_left) {
+  outer_t L = make_tot(3, 4, 5.0);
+  const outer_t expected = L.scale(2.0);
+  const outer_t empty_right;
+  L.add_to(empty_right, 2.0);
+  BOOST_CHECK(tot_equal(L, expected));
+}
+
+BOOST_AUTO_TEST_CASE(mult_to_scaled_empty_right_is_zero) {
+  outer_t L = make_tot(3, 4, 5.0);
+  const outer_t empty_right;
+  L.mult_to(empty_right, 2.0);
+  // matches the unscaled `mult_to`, which spells the zero product as an
+  // empty result
+  BOOST_CHECK(L.empty());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/arena_tot_trivial.cpp
+++ b/tests/arena_tot_trivial.cpp
@@ -581,4 +581,65 @@ BOOST_AUTO_TEST_CASE(mult_to_scaled_empty_right_is_zero) {
   BOOST_CHECK(L.empty());
 }
 
+// --- non-contiguous (block-view) right operand ---------------------------
+// `Tensor::block()` yields a `TensorInterface<T, BlockRange>`, whose cells are
+// strided in the parent's storage. Both `inplace_binary_drops_cells` and the
+// arena value-returning kernels must address it through its range; reading it
+// linearly would silently pick up the wrong cells rather than fail.
+
+namespace {
+
+/// 2-D outer arena ToT; `present[ord]==false` gives a deliberately-null cell.
+arena_outer_t make_arena_tot_2d(long n0, long n1, std::size_t n_inner,
+                                double base, const std::vector<bool>& present) {
+  auto range_fn = [&present, n_inner](std::size_t ord) {
+    return present[ord] ? TA::Range{static_cast<long>(n_inner)} : TA::Range{};
+  };
+  arena_outer_t t = TA::detail::arena_outer_init<arena_outer_t>(
+      TA::Range{n0, n1}, 1, range_fn, alignof(double), /*zero_init=*/true);
+  const std::size_t N = static_cast<std::size_t>(n0 * n1);
+  for (std::size_t ord = 0; ord < N; ++ord) {
+    arena_inner_t& c = t.data()[ord];
+    if (c.empty()) continue;
+    for (std::size_t i = 0; i < n_inner; ++i)
+      c.data()[i] = base + ord * 100.0 + i;
+  }
+  return t;
+}
+
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(arena_add_to_noncontiguous_right_block) {
+  // R is 2x3, so its leading 2x2 sub-block has row stride 3: block cell (1,0)
+  // is R ordinal 3, not 2. Reading the block linearly would take R's ordinal 2
+  // instead, which is exactly what this test is here to catch.
+  const arena_outer_t R =
+      make_arena_tot_2d(2, 3, 4, 0.5, {true, true, true, true, true, true});
+  auto blk = R.block({0l, 0l}, {2l, 2l});
+  static_assert(!TA::detail::is_contiguous_tensor<decltype(blk)>::value,
+                "a BlockRange view must be non-contiguous for this test to "
+                "exercise the strided path");
+
+  // L is 2x2 with cell (0,1) null, so the fallback fires and must not drop the
+  // block's populated cell there.
+  const arena_outer_t L =
+      make_arena_tot_2d(2, 2, 4, 1.0, {true, false, true, true});
+  arena_outer_t t = L.clone();
+  t.add_to(blk);
+
+  BOOST_REQUIRE_EQUAL(t.range().volume(), 4u);
+  for (std::size_t ord = 0; ord < 4; ++ord) {
+    const arena_inner_t& lc = L.data()[ord];
+    // the block's own view of cell `ord` -- strided, via its range
+    const arena_inner_t& rc = blk.data()[blk.range().ordinal(ord)];
+    const arena_inner_t& got = t.data()[ord];
+    BOOST_REQUIRE(!rc.empty());
+    BOOST_REQUIRE(!got.empty());
+    for (std::size_t i = 0; i < got.size(); ++i) {
+      const double lv = lc.empty() ? 0.0 : lc.data()[i];
+      BOOST_CHECK_EQUAL(got.data()[i], lv + rc.data()[i]);
+    }
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/arena_tot_trivial.cpp
+++ b/tests/arena_tot_trivial.cpp
@@ -642,4 +642,56 @@ BOOST_AUTO_TEST_CASE(arena_add_to_noncontiguous_right_block) {
   }
 }
 
+// --- mult uses intersection sparsity -------------------------------------
+// Multiplication annihilates, so the minimal correct result sparsity is the
+// *intersection* of the operands' cell patterns: a cell absent from either
+// operand has an identically zero product, which a null cell already denotes.
+// `nz_L`/`nz_R` disagree in both directions (cell 0 is right-only, cells 3/4
+// differ), so these pin the rule rather than pass vacuously.
+
+BOOST_AUTO_TEST_CASE(arena_mult_uses_intersection_sparsity) {
+  const arena_outer_t L = make_arena_tot_sparse(5, 4, 2.0, nz_L);
+  const arena_outer_t R = make_arena_tot_sparse(5, 4, 0.5, nz_R);
+  const arena_outer_t prod = L.mult(R);
+  for (std::size_t ord = 0; ord < 5; ++ord) {
+    const arena_inner_t& l = L.data()[ord];
+    const arena_inner_t& r = R.data()[ord];
+    const arena_inner_t& d = prod.data()[ord];
+    if (!l.empty() && !r.empty()) {
+      BOOST_REQUIRE(!d.empty());
+      for (std::size_t i = 0; i < d.size(); ++i)
+        BOOST_CHECK_EQUAL(d.data()[i], l.data()[i] * r.data()[i]);
+    } else {
+      // union sparsity would have emitted an explicit zero slab here
+      BOOST_CHECK(d.empty());
+    }
+  }
+}
+
+// The in-place op must not densify either: a null destination cell stays null
+// (its product is zero), and a populated cell against a null source is zeroed
+// in place because a view cannot free its own storage.
+BOOST_AUTO_TEST_CASE(arena_mult_to_does_not_densify_null_cells) {
+  const arena_outer_t L = make_arena_tot_sparse(5, 4, 2.0, nz_L);
+  const arena_outer_t R = make_arena_tot_sparse(5, 4, 0.5, nz_R);
+  arena_outer_t t = L.clone();
+  t.mult_to(R);
+  for (std::size_t ord = 0; ord < 5; ++ord) {
+    const arena_inner_t& l = L.data()[ord];
+    const arena_inner_t& r = R.data()[ord];
+    const arena_inner_t& d = t.data()[ord];
+    if (l.empty()) {
+      BOOST_CHECK(d.empty());
+    } else if (r.empty()) {
+      BOOST_REQUIRE(!d.empty());
+      for (std::size_t i = 0; i < d.size(); ++i)
+        BOOST_CHECK_EQUAL(d.data()[i], 0.0);
+    } else {
+      BOOST_REQUIRE(!d.empty());
+      for (std::size_t i = 0; i < d.size(); ++i)
+        BOOST_CHECK_EQUAL(d.data()[i], l.data()[i] * r.data()[i]);
+    }
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Follow-up hardening on top of #575, from a close read of that PR. Each item is its own
commit; they are independent enough to drop individually.

### `total_size` CPO (`0376b92b2`)

`total_size()` is a member of `TA::Tensor` and `TA::Tile` but not of every tile type —
`btas::Tensor` and `TensorInterface` expose only `size()`, which for them *is* the whole tile
since neither carries a batch dimension. Seven call sites had each open-coded the same
`if constexpr (has_member_function_total_size_anyreturn_v<T>) … else size()` dance
(`tensor/kernels.h` ×4, `tile.h`, `dist_array.h` ×2). Add `TiledArray::total_size` alongside
the other tile query CPOs (`sum`, `product`, `min`, `max`) and route them all through it.

`DistArray`'s non-ToT `volume()` branch called the member directly rather than open-coding
the fallback, so it did not compile at all for a `btas::Tensor` tile type; it goes through
the CPO now too.

### The null-cell guard walks operands like the kernel it guards (`794d0cfe0`)

`inplace_binary_drops_cells` indexed both operands as `data()[ord]` over `total_size()`,
quietly assuming a contiguous `TA::Tensor` on the right — but `add_to`'s constraint is
`is_tensor<Right>`, which also admits `TensorInterface` (no `total_size()` member at all, and
non-contiguous over a `BlockRange`) and `ShiftWrapper`.

It now scans the way `detail::inplace_tensor_op` walks the very same operands: linearly when
`is_contiguous_tensor<Tensor, Right>` holds, by strided range ordinal otherwise. Contiguity
deliberately stays *out* of the gate — folding it in would make a non-contiguous right
silently answer "no drop" and reinstate the cell-dropping bug the predicate exists to
prevent. A shape it cannot scan is a `static_assert` instead.

The gate also narrows from `is_tensor_view_v` to `is_arena_tensor_v`: the fallback body calls
the value-returning kernels, which allocate an arena slab, and `arena_tensor.h`'s own
convention reserves `is_arena_tensor_v` for exactly that.

### An empty operand is zero for every in-place binary op, not just some (`c18e23e32`)

`add_to(right)` clones `right` when `*this` is empty and the unscaled `mult_to` returns early
on both sides, but three siblings were missing a guard: `subt_to(right)` and
`subt_to(right, factor)` had no empty-`this` guard, `add_to(right, factor)` had neither, and
`mult_to(right, factor)` had no empty-`right` guard. Control reached `inplace_binary`, whose
`!empty()` precondition is a `TA_ASSERT`: it throws under `TA_ASSERT_THROW` and, compiled out
in Release, either walks a null `data()` or silently yields an empty (== zero) result — the
same silent-data-loss shape #575 fixed, one function over. Five tests, each failing before
its guard with `TA_ASSERT failed: !empty(result, tensors...)`.

### Arena kernels address operands through their range (`fa8dbefda`)

`arena_trivial_binary` / `arena_trivial_unary` read every operand as `data()[ord]`, valid only
for a contiguous tensor. A `Tensor::block()` operand would have been read at the wrong
offsets — plausible-looking numbers rather than a failure. `arena_cell_offset` maps a logical
cell ordinal to its physical slot (identity when contiguous, `range().ordinal(ord)`
otherwise), so `Tensor<ArenaTensor>::add_to(some.block(...))` is now correct end to end.

The test uses a 2×3 parent so the leading 2×2 block has row stride 3 and its cell (1,0) is
parent ordinal 3, not 2; reverting `arena_cell_offset` to the linear form fails it on exactly
the mismatched ordinals.

### `axpy_to` fallback fused into one pass (`e0279fc75`)

It composed `add(right.scale(factor))`, allocating one slab for the scaled intermediate and a
second for the sum. `arena_trivial_binary` takes an arbitrary `fill_op`, so `l + r * factor`
is one pass and one slab.

### einsum reports a view-inner ToT × T product at the einsum level (`ec9fde5d4`)

The ToT × ToT branch guards on `inner_is_view` and raises an einsum-level diagnostic; the
mixed ToT × T branch did not, so the user saw a per-cell kernel message instead. No working
case changes — that path previously produced silent all-zero results for view inner cells.

### `mult` uses intersection sparsity (`104237723`)

`arena_trivial_binary` hardcoded union sparsity — a result cell wherever *either* operand has
one. Right for `add`/`subt`, where zero is the identity; wrong for `mult`, where zero
annihilates: a cell absent from either operand has an identically zero product, which a null
cell already denotes, so emitting it allocates a slab of zeros for exactly the cells screening
removed. For the shape that motivated #575 — an all-null intermediate against a populated
operand — `mult` now allocates nothing where it previously built a full dense slab of zeros.

That also makes `Tensor::mult_to`'s tensor-of-view fallback not merely unnecessary but
harmful, so both overloads lose it, and `mult_to` becomes allocation-free in every case.

### ToT axpy picks up `detail`'s mixed complex × scalar `operator*` (`6ec23c2fe`)

The axpy paths spell the leaf update as `alpha * cell[i]` (the free arena kernel) or
`cell[i] * factor` (`Tensor`'s fill lambda and per-element leaves). For a complex element and
a scalar of a different type — `int` × `complex<double>` — std's `operator*` fails deduction
and ADL never reaches `TiledArray::detail`, so the mixed operators have to be pulled in by
hand, as `Tensor::scale`'s non-nested branch already does.

Four sites, each a hard compile error before this: the free
`axpy_to(ArenaTensor&, const ArenaTensor&, Scalar)` in `arena_tensor.h`, `axpy_to`'s arena
union-sparsity fill lambda, and the leaf branches of both `axpy_to` overloads. Reachable from
ordinary public calls — `Tensor<complex<double>>::axpy_to(b, 2)` is enough — but nothing in
the tree instantiated them with an integral factor, so it never surfaced in CI.

Noticed while reviewing #573, which hits the same gap in `scale`/`add`/`subt`/`mult`; those
sites are fixed there, these four here.

## Verification

macOS / clang++ / Debug / `TA_ASSERT_POLICY=TA_ASSERT_THROW` / PaRSEC:

- `arena_tot_trivial_suite` 28/28
- full serial (`--run_test=!@distributed`): 0 failures
- np=2 (`--run_test=!@serial`): 0 failures on both ranks

Three mutation checks confirm the new tests discriminate rather than pass vacuously: reverting
`arena_cell_offset` to linear indexing fails the block-view test on the mismatched ordinals,
forcing the kernel back to union sparsity fails the intersection test on exactly the two
mismatched cells, and dropping the four `using namespace TiledArray::detail;` directives fails
`axpy_to_complex_element_with_integral_factor` to compile at all four sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

