### PR TITLE
tests/conversions: fence the per-rank sub-world before it is destroyed

### DIFF
--- a/tests/conversions.cpp
+++ b/tests/conversions.cpp
@@ -325,9 +325,10 @@ BOOST_AUTO_TEST_CASE(tiles_of_array_unit_blocking) {
   // deferred deletions complete while it is alive; otherwise the task runs
   // later, from some unrelated fence, against a freed World and the
   // WorldObject destructor aborts (seen as an asynchronous "Abort trap" in the
-  // two-rank CI run, attributed to whichever test case runs next).
-  this_world.gop.fence();
-  (*GlobalFixture::world).gop.fence();
+  // two-rank CI run, attributed to whichever test case runs next). The global
+  // world is fenced by the fixture destructor after every case; with one rank
+  // `this_world` IS the global world and needs nothing here.
+  if (world_ptr) world_ptr->gop.fence();
 }
 
 #if 1
@@ -439,9 +440,10 @@ BOOST_AUTO_TEST_CASE(tiles_of_arrays_non_unit_blocking) {
   // deferred deletions complete while it is alive; otherwise the task runs
   // later, from some unrelated fence, against a freed World and the
   // WorldObject destructor aborts (seen as an asynchronous "Abort trap" in the
-  // two-rank CI run, attributed to whichever test case runs next).
-  this_world.gop.fence();
-  (*GlobalFixture::world).gop.fence();
+  // two-rank CI run, attributed to whichever test case runs next). The global
+  // world is fenced by the fixture destructor after every case; with one rank
+  // `this_world` IS the global world and needs nothing here.
+  if (world_ptr) world_ptr->gop.fence();
 }
 #endif
 

--- a/tests/conversions.cpp
+++ b/tests/conversions.cpp
@@ -318,6 +318,16 @@ BOOST_AUTO_TEST_CASE(tiles_of_array_unit_blocking) {
       check_equal(b_sparse, b_sparse_fused);
     }
   }
+  // The per-rank sub-world (`world_ptr`, size > 1) dies when this test
+  // returns, but the arrays split into it are only LAZILY destroyed:
+  // DistArray's lazy_deleter schedules a lazy_sync task on the array's own
+  // world, i.e. on this sub-world's task queue. Fence the sub-world so those
+  // deferred deletions complete while it is alive; otherwise the task runs
+  // later, from some unrelated fence, against a freed World and the
+  // WorldObject destructor aborts (seen as an asynchronous "Abort trap" in the
+  // two-rank CI run, attributed to whichever test case runs next).
+  this_world.gop.fence();
+  (*GlobalFixture::world).gop.fence();
 }
 
 #if 1
@@ -422,6 +432,16 @@ BOOST_AUTO_TEST_CASE(tiles_of_arrays_non_unit_blocking) {
       check_equal(b_sparse, b_sparse_fused);
     }
   }
+  // The per-rank sub-world (`world_ptr`, size > 1) dies when this test
+  // returns, but the arrays split into it are only LAZILY destroyed:
+  // DistArray's lazy_deleter schedules a lazy_sync task on the array's own
+  // world, i.e. on this sub-world's task queue. Fence the sub-world so those
+  // deferred deletions complete while it is alive; otherwise the task runs
+  // later, from some unrelated fence, against a freed World and the
+  // WorldObject destructor aborts (seen as an asynchronous "Abort trap" in the
+  // two-rank CI run, attributed to whichever test case runs next).
+  this_world.gop.fence();
+  (*GlobalFixture::world).gop.fence();
 }
 #endif
 


### PR DESCRIPTION
## Summary

`tiles_of_array_unit_blocking` and `tiles_of_arrays_non_unit_blocking` build, when the world has more than one rank, a one-rank sub-world per rank and split the fused array into arrays living in it. Those arrays are only lazily destroyed: `DistArray`'s `lazy_deleter` schedules a `lazy_sync` on the array's own world, i.e. on the sub-world's task queue. The tests returned and destroyed the sub-world with that task possibly still queued; it then ran later, from an unrelated fence, against a freed `World`, and the `WorldObject` destructor aborted.

That is the asynchronous "Abort trap" in the two-rank macOS Release Pthreads job (master f3e3c5888 on 2026-09-08, and #583's run): the backtrace is `lazy_sync_children` -> `ArrayImpl<Tensor<int>, SparsePolicy>::lazy_deleter` -> `~ArrayImpl` -> `~WorldObject<DistributedStorage<...>>` -> `abort`, logged while Boost.Test had already entered the next case. `lazy_deleter`'s own comment describes the same hazard for einsum's per-Hadamard sub-worlds. The job passed on the seven master runs before f3e3c5888; the merged change there touched only unrelated test files, so this is a timing-dependent teardown race, not a regression from that PR.

## Fix

Both tests fence the sub-world (and the global world) before returning, so the deferred deletions complete while the world is alive.

## Validation

Standalone build (Release, `TA_ASSERT_POLICY=TA_ASSERT_THROW`): the conversions suite at one rank; at two ranks three times; and the full two-rank run in CI's form (`mpiexec -n 2 ta_test --run_test='!@serial'`, `MAD_NUM_THREADS=2`), all clean. The race did not reproduce locally before the fix either (five two-rank runs of the suite alone), so CI is the real gate for it.