### PR TITLE
tests: remove the per-rank file a parallel archive actually writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@
 # IDEs
 *.idea
 *.vscode
+
+# stray parallel-archive files from the unit tests (see tests/archive_file_utils.h)
+tmp.??????.?????

--- a/tests/archive_file_utils.h
+++ b/tests/archive_file_utils.h
@@ -1,0 +1,64 @@
+/*
+ *  This file is a part of TiledArray.
+ *  Copyright (C) 2026  Virginia Tech
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef TILEDARRAY_TEST_ARCHIVE_FILE_UTILS_H__INCLUDED
+#define TILEDARRAY_TEST_ARCHIVE_FILE_UTILS_H__INCLUDED
+
+#include <madness/world/madness_exception.h>
+
+#include <unistd.h>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+namespace TiledArray::test {
+
+/// The file a `madness::archive::ParallelOutputArchive` actually writes for
+/// \p prefix_name on \p rank -- `<prefix>.<rank>`, rank zero-padded to five
+/// digits. A parallel archive never creates \p prefix_name itself, so removing
+/// the prefix does *not* clean up after one; remove this instead.
+/// \param prefix_name The archive prefix handed to the archive constructor
+/// \param rank The writing rank
+/// \return The per-rank file name
+inline std::string to_parallel_archive_file_name(const char* prefix_name,
+                                                 int rank) {
+  char buf[256];
+  MADNESS_ASSERT(strlen(prefix_name) + 7 <= sizeof(buf));
+  snprintf(buf, sizeof(buf), "%s.%5.5d", prefix_name, rank);
+  return buf;
+}
+
+/// Replace the trailing `XXXXXX` in \p name_template with a unique suffix.
+
+/// Uses mkstemp + close + remove, so the resulting *name* is free for the
+/// caller to open itself (single-file archive) or to use as a prefix for
+/// per-rank files (parallel archive); no file is left behind by this call.
+/// Unlike mktemp(3) -- which clang/macOS flags as deprecated -- this is
+/// race-free against other in-process callers.
+/// \param[in,out] name_template A writable `...XXXXXX` template
+inline void make_unique_filename_template(char* name_template) {
+  const int fd = mkstemp(name_template);
+  MADNESS_ASSERT(fd != -1);
+  ::close(fd);
+  std::remove(name_template);
+}
+
+}  // namespace TiledArray::test
+
+#endif  // TILEDARRAY_TEST_ARCHIVE_FILE_UTILS_H__INCLUDED

--- a/tests/dist_array.cpp
+++ b/tests/dist_array.cpp
@@ -27,6 +27,7 @@
 
 #include <array_fixture.h>
 #include "../src/TiledArray/dist_array.h"
+#include "archive_file_utils.h"
 #include "tiledarray.h"
 #include "unit_test_config.h"
 
@@ -56,27 +57,8 @@ ArrayFixture::ArrayFixture()
 
 ArrayFixture::~ArrayFixture() { GlobalFixture::world->gop.fence(); }
 
-namespace {
-std::string to_parallel_archive_file_name(const char* prefix_name, int rank) {
-  char buf[256];
-  MADNESS_ASSERT(strlen(prefix_name) + 7 <= sizeof(buf));
-  snprintf(buf, sizeof(buf), "%s.%5.5d", prefix_name, rank);
-  return buf;
-}
-
-// Replace the trailing XXXXXX in `name_template` with a unique suffix.
-// Uses mkstemp + close + remove so the resulting name can be reused by
-// callers that want to open it themselves (single-file archive) or use it
-// as a prefix for per-rank files (parallel archive). Unlike mktemp(3),
-// which clang/macOS flags as deprecated, this is race-free against other
-// in-process callers.
-void make_unique_filename_template(char* name_template) {
-  const int fd = mkstemp(name_template);
-  MADNESS_ASSERT(fd != -1);
-  ::close(fd);
-  std::remove(name_template);
-}
-}  // namespace
+using TiledArray::test::make_unique_filename_template;
+using TiledArray::test::to_parallel_archive_file_name;
 
 BOOST_FIXTURE_TEST_SUITE(array_suite, ArrayFixture)
 

--- a/tests/tot_dist_array_part2.cpp
+++ b/tests/tot_dist_array_part2.cpp
@@ -18,20 +18,12 @@
  */
 #include "tot_array_fixture.h"
 
-#include <unistd.h>
 #include <cstdio>
 
-namespace {
-// Replace the trailing XXXXXX in `name_template` with a unique suffix.
-// Uses mkstemp + close + remove so the resulting name can be reused by
-// callers that open the file themselves; race-free unlike mktemp(3).
-void make_unique_filename_template(char* name_template) {
-  const int fd = mkstemp(name_template);
-  MADNESS_ASSERT(fd != -1);
-  ::close(fd);
-  std::remove(name_template);
-}
-}  // namespace
+#include "archive_file_utils.h"
+
+using TiledArray::test::make_unique_filename_template;
+using TiledArray::test::to_parallel_archive_file_name;
 
 BOOST_FIXTURE_TEST_SUITE(tot_array_suite2, ToTArrayFixture)
 //------------------------------------------------------------------------------
@@ -714,7 +706,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(parallel_serialization, TestParam, test_params) {
       t2.load(m_world, ar_in);
       BOOST_TEST(are_equal(corr, t2));
     }
-    std::remove(file_name);
+    // a parallel archive writes `<prefix>.<rank>`, never `<prefix>` itself, so
+    // removing the prefix would be a no-op and leak the per-rank file
+    if (m_world.rank() < nio)
+      std::remove(
+          to_parallel_archive_file_name(file_name, m_world.rank()).c_str());
   }
 }
 


### PR DESCRIPTION
## Problem

`tests/tot_dist_array_part2.cpp`'s `parallel_serialization` cleaned up with

```cpp
madness::archive::ParallelOutputArchive<> ar_out(m_world, file_name, nio);  // writes <prefix>.00000
...
std::remove(file_name);   // removes <prefix>
```

but a parallel archive writes `<prefix>.<rank>` and never creates `<prefix>` itself.
`make_unique_filename_template` mkstemps the template and immediately removes it, so only a
unique *name* survives — which makes that `std::remove` a **complete no-op**, leaking
`<prefix>.00000` every iteration.

The test is a `BOOST_AUTO_TEST_CASE_TEMPLATE` over `test_params` wrapped in a loop over
`run_all<TestParam>()`, so it leaks one file per parameter type × tiled range. Measured here:
**168 files per serial run**, and several months of accumulated runs had left **1680**
`tmp.??????.00000` files sitting in the source directory.

`tests/dist_array.cpp` already got this right:

```cpp
if (world.rank() < nio)
  std::remove(to_parallel_archive_file_name(prefix, world.rank()).c_str());
```

## Fix

Use the correct per-rank name in the ToT test.

Both helpers were file-local to `dist_array.cpp`, and `make_unique_filename_template` had
*already* been copy-pasted into `tot_dist_array_part2.cpp` — the duplication is arguably what
let the two cleanup paths drift apart. Rather than add a third copy, they move to a shared
`tests/archive_file_utils.h`, with a doc comment on `to_parallel_archive_file_name` spelling
out why removing the prefix is not cleanup.

Second commit adds a `.gitignore` entry as belt and braces, so a future test that gets this
wrong doesn't quietly fill `git status` before anyone notices.

## Verification

macOS / clang++ / Debug / `TA_ASSERT_POLICY=TA_ASSERT_THROW` / PaRSEC:

- full serial suite (`--run_test=!@distributed`): **0 failures**
- in a directory that starts with **zero** `tmp.*` files, the same run now leaves
  **zero**; the unfixed build leaves **168**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
