### PR TITLE
Tensor::permute returns an owning tile for arena nested outers

### DIFF
--- a/src/TiledArray/tensor/arena_kernels.h
+++ b/src/TiledArray/tensor/arena_kernels.h
@@ -625,6 +625,50 @@ OuterTensor arena_permute_shallow(const SrcOuterTensor& src, const Perm& perm) {
   return result;
 }
 
+/// Deep outer permute of a slab-backed ToT outer tile: a fresh single-page
+/// slab holding a copy of every cell, laid out in permuted order. The owning
+/// counterpart of arena_permute_shallow(): the result shares nothing with
+/// `src`, so it may be consumed in place -- the expression layer consumes a
+/// permuted operand tile (`x(perm) - y`) -- without touching `src`; the
+/// shallow form aliased the source cells, and such a consume wrote through
+/// them. Inner cells keep their ranges (an inner permutation is a separate
+/// pass, arena_inner_permute()). Null cells stay null.
+template <typename OuterTensor, typename SrcOuterTensor, typename Perm>
+OuterTensor arena_permute_deep(const SrcOuterTensor& src, const Perm& perm) {
+  using inner_t = typename OuterTensor::value_type;
+  using elem_t = typename inner_t::value_type;
+  using inner_range_t = typename inner_t::range_type;
+  TA_ASSERT(perm);
+  TA_ASSERT(perm.size() == src.range().rank());
+  auto perm_range = perm * src.range();
+  const std::size_t N_cells = src.range().volume();
+  const std::size_t batch_sz = src.nbatch();
+  // target cell ordinal -> source cell ordinal (within one batch)
+  std::vector<std::size_t> src_of(N_cells);
+  for (std::size_t s = 0; s < N_cells; ++s) {
+    auto src_idx = src.range().idx(s);
+    src_of[perm_range.ordinal(perm * src_idx)] = s;
+  }
+  auto range_fn = [&](std::size_t t_off) -> inner_range_t {
+    const std::size_t b = t_off / N_cells, t = t_off % N_cells;
+    const inner_t& c = src.data()[b * N_cells + src_of[t]];
+    return c.empty() ? inner_range_t{} : c.range();
+  };
+  // every element of every live cell is written below; no zero-init
+  OuterTensor result = arena_outer_init<OuterTensor>(
+      perm_range, batch_sz, range_fn, alignof(elem_t), /*zero_init=*/false);
+  for (std::size_t b = 0; b < batch_sz; ++b) {
+    for (std::size_t t = 0; t < N_cells; ++t) {
+      inner_t& dst = result.data()[b * N_cells + t];
+      if (dst.empty()) continue;
+      const inner_t& s = src.data()[b * N_cells + src_of[t]];
+      TA_ASSERT(dst.size() == s.size());
+      std::copy_n(s.data(), s.size(), dst.data());
+    }
+  }
+  return result;
+}
+
 /// Permute the inner modes of every cell of a slab-backed ToT outer tile.
 ///
 /// Produces a fresh slab-backed tile with the same outer layout as `src`,

--- a/src/TiledArray/tensor/tensor.h
+++ b/src/TiledArray/tensor/tensor.h
@@ -1710,15 +1710,20 @@ class Tensor {
   Tensor permute(const Perm& perm) const {
     if constexpr (is_arena_tensor_v<value_type>) {
       // View inner cells cannot be permuted in place; the owning tile
-      // rewrites its slab(s). The outer cells reorder shallowly (the 8-byte
-      // views are reindexed, the slab is shared via keep-alive); a
-      // non-trivial inner permutation rewrites every cell into a fresh slab.
-      // The generic Tensor(other, perm) ctor's allocate-then-fill shape does
-      // not fit the arena slab model, so route around it.
+      // rewrites its slab(s). The outer permutation copies every cell into a
+      // fresh slab in permuted order (arena_permute_deep): like the generic
+      // Tensor(other, perm) ctor, permute() returns an OWNING tile, which the
+      // expression layer may consume in place. (The earlier shallow form
+      // reindexed the 8-byte views over the shared source slab, and an
+      // in-place op on the permuted operand -- e.g. `x(perm) - y` -- wrote
+      // through into the source.) A non-trivial inner permutation rewrites
+      // every cell into a fresh slab as before. The generic ctor's
+      // allocate-then-fill shape does not fit the arena slab model, so route
+      // around it.
       const auto outer_perm = outer(perm);
       Tensor result =
           (outer_perm && !outer_perm.is_identity())
-              ? detail::arena_permute_shallow<Tensor>(*this, outer_perm)
+              ? detail::arena_permute_deep<Tensor>(*this, outer_perm)
               : *this;
       if constexpr (detail::is_bipartite_permutation_v<Perm>) {
         const auto inner_perm = inner(perm);

--- a/tests/arena_mixed_product_order.cpp
+++ b/tests/arena_mixed_product_order.cpp
@@ -1,6 +1,6 @@
 // tests/arena_mixed_product_order.cpp
 //
-// DistArray-level regression for MIXED products (an arena tensor-of-
+// Two DistArray-level regressions for MIXED products (an arena tensor-of-
 // tensors operand times a plain tensor operand), found on the CSV-CC
 // per-batch intermediate (occ,occ,PAO;PNO) * (PAO,PAO,DF) ->
 // (occ,occ,PAO,DF;PNO):
@@ -19,8 +19,15 @@
 //     (both orders, plain and shaped, both result orders) agree and reports
 //     the wall time of each (informational; no timing assertion).
 //
-//  (A second case, a permuted arena operand consumed inside a binary
-//  expression, lands with the fix for that defect.)
+//  2. permuted operand in a binary op: reading an arena ToT through a
+//     PERMUTED annotation inside a binary expression (`x(perm) - y`)
+//     destroyed the source: Tensor::permute() returned a SHALLOW permute
+//     (cells aliasing the source slab) and the in-place binary op, which
+//     consumes a permuted operand temporary, wrote through it. A
+//     permute-COPY was unaffected, and owning (Tensor<Tensor>) inners were
+//     unaffected. permute() now returns an owning tile (arena_permute_deep);
+//     the test asserts the source's norm is unchanged after such a read and
+//     that the read itself is right.
 
 #include "TiledArray/tensor/arena_einsum.h"
 #include "TiledArray/tensor/arena_tensor.h"
@@ -123,6 +130,32 @@ BOOST_AUTO_TEST_CASE(operand_order_is_canonicalized) {
                      << t_nf << " flat*nested=" << t_ff
                      << " +shape: " << t_nf_sh << " / " << t_ff_sh
                      << " result q,k,i,j: " << t_nf_alt << " / " << t_ff_alt);
+}
+
+BOOST_AUTO_TEST_CASE(permuted_arena_operand_in_binary_op_keeps_source) {
+  // The sources are laid out (q,k,i,j), so reading them under tc_alt is a
+  // genuine permuted read of the same tensor (reading an (i,j,q,k) array
+  // under the labels q,k,i,j would relabel modes of different extents and
+  // trip the binary engine's TiledRange check). Reference laid out (i,j,q,k).
+  ToTArray ref, src_copy, src_binary;
+  ref(tc) = tot(ta) * flat(tb);
+  src_copy(tc_alt) = tot(ta) * flat(tb);
+  src_binary(tc_alt) = tot(ta) * flat(tb);
+  TA::get_default_world().gop.fence();
+  double const n0 = TA::norm2(src_copy);
+  BOOST_REQUIRE(n0 > 0.0);
+
+  ToTArray y;
+  y(tc) = src_copy(tc_alt);  // permute-copy: must not touch the source
+  TA::get_default_world().gop.fence();
+  BOOST_CHECK_CLOSE(TA::norm2(src_copy), n0, 1e-10);
+
+  ToTArray z;
+  z(tc) = src_binary(tc_alt) - ref(tc);  // permuted operand of a binary op
+  TA::get_default_world().gop.fence();
+  BOOST_CHECK_CLOSE(TA::norm2(src_binary), n0, 1e-10);
+  // the same tensor read two ways: the difference is zero
+  BOOST_CHECK_SMALL(TA::norm2(z), 1e-12 * n0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Stacked on #582 (shares its regression test file); retarget to master once #582 merges.

## Summary

For a `Tensor<ArenaTensor<...>>` outer tile, `permute()` rebuilt the outer cell array in permuted order but rebound the 8-byte cell views onto the source's slab (`arena_permute_shallow`), keeping the source alive through the new tile's deleter, so the permuted tile aliased the source. The expression layer consumes a permuted operand temporary in place (`BinaryWrapper` with a consumable side: `x(perm) - y` becomes `subt_to` on the permuted tile), so the subtraction wrote through into `x`:

```cpp
z("i,j,q,k;a") = x("q,k,i,j;a") - y("i,j,q,k;a");   // x is corrupted afterwards
```

In the reproducer `x`'s norm dropped from 2.5e5 to 1.2e2 (to 0 in another run). A permute-copy (`y(perm) = x(...)`) and owning `Tensor<Tensor>` inners were unaffected.

`permute()` now copies every cell into a fresh single-page slab in permuted order (`arena_permute_deep`), the ownership rule the generic `Tensor(other, perm)` constructor and `owning_copy_of()` already follow. The shallow helper stays available for callers that only read the permuted view.

## Cost

One slab copy per outer permute of an arena tile. In isolation, on the benchmark product of #582 whose result the engine permutes in the flat-first orientation, 0.13 s -> 0.19 s. On an MPQC CSV-CCSD water-8-mer iteration it is within noise (9.4 s -> 9.7 s DF+occupied batched, 3.3 s -> 3.4 s DF batched), energies and residual norms unchanged to 12 digits. Follow-up if it matters: an rvalue `permute() &&` that keeps the zero-copy rebind for the engine's own result temporaries (the pre-permute temporary dies, so aliasing is harmless there).

## Test

`tests/arena_mixed_product_order.cpp` case 2 (the reproducer) now passes; its note is updated. TiledArray's suite was not run locally (no test build here); SeQuant's TiledArray-backed tests and the MPQC gates above pass against this tree.